### PR TITLE
Add Cloudflare feed snapshot fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Deploy on [Vercel](https://vercel.com). Connect the Git repo in the Vercel dashb
 
 [`vercel.json`](vercel.json) includes SPA rewrites so client-side routes work on refresh.
 
+Optional feed snapshot bootstrap:
+
+- Set `VITE_FEED_SNAPSHOT_URL` to a public JSON snapshot URL, such as an Umbrel service exposed through Cloudflare Tunnel.
+- The client tries that snapshot first, falls back to `/api/feed/bootstrap`, then falls back to live Nostr relay subscriptions if both bootstrap sources fail.
+- The snapshot response should match `/api/feed/bootstrap`: `{ "fetchedAt": number, "processedEvents": [], "profiles": {} }`.
+
 Local production check:
 
 ```sh

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -8,7 +8,7 @@ import { seedProfiles } from "../shared/hooks/useProfiles";
 import {
   canUseFeedBootstrap,
   eventsFromProcessed,
-  type FeedBootstrapResponse,
+  fetchFeedBootstrapSnapshot,
 } from "../shared/lib/feedBootstrapClient";
 
 function mergeNoteEvents(bootstrapEvents: Event[], liveEvents: Event[]): Event[] {
@@ -31,11 +31,7 @@ export function useFeed() {
 
     let cancelled = false;
 
-    void fetch("/api/feed/bootstrap")
-      .then(async (response) => {
-        if (!response.ok) return null;
-        return response.json() as Promise<FeedBootstrapResponse>;
-      })
+    void fetchFeedBootstrapSnapshot()
       .then((snapshot) => {
         if (cancelled || !snapshot) return;
         setBootstrapEvents(eventsFromProcessed(snapshot.processedEvents));

--- a/src/hooks/useThreadViewModel.ts
+++ b/src/hooks/useThreadViewModel.ts
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react";
-import { Event } from "nostr-tools";
 import { subNotesOnce } from "../nostr/subscriptions";
 import { toProcessedEvents } from "../nostr/processEvents";
 import { uniqBy } from "@lib/collections";

--- a/src/shared/lib/feedBootstrapClient.test.ts
+++ b/src/shared/lib/feedBootstrapClient.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { Event } from "nostr-tools";
-import { eventsFromProcessed } from "./feedBootstrapClient";
+import {
+  eventsFromProcessed,
+  feedBootstrapUrls,
+  fetchFeedBootstrapSnapshot,
+  VERCEL_FEED_BOOTSTRAP_URL,
+} from "./feedBootstrapClient";
+import type { FeedBootstrapResponse } from "./feedBootstrapClient";
 
 const event = (overrides: Partial<Event> = {}): Event => ({
   id: "f".repeat(64),
@@ -24,5 +30,100 @@ describe("eventsFromProcessed", () => {
 
     expect(events).toHaveLength(2);
     expect(events.map((item) => item.id)).toEqual([root.id, reply.id]);
+  });
+});
+
+describe("feedBootstrapUrls", () => {
+  it("tries the external snapshot before the Vercel bootstrap endpoint", () => {
+    expect(feedBootstrapUrls("https://snapshot.example/feed.json")).toEqual([
+      "https://snapshot.example/feed.json",
+      VERCEL_FEED_BOOTSTRAP_URL,
+    ]);
+  });
+
+  it("uses only the Vercel bootstrap endpoint when no external snapshot is set", () => {
+    expect(feedBootstrapUrls(null)).toEqual([VERCEL_FEED_BOOTSTRAP_URL]);
+  });
+});
+
+describe("fetchFeedBootstrapSnapshot", () => {
+  const snapshot = (): FeedBootstrapResponse => ({
+    fetchedAt: 1,
+    processedEvents: [],
+    profiles: {},
+  });
+
+  const jsonResponse = (body: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(body), {
+      headers: { "content-type": "application/json" },
+      ...init,
+    });
+
+  it("returns the Cloudflare snapshot when it succeeds", async () => {
+    const calls: string[] = [];
+    const fetcher = async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      return jsonResponse(snapshot());
+    };
+
+    const result = await fetchFeedBootstrapSnapshot(
+      fetcher,
+      "https://snapshot.example/feed.json",
+    );
+
+    expect(result).toEqual(snapshot());
+    expect(calls).toEqual(["https://snapshot.example/feed.json"]);
+  });
+
+  it("falls back to Vercel bootstrap when the Cloudflare snapshot fails", async () => {
+    const calls: string[] = [];
+    const fetcher = async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      if (String(input).startsWith("https://snapshot.example")) {
+        return new Response("not found", { status: 404 });
+      }
+      return jsonResponse(snapshot());
+    };
+
+    const result = await fetchFeedBootstrapSnapshot(
+      fetcher,
+      "https://snapshot.example/feed.json",
+    );
+
+    expect(result).toEqual(snapshot());
+    expect(calls).toEqual([
+      "https://snapshot.example/feed.json",
+      VERCEL_FEED_BOOTSTRAP_URL,
+    ]);
+  });
+
+  it("falls back to Vercel bootstrap when the Cloudflare payload is invalid", async () => {
+    const calls: string[] = [];
+    const fetcher = async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      if (String(input).startsWith("https://snapshot.example")) {
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse(snapshot());
+    };
+
+    const result = await fetchFeedBootstrapSnapshot(
+      fetcher,
+      "https://snapshot.example/feed.json",
+    );
+
+    expect(result).toEqual(snapshot());
+    expect(calls).toEqual([
+      "https://snapshot.example/feed.json",
+      VERCEL_FEED_BOOTSTRAP_URL,
+    ]);
+  });
+
+  it("returns null when all bootstrap sources fail so live relays can take over", async () => {
+    const fetcher = async () => new Response("unavailable", { status: 503 });
+
+    await expect(
+      fetchFeedBootstrapSnapshot(fetcher, "https://snapshot.example/feed.json"),
+    ).resolves.toBeNull();
   });
 });

--- a/src/shared/lib/feedBootstrapClient.ts
+++ b/src/shared/lib/feedBootstrapClient.ts
@@ -8,6 +8,61 @@ export type FeedBootstrapResponse = {
   profiles: Record<string, ProfileMetadata>;
 };
 
+export const VERCEL_FEED_BOOTSTRAP_URL = "/api/feed/bootstrap";
+export const FEED_SNAPSHOT_URL_ENV = "VITE_FEED_SNAPSHOT_URL";
+
+type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+function configuredFeedSnapshotUrl(): string | null {
+  const url = import.meta.env[FEED_SNAPSHOT_URL_ENV]?.trim();
+  return url || null;
+}
+
+export function feedBootstrapUrls(
+  externalSnapshotUrl: string | null = configuredFeedSnapshotUrl(),
+): string[] {
+  return externalSnapshotUrl
+    ? [externalSnapshotUrl, VERCEL_FEED_BOOTSTRAP_URL]
+    : [VERCEL_FEED_BOOTSTRAP_URL];
+}
+
+function isFeedBootstrapResponse(value: unknown): value is FeedBootstrapResponse {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<FeedBootstrapResponse>;
+
+  return (
+    typeof candidate.fetchedAt === "number" &&
+    Array.isArray(candidate.processedEvents) &&
+    !!candidate.profiles &&
+    typeof candidate.profiles === "object"
+  );
+}
+
+export async function fetchFeedBootstrapSnapshot(
+  fetcher: FetchLike = fetch,
+  externalSnapshotUrl: string | null = configuredFeedSnapshotUrl(),
+): Promise<FeedBootstrapResponse | null> {
+  for (const url of feedBootstrapUrls(externalSnapshotUrl)) {
+    try {
+      const response = await fetcher(url);
+      if (!response.ok) continue;
+
+      const snapshot = (await response.json()) as unknown;
+      if (isFeedBootstrapResponse(snapshot)) {
+        return snapshot;
+      }
+    } catch {
+      // Try the next bootstrap source.
+    }
+  }
+
+  return null;
+}
+
 export function eventsFromProcessed(processedEvents: ProcessedEvent[]): Event[] {
   const events: Event[] = [];
   const seen = new Set<string>();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,12 @@ function unfurlDevApi(): Plugin {
   return {
     name: "unfurl-dev-api",
     configureServer(server) {
+      const setSnapshotCorsHeaders = (res: ServerResponse) => {
+        res.setHeader("Access-Control-Allow-Origin", "*");
+        res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+        res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+      };
+
       server.middlewares.use(
         "/api/unfurl",
         async (req: IncomingMessage, res: ServerResponse, next) => {
@@ -47,6 +53,14 @@ function unfurlDevApi(): Plugin {
       server.middlewares.use(
         "/api/feed/bootstrap",
         async (req: IncomingMessage, res: ServerResponse) => {
+          setSnapshotCorsHeaders(res);
+
+          if (req.method === "OPTIONS") {
+            res.statusCode = 204;
+            res.end();
+            return;
+          }
+
           if (req.method !== "GET") {
             res.statusCode = 405;
             res.setHeader("Allow", "GET");


### PR DESCRIPTION
## Summary
- add an optional `VITE_FEED_SNAPSHOT_URL` bootstrap source before the Vercel API fallback
- keep `/api/feed/bootstrap` as the second bootstrap source, with live relays remaining as the final fallback
- allow CORS on the local/dev bootstrap endpoint so it can be served through Cloudflare Tunnel

## Verification
- confirmed `https://snapshot.wiredsignal.online/api/feed/bootstrap` returns 200 with snapshot JSON through Cloudflare Tunnel
- previously ran `npm test`, `npm run typecheck`, `npm run lint`, and `npm run build` on this branch
- set Vercel project env `VITE_FEED_SNAPSHOT_URL=https://snapshot.wiredsignal.online/api/feed/bootstrap` for preview and production builds