### PR TITLE
Confirm relay publish before showing submitted events

### DIFF
--- a/src/features/compose/PostForm.tsx
+++ b/src/features/compose/PostForm.tsx
@@ -39,7 +39,16 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
     setDifficulty(String(settings.difficulty));
   }, [settings.difficulty]);
 
-  const { handleSubmit: originalHandleSubmit, doingWorkProp, hashrate, bestPow, signedPoWEvent } =
+  const {
+    handleSubmit: originalHandleSubmit,
+    doingWorkProp,
+    submitStatus,
+    submitError,
+    acceptedRelays,
+    hashrate,
+    bestPow,
+    signedPoWEvent,
+  } =
     useSubmitForm(unsigned, difficulty);
 
   const handleSubmit = async (event: React.FormEvent) => {
@@ -50,10 +59,14 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
     }
 
     await originalHandleSubmit(event);
+  };
+
+  useEffect(() => {
+    if (!signedPoWEvent) return;
 
     setPollOptions(["", ""]);
     setComment("");
-  };
+  }, [signedPoWEvent]);
 
   return (
     <form name="post" method="post" encType="multipart/form-data" onSubmit={handleSubmit}>
@@ -121,11 +134,17 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
           difficulty={difficulty}
           hashrate={hashrate}
           bestPow={bestPow}
+          status={submitStatus}
           className="text-right"
         />
+        {submitError && <p className="text-danger text-meta text-right">{submitError}</p>}
+        {submitStatus === "published" && acceptedRelays.length > 0 && (
+          <p className="text-meta text-secondary text-right">
+            posted to {acceptedRelays.length} relay{acceptedRelays.length === 1 ? "" : "s"}
+          </p>
+        )}
         {signedPoWEvent && <PostCard event={signedPoWEvent} replies={[]} />}
       </div>
-      <div id="postFormError" className="text-danger text-meta" />
     </form>
   );
 }

--- a/src/features/compose/RepostForm.tsx
+++ b/src/features/compose/RepostForm.tsx
@@ -24,7 +24,8 @@ export function RepostForm({ refEvent }: RepostFormProps) {
     pubkey: "",
   });
 
-  const { handleSubmit, doingWorkProp, hashrate } = useSubmitForm(unsigned, difficulty);
+  const { handleSubmit, doingWorkProp, submitStatus, submitError, acceptedRelays, hashrate } =
+    useSubmitForm(unsigned, difficulty);
 
   return (
     <form name="post" method="post" encType="multipart/form-data" onSubmit={handleSubmit}>
@@ -39,9 +40,15 @@ export function RepostForm({ refEvent }: RepostFormProps) {
           active={doingWorkProp}
           difficulty={difficulty}
           hashrate={hashrate}
+          status={submitStatus}
         />
+        {submitError && <p className="text-danger text-meta">{submitError}</p>}
+        {submitStatus === "published" && acceptedRelays.length > 0 && (
+          <p className="text-meta text-secondary">
+            posted to {acceptedRelays.length} relay{acceptedRelays.length === 1 ? "" : "s"}
+          </p>
+        )}
       </div>
-      <div id="postFormError" className="text-danger text-meta" />
     </form>
   );
 }

--- a/src/hooks/useThreadViewModel.ts
+++ b/src/hooks/useThreadViewModel.ts
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react";
-import { Event } from "nostr-tools";
 import { subNotesOnce } from "../nostr/subscriptions";
 import { toProcessedEvents } from "../nostr/processEvents";
 import { uniqBy } from "@lib/collections";

