### PR TITLE
Fix thread reply loading from enrichment relays

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,8 +5,17 @@ export const DEFAULT_RELAYS = [
   "wss://pow.relays.land",
 ] as const;
 
-export const QUOTE_FALLBACK_RELAYS = [
+export const ENRICHMENT_RELAYS = [
   "wss://relay.damus.io",
   "wss://offchain.pub",
   "wss://nos.lol",
+  "wss://relay.primal.net",
+  "wss://relay.nostr.band",
+  "wss://nostr.wine",
+  "wss://relay.snort.social",
+  "wss://eden.nostr.land",
+  "wss://nostr.mom",
+  "wss://purplerelay.com",
 ] as const;
+
+export const QUOTE_FALLBACK_RELAYS = ENRICHMENT_RELAYS;

--- a/src/features/thread/ThreadPage.tsx
+++ b/src/features/thread/ThreadPage.tsx
@@ -8,6 +8,7 @@ import { ContentColumn, PageShell } from "../../shared/ui/PageShell";
 import { ThreadComposer } from "../compose/ThreadComposer";
 import { useInfiniteScroll } from "../../shared/hooks/useInfiniteScroll";
 import { useThreadViewModel } from "../../hooks/useThreadViewModel";
+import { isThreadDescendant } from "@lib/threadVisibility";
 
 function decodeNoteId(id: string | undefined): string | null {
   if (!id) return null;
@@ -69,7 +70,7 @@ function ThreadView({ hexID }: { hexID: string }) {
             .filter(
               (event) =>
                 (showAllReplies || Math.log2(event.totalWork) > 10) &&
-                event.postEvent.tags.some((tag) => tag[0] === "e" && tag[1] === opEvent.id),
+                isThreadDescendant(event.postEvent, opEvent.id, eventsById),
             )
             .map((event) => (
               <PostCard

--- a/src/hooks/useThreadViewModel.ts
+++ b/src/hooks/useThreadViewModel.ts
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react";
-import { Event } from "nostr-tools";
 import { subNotesOnce } from "../nostr/subscriptions";
 import { toProcessedEvents } from "../nostr/processEvents";
 import { uniqBy } from "@lib/collections";

--- a/src/nostr/client.test.ts
+++ b/src/nostr/client.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_RELAYS, ENRICHMENT_RELAYS } from "../config";
+
+const relayPoolMocks = vi.hoisted(() => ({
+  instances: [] as Array<{
+    connect: ReturnType<typeof vi.fn>;
+    ensureConnected: ReturnType<typeof vi.fn>;
+    publish: ReturnType<typeof vi.fn>;
+    isConnected: boolean;
+  }>,
+}));
+
+vi.mock("./relay-pool", () => ({
+  RelayPool: vi.fn().mockImplementation(() => {
+    const instance = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      ensureConnected: vi.fn().mockResolvedValue(undefined),
+      publish: vi.fn().mockResolvedValue(new Set()),
+      isConnected: true,
+    };
+    relayPoolMocks.instances.push(instance);
+    return instance;
+  }),
+}));
+
+vi.mock("./subscription-registry", () => ({
+  SubscriptionRegistry: vi.fn().mockImplementation(() => ({})),
+}));
+
+describe("nostr client relay sets", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    relayPoolMocks.instances.length = 0;
+  });
+
+  it("uses enrichment relays for thread, quote, and profile lookups", async () => {
+    const { PROFILE_RELAYS, QUOTE_RELAYS, THREAD_RELAYS } = await import("./client");
+    const expectedRelays = [...new Set([...DEFAULT_RELAYS, ...ENRICHMENT_RELAYS])];
+
+    expect(THREAD_RELAYS).toEqual(expectedRelays);
+    expect(QUOTE_RELAYS).toEqual(expectedRelays);
+    expect(PROFILE_RELAYS).toEqual(expectedRelays);
+  });
+
+  it("connects default relays and enrichment relays during initialization", async () => {
+    const { initNostr } = await import("./client");
+
+    await initNostr();
+
+    expect(relayPoolMocks.instances).toHaveLength(1);
+    expect(relayPoolMocks.instances[0].connect).toHaveBeenCalledWith(DEFAULT_RELAYS);
+    expect(relayPoolMocks.instances[0].ensureConnected).toHaveBeenCalledWith(ENRICHMENT_RELAYS);
+  });
+});

