### PR TITLE
Rank feed replies by filtered work

### DIFF
--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -21,8 +21,13 @@ useWebSocketImplementation(WebSocket);
 const PROFILE_RELAYS = [
   ...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS]),
 ] as string[];
+const FEED_SNAPSHOT_RELAYS = [
+  ...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS]),
+] as string[];
+const REPLY_RELAYS = FEED_SNAPSHOT_RELAYS;
 
 const DEFAULT_TIMEOUT_MS = 12_000;
+const REPLY_FETCH_DEPTH = 3;
 
 export type FeedBootstrapSnapshot = {
   fetchedAt: number;
@@ -135,7 +140,7 @@ async function fetchGlobalFeedEvents(
   ageHours: number,
   timeoutMs: number,
 ): Promise<Event[]> {
-  const relays = await connectRelays(DEFAULT_RELAYS, timeoutMs);
+  const relays = await connectRelays(FEED_SNAPSHOT_RELAYS, timeoutMs);
 
   try {
     const notes = new Set<string>();
@@ -146,6 +151,7 @@ async function fetchGlobalFeedEvents(
       relays,
       { kinds: [1, 1068], since, limit: 500 },
       timeoutMs,
+      [...DEFAULT_RELAYS],
     );
 
     rootEvents.forEach((event) => trackRootNote(notes, event));
@@ -154,11 +160,29 @@ async function fetchGlobalFeedEvents(
       return rootEvents;
     }
 
-    const replyEvents = await subscribeOnce(
-      relays,
-      { "#e": [...notes], kinds: [1] },
-      timeoutMs,
-    );
+    const replyEvents: Event[] = [];
+    const seenReplyIds = new Set<string>();
+    let parentIds = [...notes];
+
+    for (let depth = 0; depth < REPLY_FETCH_DEPTH && parentIds.length > 0; depth += 1) {
+      const nextReplies = await subscribeOnce(
+        relays,
+        { "#e": parentIds, kinds: [1] },
+        timeoutMs,
+        REPLY_RELAYS,
+      );
+      const nextParentIds: string[] = [];
+
+      nextReplies.forEach((event) => {
+        if (seenReplyIds.has(event.id)) return;
+
+        seenReplyIds.add(event.id);
+        replyEvents.push(event);
+        nextParentIds.push(event.id);
+      });
+
+      parentIds = nextParentIds;
+    }
 
     const merged = new Map<string, Event>();
     [...rootEvents, ...replyEvents].forEach((event) => {

--- a/src/features/feed/FeedPage.tsx
+++ b/src/features/feed/FeedPage.tsx
@@ -62,6 +62,8 @@ export default function FeedPage() {
               key={event.postEvent.id}
               event={event.postEvent}
               replies={event.replies}
+              totalWork={event.totalWork}
+              replyCount={event.threadReplyCount}
               animate={shouldResolve}
               animationIndex={index - SKIP_RESOLVE_COUNT}
               fadeIn={shouldFadeIn}

--- a/src/features/thread/ThreadPage.tsx
+++ b/src/features/thread/ThreadPage.tsx
@@ -8,6 +8,7 @@ import { ContentColumn, PageShell } from "../../shared/ui/PageShell";
 import { ThreadComposer } from "../compose/ThreadComposer";
 import { useInfiniteScroll } from "../../shared/hooks/useInfiniteScroll";
 import { useThreadViewModel } from "../../hooks/useThreadViewModel";
+import { eventWork } from "../../nostr/processing/pow-score";
 
 function decodeNoteId(id: string | undefined): string | null {
   if (!id) return null;
@@ -30,6 +31,13 @@ function ThreadView({ hexID }: { hexID: string }) {
     setShowAllReplies,
     uniqMentions,
   } = useThreadViewModel(hexID);
+  const directReplyEvents = replyEvents.filter((event) =>
+    event.postEvent.tags.some((tag) => tag[0] === "e" && tag[1] === hexID),
+  );
+  const opTotalWork = opEvent
+    ? eventWork(opEvent) +
+      directReplyEvents.reduce((total, event) => total + event.totalWork, 0)
+    : undefined;
 
   if (opEvent) {
     return (
@@ -49,6 +57,8 @@ function ThreadView({ hexID }: { hexID: string }) {
             event={opEvent}
             replies={replyEvents.flatMap((event) => event.replies)}
             role="threadOp"
+            totalWork={opTotalWork || undefined}
+            replyCount={directReplyEvents.length}
           />
         </ContentColumn>
         <ThreadComposer OPEvent={opEvent} />
@@ -76,6 +86,8 @@ function ThreadView({ hexID }: { hexID: string }) {
                 key={event.postEvent.id}
                 event={event.postEvent}
                 replies={event.replies}
+                totalWork={event.totalWork}
+                replyCount={event.threadReplyCount}
                 depth={getThreadDepth(event.postEvent, opEvent.id, eventsById)}
               />
             ))}

--- a/src/nostr/processEvents.test.ts
+++ b/src/nostr/processEvents.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Event } from "nostr-tools";
-import { processFeedEvents, toProcessedEvents } from "./processEvents";
+import {
+  compareProcessedEventsByWork,
+  processFeedEvents,
+  toProcessedEvents,
+} from "./processEvents";
+
+vi.mock("../shared/pow/core", () => ({
+  verifyPow: (event: Event) =>
+    Number(event.tags.find((tag) => tag[0] === "nonce")?.[2] ?? 0),
+}));
 
 const event = (overrides: Partial<Event> = {}): Event => ({
   id: "f".repeat(64),
@@ -52,5 +61,97 @@ describe("processFeedEvents", () => {
     const repost = event({ kind: 6, content: JSON.stringify(event()) });
 
     expect(processFeedEvents([repost])).toEqual([]);
+  });
+
+  it("uses the active filter difficulty as the minimum reply work difficulty", () => {
+    const lowerWorkRoot = event({
+      id: "1".repeat(64),
+      pubkey: "1".repeat(64),
+      created_at: 2,
+      tags: [["nonce", "root-a", "16"]],
+    });
+    const highWorkRoot = event({
+      id: "2".repeat(64),
+      pubkey: "2".repeat(64),
+      created_at: 1,
+      tags: [["nonce", "root-b", "20"]],
+    });
+    const lowPowReplies = Array.from({ length: 20 }, (_, index) =>
+      event({
+        id: `3${String(index).padStart(63, "0")}`,
+        pubkey: `3${String(index).padStart(63, "0")}`,
+        created_at: 3 + index,
+        tags: [["e", lowerWorkRoot.id], ["nonce", String(index), "15"]],
+      }),
+    );
+
+    const result = processFeedEvents(
+      [lowerWorkRoot, highWorkRoot, ...lowPowReplies],
+      16,
+    );
+
+    expect(result.map((item) => item.postEvent.id)).toEqual([
+      highWorkRoot.id,
+      lowerWorkRoot.id,
+    ]);
+    expect(result.find((item) => item.postEvent.id === lowerWorkRoot.id)).toMatchObject({
+      replies: lowPowReplies,
+      replyWork: 0,
+      rankingReplyCount: 0,
+    });
+  });
+
+  it("allows qualifying reply work to lift a thread", () => {
+    const repliedRoot = event({
+      id: "1".repeat(64),
+      pubkey: "1".repeat(64),
+      created_at: 1,
+      tags: [["nonce", "root-a", "16"]],
+    });
+    const unrepliedRoot = event({
+      id: "2".repeat(64),
+      pubkey: "2".repeat(64),
+      created_at: 2,
+      tags: [["nonce", "root-b", "20"]],
+    });
+    const qualifyingReplies = Array.from({ length: 16 }, (_, index) =>
+      event({
+        id: `3${String(index).padStart(63, "0")}`,
+        pubkey: `3${String(index).padStart(63, "0")}`,
+        created_at: 3 + index,
+        tags: [["e", repliedRoot.id], ["nonce", String(index), "16"]],
+      }),
+    );
+
+    const result = processFeedEvents(
+      [repliedRoot, unrepliedRoot, ...qualifyingReplies],
+      16,
+    );
+
+    expect(result.map((item) => item.postEvent.id)).toEqual([
+      repliedRoot.id,
+      unrepliedRoot.id,
+    ]);
+    expect(result[0]).toMatchObject({
+      replyWork: Math.pow(2, 20),
+      rankingReplyCount: 16,
+    });
+  });
+});
+
+describe("compareProcessedEventsByWork", () => {
+  it("breaks equal work ties by newer root post first", () => {
+    const older = {
+      postEvent: event({ id: "1".repeat(64), created_at: 1 }),
+      replies: [],
+      totalWork: 100,
+    };
+    const newer = {
+      postEvent: event({ id: "2".repeat(64), created_at: 2 }),
+      replies: [],
+      totalWork: 100,
+    };
+
+    expect([older, newer].sort(compareProcessedEventsByWork)).toEqual([newer, older]);
   });
 });

--- a/src/nostr/processEvents.test.ts
+++ b/src/nostr/processEvents.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { Event } from "nostr-tools";
 import {
+  collectThreadReplies,
   compareProcessedEventsByWork,
   processFeedEvents,
   toProcessedEvents,
@@ -55,6 +56,38 @@ describe("processFeedEvents", () => {
     expect(result).toHaveLength(1);
     expect(result[0].postEvent.id).toBe(root.id);
     expect(result[0].replies).toEqual([reply]);
+    expect(result[0].threadReplyCount).toBe(1);
+  });
+
+  it("includes nested thread replies in feed reply count and total work", () => {
+    const root = event({
+      id: "1".repeat(64),
+      pubkey: "1".repeat(64),
+      tags: [["nonce", "root", "16"]],
+    });
+    const directReply = event({
+      id: "2".repeat(64),
+      pubkey: "2".repeat(64),
+      tags: [["e", root.id], ["nonce", "direct", "16"]],
+    });
+    const nestedReply = event({
+      id: "3".repeat(64),
+      pubkey: "3".repeat(64),
+      tags: [["e", directReply.id], ["nonce", "nested", "16"]],
+    });
+
+    const result = processFeedEvents([root, directReply, nestedReply], 16);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replies.map((reply) => reply.id)).toEqual([
+      directReply.id,
+      nestedReply.id,
+    ]);
+    expect(result[0]).toMatchObject({
+      threadReplyCount: 2,
+      replyWork: Math.pow(2, 17),
+      rankingReplyCount: 2,
+    });
   });
 
   it("ignores plain repost events", () => {
@@ -136,6 +169,29 @@ describe("processFeedEvents", () => {
       replyWork: Math.pow(2, 20),
       rankingReplyCount: 16,
     });
+  });
+});
+
+describe("collectThreadReplies", () => {
+  it("deduplicates replies that tag both root and parent", () => {
+    const root = event({ id: "1".repeat(64) });
+    const directReply = event({
+      id: "2".repeat(64),
+      tags: [["e", root.id]],
+    });
+    const nestedReply = event({
+      id: "3".repeat(64),
+      tags: [["e", root.id], ["e", directReply.id]],
+    });
+    const repliesByParent = new Map([
+      [root.id, [directReply, nestedReply]],
+      [directReply.id, [nestedReply]],
+    ]);
+
+    expect(collectThreadReplies(root.id, repliesByParent).map((reply) => reply.id)).toEqual([
+      directReply.id,
+      nestedReply.id,
+    ]);
   });
 });
 

--- a/src/nostr/processEvents.ts
+++ b/src/nostr/processEvents.ts
@@ -29,6 +29,26 @@ export function buildRepliesByParent(events: Event[]): Map<string, Event[]> {
   return repliesByParent;
 }
 
+export function collectThreadReplies(
+  rootId: string,
+  repliesByParent: Map<string, Event[]>,
+): Event[] {
+  const replies: Event[] = [];
+  const seen = new Set<string>();
+  const pending = [...(repliesByParent.get(rootId) ?? [])];
+
+  while (pending.length > 0) {
+    const reply = pending.shift();
+    if (!reply || seen.has(reply.id)) continue;
+
+    seen.add(reply.id);
+    replies.push(reply);
+    pending.push(...(repliesByParent.get(reply.id) ?? []));
+  }
+
+  return replies;
+}
+
 export function toProcessedEvents(
   posts: Event[],
   replySource: Event[],
@@ -41,6 +61,7 @@ export function toProcessedEvents(
       return {
         postEvent,
         replies,
+        threadReplyCount: replies.length,
         ...workScoreBreakdown(postEvent, replies),
       };
     })
@@ -64,10 +85,11 @@ export const processFeedEvents = (events: Event[], filterDifficulty = 0): Proces
 
   return posts
     .map((postEvent) => {
-      const replies = repliesByParent.get(postEvent.id) ?? [];
+      const replies = collectThreadReplies(postEvent.id, repliesByParent);
       return {
         postEvent,
         replies,
+        threadReplyCount: replies.length,
         ...workScoreBreakdown(postEvent, replies, {
           minReplyDifficulty: filterDifficulty,
         }),

--- a/src/nostr/processEvents.ts
+++ b/src/nostr/processEvents.ts
@@ -1,10 +1,17 @@
 import type { Event } from "nostr-tools";
 import { verifyPow } from "../shared/pow/core.js";
 import { isRootNote } from "../shared/lib/noteEvents.js";
-import { totalWork } from "./processing/pow-score.js";
+import { workScoreBreakdown } from "./processing/pow-score.js";
 import type { ProcessedEvent } from "./types.js";
 
 export type { ProcessedEvent } from "./types.js";
+
+export function compareProcessedEventsByWork(
+  a: ProcessedEvent,
+  b: ProcessedEvent,
+): number {
+  return b.totalWork - a.totalWork || b.postEvent.created_at - a.postEvent.created_at;
+}
 
 export function buildRepliesByParent(events: Event[]): Map<string, Event[]> {
   const repliesByParent = new Map<string, Event[]>();
@@ -31,7 +38,11 @@ export function toProcessedEvents(
   return posts
     .map((postEvent) => {
       const replies = repliesByParent.get(postEvent.id) ?? [];
-      return { postEvent, replies, totalWork: totalWork(postEvent, replies) };
+      return {
+        postEvent,
+        replies,
+        ...workScoreBreakdown(postEvent, replies),
+      };
     })
     .sort((a, b) => a.postEvent.created_at - b.postEvent.created_at);
 }
@@ -54,7 +65,13 @@ export const processFeedEvents = (events: Event[], filterDifficulty = 0): Proces
   return posts
     .map((postEvent) => {
       const replies = repliesByParent.get(postEvent.id) ?? [];
-      return { postEvent, replies, totalWork: totalWork(postEvent, replies) };
+      return {
+        postEvent,
+        replies,
+        ...workScoreBreakdown(postEvent, replies, {
+          minReplyDifficulty: filterDifficulty,
+        }),
+      };
     })
-    .sort((a, b) => b.totalWork - a.totalWork || b.postEvent.created_at - a.postEvent.created_at);
+    .sort(compareProcessedEventsByWork);
 };

--- a/src/nostr/processing/pow-score.test.ts
+++ b/src/nostr/processing/pow-score.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Event } from "nostr-tools";
 import { verifyPow } from "../../shared/pow/core";
-import { eventWork, replyWork, totalWork, replyEquivalentDifficulty } from "./pow-score";
+import {
+  eventWork,
+  replyWork,
+  totalWork,
+  replyEquivalentDifficulty,
+  workScoreBreakdown,
+} from "./pow-score";
+
+vi.mock("../../shared/pow/core", () => ({
+  verifyPow: (event: Event) =>
+    Number(event.tags.find((tag) => tag[0] === "nonce")?.[2] ?? 0),
+}));
 
 const event = (overrides: Partial<Event> = {}): Event => ({
   id: "f".repeat(64),
@@ -20,17 +31,47 @@ describe("pow-score", () => {
     expect(eventWork(evt)).toBe(Math.pow(2, verifyPow(evt)));
   });
 
-  it("replyWork uses zero-prefix gate", () => {
-    const zeroPrefix = event({ id: "0" + "f".repeat(63) });
-    const other = event({ id: "f".repeat(64) });
-    expect(replyWork(other)).toBe(1);
-    expect(replyWork(zeroPrefix)).toBe(Math.pow(2, verifyPow(zeroPrefix)));
+  it("replyWork mirrors reply PoW when it meets the minimum difficulty", () => {
+    const reply = event({ tags: [["nonce", "1", "16"]] });
+
+    expect(replyWork(reply, { minReplyDifficulty: 16 })).toBe(Math.pow(2, 16));
   });
 
-  it("totalWork sums event and reply work", () => {
+  it("replyWork ignores replies below the minimum difficulty", () => {
+    const reply = event({ tags: [["nonce", "1", "15"]] });
+
+    expect(replyWork(reply, { minReplyDifficulty: 16 })).toBe(0);
+  });
+
+  it("totalWork sums root work and qualifying reply work", () => {
     const root = event();
-    const reply = event({ id: "f".repeat(64) });
-    expect(totalWork(root, [reply])).toBe(eventWork(root) + replyWork(reply));
+    const qualifyingReply = event({ tags: [["nonce", "1", "16"]] });
+    const ignoredReply = event({ tags: [["nonce", "1", "15"]] });
+
+    expect(
+      totalWork(root, [qualifyingReply, ignoredReply], {
+        minReplyDifficulty: 16,
+      }),
+    ).toBe(eventWork(root) + replyWork(qualifyingReply));
+  });
+
+  it("sixteen 16-PoW replies equal one 20-PoW event worth of reply work", () => {
+    const replies = Array.from({ length: 16 }, (_, index) =>
+      event({
+        id: String(index).padStart(64, "0"),
+        tags: [["nonce", String(index), "16"]],
+      }),
+    );
+
+    const { replyWork: totalReplyWork, rankingReplyCount } = workScoreBreakdown(
+      event({ tags: [["nonce", "root", "0"]] }),
+      replies,
+      { minReplyDifficulty: 16 },
+    );
+
+    expect(totalReplyWork).toBe(Math.pow(2, 20));
+    expect(totalReplyWork).toBe(eventWork(event({ tags: [["nonce", "1", "20"]] })));
+    expect(rankingReplyCount).toBe(16);
   });
 
   it("replyEquivalentDifficulty is zero for empty replies", () => {

--- a/src/nostr/processing/pow-score.ts
+++ b/src/nostr/processing/pow-score.ts
@@ -1,16 +1,62 @@
 import type { Event } from "nostr-tools";
 import { verifyPow } from "../../shared/pow/core.js";
 
+export type WorkScoreOptions = {
+  minReplyDifficulty?: number;
+};
+
+export type WorkScoreBreakdown = {
+  rootWork: number;
+  replyWork: number;
+  totalWork: number;
+  rankingReplyCount: number;
+};
+
 export function eventWork(event: Event): number {
   return Math.pow(2, verifyPow(event));
 }
 
-export function replyWork(reply: Event): number {
-  return Math.pow(2, reply.id.startsWith("0") ? verifyPow(reply) : 0);
+export function replyWork(reply: Event, options: WorkScoreOptions = {}): number {
+  const difficulty = verifyPow(reply);
+  const minDifficulty = options.minReplyDifficulty ?? 0;
+
+  if (difficulty < minDifficulty) {
+    return 0;
+  }
+
+  return Math.pow(2, difficulty);
 }
 
-export function totalWork(event: Event, replies: Event[]): number {
-  return eventWork(event) + replies.reduce((sum, reply) => sum + replyWork(reply), 0);
+export function workScoreBreakdown(
+  event: Event,
+  replies: Event[],
+  options: WorkScoreOptions = {},
+): WorkScoreBreakdown {
+  const rootWork = eventWork(event);
+  let rankingReplyCount = 0;
+
+  const replyTotal = replies.reduce((sum, reply) => {
+    const work = replyWork(reply, options);
+    if (work > 0) {
+      rankingReplyCount += 1;
+    }
+    return sum + work;
+  }, 0);
+
+  return {
+    rootWork,
+    replyWork: replyTotal,
+    totalWork: rootWork + replyTotal,
+    rankingReplyCount,
+  };
+}
+
+export function totalWork(
+  event: Event,
+  replies: Event[],
+  options: WorkScoreOptions = {},
+): number {
+  return workScoreBreakdown(event, replies, options).totalWork;
 }
 
 export function replyEquivalentDifficulty(replies: Event[]): number {

--- a/src/nostr/types.ts
+++ b/src/nostr/types.ts
@@ -7,6 +7,7 @@ export type ProcessedEvent = {
   rootWork?: number;
   replyWork?: number;
   rankingReplyCount?: number;
+  threadReplyCount?: number;
 };
 
 export type SubCallback = (event: Event, relay: string) => void;

--- a/src/nostr/types.ts
+++ b/src/nostr/types.ts
@@ -4,6 +4,9 @@ export type ProcessedEvent = {
   postEvent: Event;
   replies: Event[];
   totalWork: number;
+  rootWork?: number;
+  replyWork?: number;
+  rankingReplyCount?: number;
 };
 
 export type SubCallback = (event: Event, relay: string) => void;

--- a/src/shared/ui/MetadataRow.tsx
+++ b/src/shared/ui/MetadataRow.tsx
@@ -6,7 +6,6 @@ import { SignalAvatar } from "./SignalAvatar";
 type MetadataRowProps = {
   pubkey: string;
   signal: number;
-  replySignal?: number;
   replyCount: number;
   timestamp: string;
   onOpenThread?: () => void;
@@ -17,13 +16,11 @@ type MetadataRowProps = {
 function formatTelemetry({
   authorLabel,
   signal,
-  replySignal = 0,
   replyCount,
   timestamp,
 }: {
   authorLabel: string;
   signal: number;
-  replySignal?: number;
   replyCount: number;
   timestamp: string;
 }) {
@@ -34,11 +31,7 @@ function formatTelemetry({
   }
 
   const replyLabel = `${replyCount} ${replyCount === 1 ? "reply" : "replies"}`;
-  parts.push(
-    replySignal > 0
-      ? `${replyLabel} · signal ${Math.round(replySignal)}`
-      : replyLabel,
-  );
+  parts.push(replyLabel);
 
   parts.push(timestamp);
 
@@ -48,7 +41,6 @@ function formatTelemetry({
 export function MetadataRow({
   pubkey,
   signal,
-  replySignal = 0,
   replyCount,
   timestamp,
   onOpenThread,
@@ -61,7 +53,6 @@ export function MetadataRow({
   const telemetry = formatTelemetry({
     authorLabel,
     signal,
-    replySignal,
     replyCount,
     timestamp,
   });

--- a/src/shared/ui/PostCard.tsx
+++ b/src/shared/ui/PostCard.tsx
@@ -21,6 +21,8 @@ interface PostCardProps {
   fadeIn?: boolean;
   imagePriority?: boolean;
   avatarPriority?: boolean;
+  totalWork?: number;
+  replyCount?: number;
 }
 
 const depthClasses: Record<number, string> = {
@@ -46,6 +48,8 @@ export function PostCard({
   fadeIn = false,
   imagePriority = false,
   avatarPriority = false,
+  totalWork,
+  replyCount,
 }: PostCardProps) {
   const navigate = useNavigate();
 
@@ -53,7 +57,9 @@ export function PostCard({
   const replySumPow = useMemo(() => replyEquivalentDifficulty(replies), [replies]);
   const authorLabel = getDisplayName(undefined, event.pubkey);
 
-  const signal = verifyPow(event);
+  const signal = totalWork ? Math.floor(Math.log2(totalWork)) : verifyPow(event);
+  const displayedReplyCount = replyCount ?? replies.length;
+  const displayedReplySignal = totalWork ? undefined : replySumPow;
   const timestamp = timeAgo(event.created_at);
   const isNavigable = role !== "threadOp";
 
@@ -89,8 +95,8 @@ export function PostCard({
       <MetadataRow
         pubkey={event.pubkey}
         signal={signal}
-        replySignal={replySumPow}
-        replyCount={replies.length}
+        replySignal={displayedReplySignal}
+        replyCount={displayedReplyCount}
         timestamp={timestamp}
         onOpenThread={isNavigable ? handleNavigate : undefined}
         forceSecondary={role === "threadOp"}

--- a/src/shared/ui/PostCard.tsx
+++ b/src/shared/ui/PostCard.tsx
@@ -1,7 +1,6 @@
 import { Event, nip19 } from "nostr-tools";
 import { timeAgo } from "@lib/timeFormat";
 import { verifyPow } from "../../shared/pow/core";
-import { replyEquivalentDifficulty } from "../../nostr/processing/pow-score";
 import { uniqBy } from "@lib/collections";
 import { getDisplayName } from "@lib/profile";
 import { TextContent } from "./TextContent";
@@ -54,12 +53,10 @@ export function PostCard({
   const navigate = useNavigate();
 
   const relatedEvents = useMemo(() => [event, ...(replies || [])], [event, replies]);
-  const replySumPow = useMemo(() => replyEquivalentDifficulty(replies), [replies]);
   const authorLabel = getDisplayName(undefined, event.pubkey);
 
   const signal = totalWork ? Math.floor(Math.log2(totalWork)) : verifyPow(event);
   const displayedReplyCount = replyCount ?? replies.length;
-  const displayedReplySignal = totalWork ? undefined : replySumPow;
   const timestamp = timeAgo(event.created_at);
   const isNavigable = role !== "threadOp";
 
@@ -95,7 +92,6 @@ export function PostCard({
       <MetadataRow
         pubkey={event.pubkey}
         signal={signal}
-        replySignal={displayedReplySignal}
         replyCount={displayedReplyCount}
         timestamp={timestamp}
         onOpenThread={isNavigable ? handleNavigate : undefined}


### PR DESCRIPTION
## Summary
- make main-feed reply work use the active feed filter difficulty as its minimum contribution threshold
- remove the old zero-prefix reply-work gate and score replies directly from verified PoW
- expose root/reply work breakdown fields on processed events for debugging/future UI
- centralize work ranking tie-break behavior

## Behavior
- with the default filter difficulty of 16, replies below 16 PoW still display but add 0 ranking work
- sixteen 16-PoW replies contribute the same reply work as one 20-PoW event
- ties still break by newer root post first

## Verification
- npm run typecheck
- npm test