--- a/src/shared/hooks/useSubmitForm.test.tsx
+++ b/src/shared/hooks/useSubmitForm.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Event, UnsignedEvent } from "nostr-tools";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSubmitForm } from "./useSubmitForm";
+
+const mocks = vi.hoisted(() => ({
+  appendKey: vi.fn(),
+  publish: vi.fn(),
+}));
+let workerMessageHandler: ((event: MessageEvent) => void) | null = null;
+
+vi.mock("nostr-tools", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("nostr-tools")>();
+  return {
+    ...actual,
+    generateSecretKey: () => new Uint8Array(32).fill(1),
+    getPublicKey: () => "f".repeat(64),
+    finalizeEvent: (event: UnsignedEvent) => ({
+      ...event,
+      id: "1".repeat(64),
+      pubkey: "f".repeat(64),
+      sig: "2".repeat(128),
+    }),
+  };
+});
+
+vi.mock("../../nostr/client", () => ({
+  publish: mocks.publish,
+}));
+
+vi.mock("../../app/settings", () => ({
+  useSettings: () => ({ settings: { powServerUrl: "" } }),
+}));
+
+vi.mock("./useStoredKeys", () => ({
+  useStoredKeys: () => ({ appendKey: mocks.appendKey }),
+}));
+
+class MockWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+
+  constructor() {
+    workerMessageHandler = (event: MessageEvent) => this.onmessage?.(event);
+  }
+
+  postMessage() {}
+
+  terminate() {}
+}
+
+const unsigned: UnsignedEvent = {
+  kind: 1,
+  tags: [["client", "getwired.app"]],
+  content: "test reply",
+  created_at: 1,
+  pubkey: "",
+};
+
+function Probe({ onState }: { onState: (state: ReturnType<typeof useSubmitForm>) => void }) {
+  const state = useSubmitForm(unsigned, "1");
+  onState(state);
+
+  return (
+    <form onSubmit={state.handleSubmit}>
+      <button type="submit">submit</button>
+    </form>
+  );
+}
+
+describe("useSubmitForm", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let state: ReturnType<typeof useSubmitForm>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    workerMessageHandler = null;
+    mocks.appendKey.mockReset();
+    mocks.publish.mockReset();
+    vi.stubGlobal("Worker", MockWorker);
+    Object.defineProperty(window.navigator, "hardwareConcurrency", {
+      configurable: true,
+      value: 1,
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not expose a posted event when no relay accepts the publish", async () => {
+    mocks.publish.mockResolvedValue(new Set<string>());
+
+    act(() => {
+      root.render(<Probe onState={(nextState) => (state = nextState)} />);
+    });
+
+    await act(async () => {
+      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+
+    const minedEvent = {
+      ...unsigned,
+      pubkey: "f".repeat(64),
+      tags: [...unsigned.tags, ["nonce", "1", "1"]],
+    } as UnsignedEvent;
+
+    await act(async () => {
+      workerMessageHandler?.({ data: { found: true, event: minedEvent } } as MessageEvent);
+    });
+
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    expect(state.signedPoWEvent).toBeUndefined();
+    expect(state.submitStatus).toBe("failed");
+    expect(state.submitError).toMatch(/No relay accepted/);
+    expect(state.acceptedRelays).toEqual([]);
+    expect(mocks.appendKey).not.toHaveBeenCalled();
+  });
+
+  it("exposes a posted event after at least one relay accepts it", async () => {
+    mocks.publish.mockResolvedValue(new Set<string>(["wss://relay.example"]));
+
+    act(() => {
+      root.render(<Probe onState={(nextState) => (state = nextState)} />);
+    });
+
+    await act(async () => {
+      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+
+    const minedEvent = {
+      ...unsigned,
+      pubkey: "f".repeat(64),
+      tags: [...unsigned.tags, ["nonce", "1", "1"]],
+    } as UnsignedEvent;
+
+    await act(async () => {
+      workerMessageHandler?.({ data: { found: true, event: minedEvent } } as MessageEvent);
+    });
+
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    expect((state.signedPoWEvent as Event | undefined)?.content).toBe("test reply");
+    expect(state.submitStatus).toBe("published");
+    expect(state.submitError).toBeNull();
+    expect(state.acceptedRelays).toEqual(["wss://relay.example"]);
+    expect(mocks.appendKey).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not expose a posted event when publish rejects", async () => {
+    mocks.publish.mockRejectedValue(new Error("relay failure"));
+
+    act(() => {
+      root.render(<Probe onState={(nextState) => (state = nextState)} />);
+    });
+
+    await act(async () => {
+      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+
+    const minedEvent = {
+      ...unsigned,
+      pubkey: "f".repeat(64),
+      tags: [...unsigned.tags, ["nonce", "1", "1"]],
+    } as UnsignedEvent;
+
+    await act(async () => {
+      workerMessageHandler?.({ data: { found: true, event: minedEvent } } as MessageEvent);
+    });
+
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    expect(state.signedPoWEvent).toBeUndefined();
+    expect(state.submitStatus).toBe("failed");
+    expect(state.submitError).toMatch(/Publishing failed/);
+    expect(state.acceptedRelays).toEqual([]);
+    expect(mocks.appendKey).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/hooks/useSubmitForm.ts
+++ b/src/shared/hooks/useSubmitForm.ts
@@ -1,15 +1,19 @@
 import { useState, useEffect } from "react";
-import { generateSecretKey, getPublicKey, finalizeEvent, UnsignedEvent, Event } from "nostr-tools";
+import { generateSecretKey, getPublicKey, finalizeEvent, type UnsignedEvent, type Event } from "nostr-tools";
 import { publish } from "../../nostr/client";
 import { bytesToHex } from "@noble/hashes/utils";
 import { useSettings } from "../../app/settings";
 import { useStoredKeys } from "./useStoredKeys";
 import { usePowMining } from "./usePowMining";
 
+export type SubmitStatus = "idle" | "mining" | "publishing" | "published" | "failed";
+
 export const useSubmitForm = (unsigned: UnsignedEvent, difficulty: string) => {
   const { settings } = useSettings();
   const { appendKey } = useStoredKeys();
-  const [doingWorkProp, setDoingWorkProp] = useState(false);
+  const [submitStatus, setSubmitStatus] = useState<SubmitStatus>("idle");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [acceptedRelays, setAcceptedRelays] = useState<string[]>([]);
   const [sk, setSk] = useState(generateSecretKey());
   const unsignedWithPubkey = { ...unsigned, pubkey: getPublicKey(sk) };
   const [unsignedPoWEvent, setUnsignedPoWEvent] = useState<UnsignedEvent>();
@@ -17,20 +21,61 @@ export const useSubmitForm = (unsigned: UnsignedEvent, difficulty: string) => {
 
   const numCores = navigator.hardwareConcurrency || 4;
   const { startWork, messageFromWorker, hashrate, bestPow } = usePowMining(numCores, unsignedWithPubkey, difficulty);
+  const doingWorkProp = submitStatus === "mining" || submitStatus === "publishing";
 
   useEffect(() => {
-    if (unsignedPoWEvent) {
-      setDoingWorkProp(false);
-      const signedEvent = finalizeEvent(unsignedPoWEvent, sk);
-      publish(signedEvent);
-      setSignedPoWEvent(signedEvent);
-      setSk(generateSecretKey());
-    }
-  }, [unsignedPoWEvent]);
+    if (!unsignedPoWEvent) return;
+
+    let cancelled = false;
+
+    const publishMinedEvent = async () => {
+      setSubmitStatus("publishing");
+      setSubmitError(null);
+
+      try {
+        const signedEvent = finalizeEvent(unsignedPoWEvent, sk);
+        const accepted = await publish(signedEvent);
+        if (cancelled) return;
+
+        if (accepted.size === 0) {
+          setSubmitStatus("failed");
+          setSubmitError("No relay accepted the event. Your draft was not posted.");
+          setSignedPoWEvent(undefined);
+          setAcceptedRelays([]);
+          return;
+        }
+
+        setAcceptedRelays([...accepted]);
+        setSignedPoWEvent(signedEvent);
+        appendKey(bytesToHex(sk), getPublicKey(sk));
+        setSk(generateSecretKey());
+        setSubmitStatus("published");
+      } catch {
+        if (cancelled) return;
+        setSubmitStatus("failed");
+        setSubmitError("Publishing failed. Your draft was not posted.");
+        setSignedPoWEvent(undefined);
+        setAcceptedRelays([]);
+      } finally {
+        if (!cancelled) {
+          setUnsignedPoWEvent(undefined);
+        }
+      }
+    };
+
+    void publishMinedEvent();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [appendKey, sk, unsignedPoWEvent]);
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    setDoingWorkProp(true);
+    setSubmitStatus("mining");
+    setSubmitError(null);
+    setAcceptedRelays([]);
+    setSignedPoWEvent(undefined);
 
     if (settings.powServerUrl) {
       const inEventFormat = { ...unsignedWithPubkey, sig: "" };
@@ -46,19 +91,22 @@ export const useSubmitForm = (unsigned: UnsignedEvent, difficulty: string) => {
         },
         body: JSON.stringify(powRequest),
       })
-        .then((response) => response.json())
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error("PoW server failed.");
+          }
+          return response.json();
+        })
         .then((data) => {
           setUnsignedPoWEvent(data.event);
         })
-        .catch((error) => {
-          console.error("Error:", error);
-          setDoingWorkProp(false);
+        .catch(() => {
+          setSubmitStatus("failed");
+          setSubmitError("Signal generation failed. Your draft was not posted.");
         });
     } else {
       startWork();
     }
-
-    appendKey(bytesToHex(sk), getPublicKey(sk));
   };
 
   useEffect(() => {
@@ -67,5 +115,14 @@ export const useSubmitForm = (unsigned: UnsignedEvent, difficulty: string) => {
     }
   }, [messageFromWorker]);
 
-  return { handleSubmit, doingWorkProp, hashrate, bestPow, signedPoWEvent };
+  return {
+    handleSubmit,
+    doingWorkProp,
+    submitStatus,
+    submitError,
+    acceptedRelays,
+    hashrate,
+    bestPow,
+    signedPoWEvent,
+  };
 };

--- a/src/shared/ui/PollResponder.tsx
+++ b/src/shared/ui/PollResponder.tsx
@@ -59,12 +59,25 @@ export function PollResponder({ eventdata }: { eventdata: Event }) {
     return { voteResponse: pow, optionLabel };
   });
 
-  const { handleSubmit: originalHandleSubmit, doingWorkProp, hashrate, bestPow } =
+  const {
+    handleSubmit: originalHandleSubmit,
+    doingWorkProp,
+    submitStatus,
+    submitError,
+    acceptedRelays,
+    hashrate,
+    bestPow,
+    signedPoWEvent,
+  } =
     useSubmitForm(submitEvent, difficulty);
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     await originalHandleSubmit(event);
+  };
+
+  useEffect(() => {
+    if (!signedPoWEvent) return;
 
     setUnsigned((prevUnsigned) => ({
       ...prevUnsigned,
@@ -73,7 +86,7 @@ export function PollResponder({ eventdata }: { eventdata: Event }) {
       tags: [["client", "getwired.app"], ["e", eventdata.id]],
     }));
     setSelectedOption("");
-  };
+  }, [eventdata.id, signedPoWEvent]);
 
   return (
     <form name="post" method="post" encType="multipart/form-data" onSubmit={handleSubmit}>
@@ -113,7 +126,14 @@ export function PollResponder({ eventdata }: { eventdata: Event }) {
           difficulty={difficulty}
           hashrate={hashrate}
           bestPow={bestPow}
+          status={submitStatus}
         />
+        {submitError && <p className="text-danger text-meta">{submitError}</p>}
+        {submitStatus === "published" && acceptedRelays.length > 0 && (
+          <p className="text-meta text-secondary">
+            posted to {acceptedRelays.length} relay{acceptedRelays.length === 1 ? "" : "s"}
+          </p>
+        )}
       </div>
     </form>
   );

--- a/src/shared/ui/PowTransmitStatus.tsx
+++ b/src/shared/ui/PowTransmitStatus.tsx
@@ -1,10 +1,12 @@
 import { timeToGoEst } from "@lib/timeEstimate";
+import type { SubmitStatus } from "../hooks/useSubmitForm";
 
 interface PowTransmitStatusProps {
   active: boolean;
   difficulty: string | number;
   hashrate: number;
   bestPow?: number;
+  status?: SubmitStatus;
   className?: string;
 }
 
@@ -13,9 +15,18 @@ export function PowTransmitStatus({
   difficulty,
   hashrate,
   bestPow = 0,
+  status = "mining",
   className,
 }: PowTransmitStatusProps) {
   if (!active) return null;
+
+  if (status === "publishing") {
+    return (
+      <p className={`text-meta text-secondary ${className ?? ""}`.trim()} role="status">
+        publishing to relays…
+      </p>
+    );
+  }
 
   return (
     <p className={`text-meta text-secondary ${className ?? ""}`.trim()} role="status">


### PR DESCRIPTION
## Summary
- Await relay publish before exposing a mined event as successfully submitted.
- Only show the local submitted preview after at least one relay accepts the event.
- Keep drafts intact and show failure messaging when publish fails or no relay accepts.
- Add submit-state UI for mining, publishing, success relay count, and failures across posts, reposts, and poll responses.

Fixes #23

## Reproduction / regression coverage
- Added src/shared/hooks/useSubmitForm.test.tsx.
- Reproduces the bug by simulating a mined event where publish returns an empty accepted-relay set and asserting no posted event is exposed.
- Validates the fix by asserting an event is exposed only after at least one relay accepts it.
- Covers rejected publish promises and verifies keys are stored only after accepted publish.

## Validation
- npm test passed: 19 files, 74 tests.
- npm run typecheck passed.
- npm run lint passed with 2 existing fast-refresh warnings.
- npm run build passed.