--- a/src/nostr/client.ts
+++ b/src/nostr/client.ts
@@ -1,5 +1,5 @@
 import type { Event } from "nostr-tools";
-import { DEFAULT_RELAYS, QUOTE_FALLBACK_RELAYS } from "../config";
+import { DEFAULT_RELAYS, ENRICHMENT_RELAYS } from "../config";
 import { RelayPool } from "./relay-pool";
 import { SubscriptionRegistry } from "./subscription-registry";
 
@@ -8,9 +8,10 @@ let registry: SubscriptionRegistry | null = null;
 let connectPromise: Promise<void> | null = null;
 
 export const THREAD_RELAYS = [
-  ...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS]),
+  ...new Set([...DEFAULT_RELAYS, ...ENRICHMENT_RELAYS]),
 ] as string[];
 
+export const QUOTE_RELAYS = THREAD_RELAYS;
 export const PROFILE_RELAYS = THREAD_RELAYS;
 
 function ensureNostrClient(): void {
@@ -29,7 +30,7 @@ export function initNostr(): Promise<void> {
   if (!connectPromise) {
     connectPromise = Promise.all([
       pool.connect(DEFAULT_RELAYS),
-      pool.ensureConnected(QUOTE_FALLBACK_RELAYS),
+      pool.ensureConnected(ENRICHMENT_RELAYS),
     ]).then(() => {});
   }
 

--- a/src/nostr/subscriptions/index.ts
+++ b/src/nostr/subscriptions/index.ts
@@ -1,8 +1,9 @@
-import { DEFAULT_RELAYS, QUOTE_FALLBACK_RELAYS } from "../../config";
+import { DEFAULT_RELAYS } from "../../config";
 import {
   ensureRelaysConnected,
   initNostr,
   PROFILE_RELAYS,
+  QUOTE_RELAYS,
   THREAD_RELAYS,
   getRegistry,
 } from "../client";
@@ -77,7 +78,7 @@ export async function subProfilesOnce(
 }
 
 function relayUrlsForQuote(ref: QuotedRef): string[] {
-  return [...new Set([...DEFAULT_RELAYS, ...ref.relays, ...QUOTE_FALLBACK_RELAYS])];
+  return [...new Set([...DEFAULT_RELAYS, ...ref.relays, ...QUOTE_RELAYS])];
 }
 
 export async function subQuotedEventsOnce(

--- a/src/nostr/subscriptions/thread.test.ts
+++ b/src/nostr/subscriptions/thread.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { DEFAULT_RELAYS, QUOTE_FALLBACK_RELAYS } from "../../config";
+import { DEFAULT_RELAYS, ENRICHMENT_RELAYS } from "../../config";
 
 const subscribeMock = vi.fn();
 
@@ -7,12 +7,12 @@ vi.mock("../client", () => ({
   getRegistry: () => ({
     subscribe: subscribeMock,
   }),
-  THREAD_RELAYS: [...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS])],
+  THREAD_RELAYS: [...new Set([...DEFAULT_RELAYS, ...ENRICHMENT_RELAYS])],
 }));
 
-import { subNote } from "./thread";
+import { getThreadRelayUrls, subNote } from "./thread";
 
-const expectedRelays = [...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS])];
+const expectedRelays = [...new Set([...DEFAULT_RELAYS, ...ENRICHMENT_RELAYS])];
 
 describe("subNote", () => {
   beforeEach(() => {
@@ -20,7 +20,7 @@ describe("subNote", () => {
     subscribeMock.mockImplementation(() => ({ id: "1", close: vi.fn() }));
   });
 
-  it("subscribes to the OP and replies on default and fallback relays", () => {
+  it("subscribes to the OP and replies on default and enrichment relays", () => {
     subNote("1".repeat(64), vi.fn());
 
     expect(subscribeMock).toHaveBeenCalledTimes(2);
@@ -34,5 +34,9 @@ describe("subNote", () => {
       "#e": ["1".repeat(64)],
       kinds: [1],
     });
+  });
+
+  it("exposes thread relay selection for lookup subscriptions", () => {
+    expect(getThreadRelayUrls()).toEqual(expectedRelays);
   });
 });

--- a/src/nostr/subscriptions/thread.ts
+++ b/src/nostr/subscriptions/thread.ts
@@ -2,11 +2,14 @@ import { getRegistry, THREAD_RELAYS } from "../client";
 import type { SubCallback, SubHandle } from "../types";
 import { composeSubHandle } from "./utils";
 
+export const getThreadRelayUrls = (): string[] => THREAD_RELAYS;
+
 export const subNote = (eventId: string, onEvent: SubCallback): SubHandle => {
   const registry = getRegistry();
   const children: SubHandle[] = [];
   let replyHandle: SubHandle | null = null;
   const replies = new Set<string>([eventId]);
+  const relayUrls = getThreadRelayUrls();
 
   const refreshReplySubscription = () => {
     replyHandle?.close();
@@ -16,7 +19,7 @@ export const subNote = (eventId: string, onEvent: SubCallback): SubHandle => {
           "#e": Array.from(replies),
           kinds: [1],
         },
-        relayUrls: THREAD_RELAYS,
+        relayUrls,
         cb: (evt, relay) => {
           const isNew = !replies.has(evt.id);
           if (isNew) {
@@ -39,7 +42,7 @@ export const subNote = (eventId: string, onEvent: SubCallback): SubHandle => {
           kinds: [1, 1068],
           limit: 1,
         },
-        relayUrls: THREAD_RELAYS,
+        relayUrls,
         cb: onEvent,
         closeOnEose: true,
       },

--- a/src/shared/lib/threadVisibility.test.ts
+++ b/src/shared/lib/threadVisibility.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { Event } from "nostr-tools";
+import { isThreadDescendant } from "./threadVisibility";
+
+function makeEvent(id: string, parentIds: string[] = []): Event {
+  return {
+    id,
+    kind: 1,
+    pubkey: "aa".repeat(32),
+    created_at: 1,
+    tags: parentIds.map((parentId) => ["e", parentId]),
+    content: id,
+    sig: "sig",
+  };
+}
+
+describe("isThreadDescendant", () => {
+  it("matches direct replies to the thread root", () => {
+    const root = makeEvent("root");
+    const reply = makeEvent("reply", ["root"]);
+
+    expect(isThreadDescendant(reply, root.id, new Map([[root.id, root]]))).toBe(true);
+  });
+
+  it("matches nested replies whose parent chain reaches the thread root", () => {
+    const root = makeEvent("root");
+    const reply = makeEvent("reply", ["root"]);
+    const nested = makeEvent("nested", ["reply"]);
+    const eventsById = new Map(
+      [root, reply, nested].map((event) => [event.id, event]),
+    );
+
+    expect(isThreadDescendant(nested, root.id, eventsById)).toBe(true);
+  });
+
+  it("does not match events from another thread", () => {
+    const root = makeEvent("root");
+    const otherRoot = makeEvent("other-root");
+    const reply = makeEvent("reply", ["other-root"]);
+    const eventsById = new Map(
+      [root, otherRoot, reply].map((event) => [event.id, event]),
+    );
+
+    expect(isThreadDescendant(reply, root.id, eventsById)).toBe(false);
+  });
+});

--- a/src/shared/lib/threadVisibility.ts
+++ b/src/shared/lib/threadVisibility.ts
@@ -1,0 +1,30 @@
+import type { Event } from "nostr-tools";
+
+export function isThreadDescendant(
+  event: Event,
+  rootId: string,
+  eventsById: Map<string, Event>,
+): boolean {
+  const visited = new Set<string>();
+  const pending = event.tags
+    .filter((tag) => tag[0] === "e" && Boolean(tag[1]))
+    .map((tag) => tag[1]);
+
+  while (pending.length > 0) {
+    const candidateId = pending.shift();
+    if (!candidateId || visited.has(candidateId)) continue;
+    if (candidateId === rootId) return true;
+
+    visited.add(candidateId);
+    const candidate = eventsById.get(candidateId);
+    if (!candidate) continue;
+
+    pending.push(
+      ...candidate.tags
+        .filter((tag) => tag[0] === "e" && Boolean(tag[1]))
+        .map((tag) => tag[1]),
+    );
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- Add `ENRICHMENT_RELAYS` for thread, quote, profile, metadata-style lookups while preserving PoW default relays for the main feed and publish path.
- Connect enrichment relays during Nostr initialization so thread subscriptions can use them.
- Render nested descendant replies in thread pages when their parent chain belongs to the OP thread.
- This stays within free Vercel usage: no paid Vercel features, storage/config, high-frequency cron, long-running functions, or publish-path changes were added.

Fixes #24.

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings in unrelated files)
- `npm run build`