### PR TITLE
Add raw PoW feed route

### DIFF
--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -1,8 +1,8 @@
 import { Relay, type Event, type Filter, useWebSocketImplementation } from "nostr-tools";
 import { WebSocket } from "ws";
 import {
-  DEFAULT_RELAYS,
-  QUOTE_FALLBACK_RELAYS,
+  POW_RELAYS,
+  THREAD_RELAYS,
 } from "../src/config.js";
 import {
   BOOTSTRAP_AGE_HOURS,
@@ -18,13 +18,9 @@ import {
 
 useWebSocketImplementation(WebSocket);
 
-const PROFILE_RELAYS = [
-  ...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS]),
-] as string[];
-const FEED_SNAPSHOT_RELAYS = [
-  ...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS]),
-] as string[];
-const REPLY_RELAYS = FEED_SNAPSHOT_RELAYS;
+const PROFILE_RELAYS = [...THREAD_RELAYS];
+const FEED_SNAPSHOT_RELAYS = [...THREAD_RELAYS];
+const REPLY_RELAYS = [...THREAD_RELAYS];
 
 const DEFAULT_TIMEOUT_MS = 12_000;
 const REPLY_FETCH_DEPTH = 3;
@@ -151,7 +147,7 @@ async function fetchGlobalFeedEvents(
       relays,
       { kinds: [1, 1068], since, limit: 500 },
       timeoutMs,
-      [...DEFAULT_RELAYS],
+      [...POW_RELAYS],
     );
 
     rootEvents.forEach((event) => trackRootNote(notes, event));

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -9,6 +9,7 @@ export function AppRoutes() {
     <Routes>
       <Route path="/settings" element={<SettingsPage />} />
       <Route path="/" element={<FeedPage />} />
+      <Route path="/raw" element={<FeedPage mode="raw" />} />
       <Route path="/thread/:id" element={<ThreadPage />} />
       <Route path="/notifications" element={<NotificationsPage />} />
     </Routes>

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,8 +5,20 @@ export const DEFAULT_RELAYS = [
   "wss://pow.relays.land",
 ] as const;
 
-export const QUOTE_FALLBACK_RELAYS = [
+export const POW_RELAYS = DEFAULT_RELAYS;
+
+export const ENRICHMENT_RELAYS = [
   "wss://relay.damus.io",
   "wss://offchain.pub",
   "wss://nos.lol",
+  "wss://relay.primal.net",
+  "wss://relay.nostr.band",
+  "wss://nostr.wine",
+  "wss://relay.snort.social",
+] as const;
+
+export const QUOTE_FALLBACK_RELAYS = ENRICHMENT_RELAYS;
+
+export const THREAD_RELAYS = [
+  ...new Set([...POW_RELAYS, ...ENRICHMENT_RELAYS]),
 ] as const;

--- a/src/features/feed/FeedPage.tsx
+++ b/src/features/feed/FeedPage.tsx
@@ -12,9 +12,13 @@ const INITIAL_RESOLVE_COUNT = 20;
 const RESOLVE_DURATION_MS = 600;
 const STAGGER_MS = 40;
 
-export default function FeedPage() {
+type FeedPageProps = {
+  mode?: "default" | "raw";
+};
+
+export default function FeedPage({ mode = "default" }: FeedPageProps) {
   const { settings, updateSettings } = useSettings();
-  const { processedEvents } = useFeed();
+  const { processedEvents } = useFeed({ mode });
   const visibleCount = useInfiniteScroll();
   const [resolveWindowOpen, setResolveWindowOpen] = useState(true);
 

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Event } from "nostr-tools";
-import { subGlobalFeed } from "../nostr/subscriptions";
+import { subGlobalFeed, subRepliesForRootIds } from "../nostr/subscriptions";
 import { processFeedEvents } from "../nostr/processEvents";
 import { useSettings } from "../app/settings";
-import { DEFAULT_RELAYS, QUOTE_FALLBACK_RELAYS } from "../config";
+import { POW_RELAYS, THREAD_RELAYS } from "../config";
 import { useFilteredNoteSubscription } from "../shared/hooks/useFilteredNoteSubscription";
 import { seedProfiles } from "../shared/hooks/useProfiles";
 import {
@@ -12,17 +12,15 @@ import {
   fetchFeedBootstrapSnapshot,
 } from "../shared/lib/feedBootstrapClient";
 
-const RAW_REPLY_RELAYS = [
-  ...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS]),
-];
-const RAW_REPLY_DEPTH = 3;
+const FEED_REPLY_DEPTH = 3;
 
 type FeedMode = "default" | "raw";
 
-function mergeNoteEvents(bootstrapEvents: Event[], liveEvents: Event[]): Event[] {
+function mergeNoteEvents(...eventGroups: Event[][]): Event[] {
   const merged = new Map<string, Event>();
-  bootstrapEvents.forEach((event) => merged.set(event.id, event));
-  liveEvents.forEach((event) => merged.set(event.id, event));
+  eventGroups.forEach((events) => {
+    events.forEach((event) => merged.set(event.id, event));
+  });
   return [...merged.values()];
 }
 
@@ -32,10 +30,12 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
   const rawFilterDifficulty = isRawMode ? settings.filterDifficulty : undefined;
   const bootstrapEligible = !isRawMode && canUseFeedBootstrap(settings);
   const [bootstrapEvents, setBootstrapEvents] = useState<Event[]>([]);
+  const [bootstrapRootIds, setBootstrapRootIds] = useState<string[]>([]);
 
   useEffect(() => {
     if (!bootstrapEligible) {
       setBootstrapEvents([]);
+      setBootstrapRootIds([]);
       return;
     }
 
@@ -43,12 +43,22 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
 
     void fetchFeedBootstrapSnapshot()
       .then((snapshot) => {
-        if (cancelled || !snapshot) return;
+        if (cancelled) return;
+        if (!snapshot) {
+          setBootstrapEvents([]);
+          setBootstrapRootIds([]);
+          return;
+        }
         setBootstrapEvents(eventsFromProcessed(snapshot.processedEvents));
+        setBootstrapRootIds(
+          snapshot.processedEvents.map((event) => event.postEvent.id),
+        );
         seedProfiles(snapshot.profiles);
       })
       .catch(() => {
         // Fall back to live relay subscription only.
+        setBootstrapEvents([]);
+        setBootstrapRootIds([]);
       });
 
     return () => {
@@ -61,14 +71,12 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
       subGlobalFeed(
         onEvent,
         settings.ageHours,
-        isRawMode
-          ? {
-              rootRelayUrls: DEFAULT_RELAYS,
-              replyRelayUrls: RAW_REPLY_RELAYS,
-              rootFilterDifficulty: rawFilterDifficulty,
-              replyDepth: RAW_REPLY_DEPTH,
-            }
-          : undefined,
+        {
+          rootRelayUrls: POW_RELAYS,
+          replyRelayUrls: THREAD_RELAYS,
+          rootFilterDifficulty: rawFilterDifficulty,
+          replyDepth: FEED_REPLY_DEPTH,
+        },
       ),
     [isRawMode, rawFilterDifficulty, settings.ageHours],
   );
@@ -78,9 +86,27 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
     settings.ageHours,
     rawFilterDifficulty,
   ]);
+
+  const bootstrapRootKey = bootstrapRootIds.join(",");
+  const subscribeBootstrapReplies = useCallback(
+    (onEvent: Parameters<typeof subRepliesForRootIds>[1]) =>
+      subRepliesForRootIds(bootstrapRootIds, onEvent, {
+        relayUrls: THREAD_RELAYS,
+        depth: FEED_REPLY_DEPTH,
+      }),
+    // Subscription factory is intentionally tied to the stable root key.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [bootstrapRootKey],
+  );
+  const bootstrapReplyEvents = useFilteredNoteSubscription(
+    subscribeBootstrapReplies,
+    [bootstrapRootKey],
+    !isRawMode && bootstrapRootIds.length > 0,
+  );
+
   const noteEvents = useMemo(
-    () => mergeNoteEvents(bootstrapEvents, liveEvents),
-    [bootstrapEvents, liveEvents],
+    () => mergeNoteEvents(bootstrapEvents, liveEvents, bootstrapReplyEvents),
+    [bootstrapEvents, liveEvents, bootstrapReplyEvents],
   );
   const processedEvents = useMemo(
     () => processFeedEvents(noteEvents, settings.filterDifficulty),

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -3,6 +3,7 @@ import type { Event } from "nostr-tools";
 import { subGlobalFeed } from "../nostr/subscriptions";
 import { processFeedEvents } from "../nostr/processEvents";
 import { useSettings } from "../app/settings";
+import { DEFAULT_RELAYS, QUOTE_FALLBACK_RELAYS } from "../config";
 import { useFilteredNoteSubscription } from "../shared/hooks/useFilteredNoteSubscription";
 import { seedProfiles } from "../shared/hooks/useProfiles";
 import {
@@ -11,6 +12,13 @@ import {
   fetchFeedBootstrapSnapshot,
 } from "../shared/lib/feedBootstrapClient";
 
+const RAW_REPLY_RELAYS = [
+  ...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS]),
+];
+const RAW_REPLY_DEPTH = 3;
+
+type FeedMode = "default" | "raw";
+
 function mergeNoteEvents(bootstrapEvents: Event[], liveEvents: Event[]): Event[] {
   const merged = new Map<string, Event>();
   bootstrapEvents.forEach((event) => merged.set(event.id, event));
@@ -18,9 +26,11 @@ function mergeNoteEvents(bootstrapEvents: Event[], liveEvents: Event[]): Event[]
   return [...merged.values()];
 }
 
-export function useFeed() {
+export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
   const { settings } = useSettings();
-  const bootstrapEligible = canUseFeedBootstrap(settings);
+  const isRawMode = mode === "raw";
+  const rawFilterDifficulty = isRawMode ? settings.filterDifficulty : undefined;
+  const bootstrapEligible = !isRawMode && canUseFeedBootstrap(settings);
   const [bootstrapEvents, setBootstrapEvents] = useState<Event[]>([]);
 
   useEffect(() => {
@@ -48,11 +58,26 @@ export function useFeed() {
 
   const subscribe = useCallback(
     (onEvent: Parameters<typeof subGlobalFeed>[0]) =>
-      subGlobalFeed(onEvent, settings.ageHours),
-    [settings.ageHours],
+      subGlobalFeed(
+        onEvent,
+        settings.ageHours,
+        isRawMode
+          ? {
+              rootRelayUrls: DEFAULT_RELAYS,
+              replyRelayUrls: RAW_REPLY_RELAYS,
+              rootFilterDifficulty: rawFilterDifficulty,
+              replyDepth: RAW_REPLY_DEPTH,
+            }
+          : undefined,
+      ),
+    [isRawMode, rawFilterDifficulty, settings.ageHours],
   );
 
-  const liveEvents = useFilteredNoteSubscription(subscribe, [settings.ageHours]);
+  const liveEvents = useFilteredNoteSubscription(subscribe, [
+    mode,
+    settings.ageHours,
+    rawFilterDifficulty,
+  ]);
   const noteEvents = useMemo(
     () => mergeNoteEvents(bootstrapEvents, liveEvents),
     [bootstrapEvents, liveEvents],

--- a/src/nostr/client.ts
+++ b/src/nostr/client.ts
@@ -1,17 +1,19 @@
 import type { Event } from "nostr-tools";
-import { DEFAULT_RELAYS, QUOTE_FALLBACK_RELAYS } from "../config";
+import {
+  ENRICHMENT_RELAYS,
+  POW_RELAYS,
+  THREAD_RELAYS as CONFIG_THREAD_RELAYS,
+} from "../config";
 import { RelayPool } from "./relay-pool";
 import { SubscriptionRegistry } from "./subscription-registry";
+
+export { THREAD_RELAYS } from "../config";
 
 let pool: RelayPool | null = null;
 let registry: SubscriptionRegistry | null = null;
 let connectPromise: Promise<void> | null = null;
 
-export const THREAD_RELAYS = [
-  ...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS]),
-] as string[];
-
-export const PROFILE_RELAYS = THREAD_RELAYS;
+export const PROFILE_RELAYS = [...CONFIG_THREAD_RELAYS];
 
 function ensureNostrClient(): void {
   if (!pool) {
@@ -28,8 +30,8 @@ export function initNostr(): Promise<void> {
 
   if (!connectPromise) {
     connectPromise = Promise.all([
-      pool.connect(DEFAULT_RELAYS),
-      pool.ensureConnected(QUOTE_FALLBACK_RELAYS),
+      pool.connect(POW_RELAYS),
+      pool.ensureConnected(ENRICHMENT_RELAYS),
     ]).then(() => {});
   }
 

--- a/src/nostr/relay-pool.ts
+++ b/src/nostr/relay-pool.ts
@@ -3,7 +3,7 @@ import type { SubCallback } from "./types";
 
 export type SubscribeOptions = {
   closeOnEose?: boolean;
-  relayUrls?: string[];
+  relayUrls?: readonly string[];
   onEose?: () => void;
 };
 

--- a/src/nostr/subscription-registry.ts
+++ b/src/nostr/subscription-registry.ts
@@ -6,7 +6,7 @@ type SubscribeRequest = {
   filter: Filter;
   cb: SubCallback;
   closeOnEose?: boolean;
-  relayUrls?: string[];
+  relayUrls?: readonly string[];
   onEose?: () => void;
 };
 

--- a/src/nostr/subscriptions/global-feed.test.ts
+++ b/src/nostr/subscriptions/global-feed.test.ts
@@ -10,7 +10,7 @@ vi.mock("../client", () => ({
   }),
 }));
 
-import { subGlobalFeed } from "./global-feed";
+import { subGlobalFeed, subRepliesForRootIds } from "./global-feed";
 
 const rootNote = (id: string): Event => ({
   id,
@@ -123,5 +123,43 @@ describe("subGlobalFeed", () => {
       kinds: [1],
     });
     expect(nestedReplyRequest.relayUrls).toEqual(enrichmentRelays);
+  });
+
+  it("can enrich replies for known root ids", () => {
+    const rootId = `${"1".repeat(64)}`;
+    const replyId = `${"2".repeat(64)}`;
+    const enrichmentRelays = ["wss://relay.damus.io"];
+
+    subscribeMock.mockImplementation((requests) => {
+      const id = String(subscribeMock.mock.calls.length);
+
+      if (id === "1") {
+        const { cb, onEose } = requests[0];
+        cb(rootNote(replyId), enrichmentRelays[0]);
+        onEose?.();
+      }
+
+      return { id, close: vi.fn() };
+    });
+
+    subRepliesForRootIds([rootId], vi.fn(), {
+      relayUrls: enrichmentRelays,
+      depth: 2,
+    });
+
+    expect(subscribeMock).toHaveBeenCalledTimes(2);
+
+    const replyRequest = subscribeMock.mock.calls[0][0][0];
+    expect(replyRequest.filter).toMatchObject({
+      "#e": [rootId],
+      kinds: [1],
+    });
+    expect(replyRequest.relayUrls).toEqual(enrichmentRelays);
+
+    const nestedReplyRequest = subscribeMock.mock.calls[1][0][0];
+    expect(nestedReplyRequest.filter).toMatchObject({
+      "#e": [replyId],
+      kinds: [1],
+    });
   });
 });

--- a/src/nostr/subscriptions/global-feed.test.ts
+++ b/src/nostr/subscriptions/global-feed.test.ts
@@ -22,6 +22,11 @@ const rootNote = (id: string): Event => ({
   sig: "b".repeat(128),
 });
 
+const rootNoteFromPubkey = (id: string, pubkey: string): Event => ({
+  ...rootNote(id),
+  pubkey,
+});
+
 describe("subGlobalFeed", () => {
   beforeEach(() => {
     subscribeMock.mockReset();
@@ -64,5 +69,59 @@ describe("subGlobalFeed", () => {
     subGlobalFeed(vi.fn(), 24);
 
     expect(subscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("can fetch PoW roots first and then enrich accepted roots from separate reply relays", () => {
+    const rootId = `${"1".repeat(64)}`;
+    const replyId = `${"2".repeat(64)}`;
+    const powRelays = ["wss://powrelay.xyz"];
+    const enrichmentRelays = ["wss://relay.damus.io"];
+
+    subscribeMock.mockImplementation((requests) => {
+      const id = String(subscribeMock.mock.calls.length);
+
+      if (id === "1") {
+        const { cb, onEose } = requests[0];
+        cb(rootNoteFromPubkey(rootId, "a".repeat(64)), powRelays[0]);
+        onEose?.();
+        return { id, close: vi.fn() };
+      }
+
+      if (id === "2") {
+        const { cb, onEose } = requests[0];
+        cb(rootNote(replyId), enrichmentRelays[0]);
+        onEose?.();
+        return { id, close: vi.fn() };
+      }
+
+      return { id, close: vi.fn() };
+    });
+
+    const onEvent = vi.fn() as SubCallback;
+    subGlobalFeed(onEvent, 24, {
+      rootRelayUrls: powRelays,
+      replyRelayUrls: enrichmentRelays,
+      rootFilterDifficulty: 0,
+      replyDepth: 2,
+    });
+
+    expect(subscribeMock).toHaveBeenCalledTimes(3);
+
+    const rootRequest = subscribeMock.mock.calls[0][0][0];
+    expect(rootRequest.relayUrls).toEqual(powRelays);
+
+    const replyRequest = subscribeMock.mock.calls[1][0][0];
+    expect(replyRequest.filter).toMatchObject({
+      "#e": [rootId],
+      kinds: [1],
+    });
+    expect(replyRequest.relayUrls).toEqual(enrichmentRelays);
+
+    const nestedReplyRequest = subscribeMock.mock.calls[2][0][0];
+    expect(nestedReplyRequest.filter).toMatchObject({
+      "#e": [replyId],
+      kinds: [1],
+    });
+    expect(nestedReplyRequest.relayUrls).toEqual(enrichmentRelays);
   });
 });

--- a/src/nostr/subscriptions/global-feed.ts
+++ b/src/nostr/subscriptions/global-feed.ts
@@ -74,6 +74,26 @@ const subRepliesForParents = (
   );
 };
 
+export const subRepliesForRootIds = (
+  rootIds: string[],
+  onEvent: SubCallback,
+  options: {
+    relayUrls?: readonly string[];
+    depth?: number;
+  } = {},
+): SubHandle => {
+  const children: SubHandle[] = [];
+  subRepliesForParents(
+    rootIds,
+    onEvent,
+    options.relayUrls,
+    options.depth ?? 1,
+    children,
+  );
+
+  return composeSubHandle("feed-replies", children);
+};
+
 export const subGlobalFeed = (
   onEvent: SubCallback,
   ageHours: number,

--- a/src/nostr/subscriptions/global-feed.ts
+++ b/src/nostr/subscriptions/global-feed.ts
@@ -3,6 +3,14 @@ import { isRootNote } from "@lib/noteEvents";
 import { getRegistry } from "../client";
 import type { SubCallback, SubHandle } from "../types";
 import { composeSubHandle } from "./utils";
+import { verifyPow } from "../../shared/pow/core";
+
+type GlobalFeedOptions = {
+  rootRelayUrls?: readonly string[];
+  replyRelayUrls?: readonly string[];
+  rootFilterDifficulty?: number;
+  replyDepth?: number;
+};
 
 const trackRootNote = (notes: Set<string>, evt: Event) => {
   if (isRootNote(evt)) {
@@ -10,12 +18,74 @@ const trackRootNote = (notes: Set<string>, evt: Event) => {
   }
 };
 
-export const subGlobalFeed = (onEvent: SubCallback, ageHours: number): SubHandle => {
+const trackAcceptedRootNote = (
+  notes: Set<string>,
+  seenPubkeys: Set<string>,
+  evt: Event,
+  filterDifficulty: number,
+) => {
+  if (evt.kind !== 1 && evt.kind !== 1068) return;
+  if (evt.kind === 1 && !isRootNote(evt)) return;
+  if (seenPubkeys.has(evt.pubkey)) return;
+  if (verifyPow(evt) < filterDifficulty) return;
+
+  seenPubkeys.add(evt.pubkey);
+
+  if (evt.kind === 1) {
+    notes.add(evt.id);
+  }
+};
+
+const subRepliesForParents = (
+  parentIds: string[],
+  onEvent: SubCallback,
+  relayUrls: readonly string[] | undefined,
+  depth: number,
+  children: SubHandle[],
+) => {
+  if (parentIds.length === 0 || depth <= 0) return;
+
+  const childReplyIds = new Set<string>();
+
+  children.push(
+    getRegistry().subscribe([
+      {
+        filter: {
+          "#e": parentIds,
+          kinds: [1],
+        },
+        relayUrls: relayUrls ? [...relayUrls] : undefined,
+        cb: (evt, relay) => {
+          childReplyIds.add(evt.id);
+          onEvent(evt, relay);
+        },
+        closeOnEose: true,
+        onEose: () => {
+          subRepliesForParents(
+            Array.from(childReplyIds),
+            onEvent,
+            relayUrls,
+            depth - 1,
+            children,
+          );
+        },
+      },
+    ]),
+  );
+};
+
+export const subGlobalFeed = (
+  onEvent: SubCallback,
+  ageHours: number,
+  options: GlobalFeedOptions = {},
+): SubHandle => {
   const registry = getRegistry();
   const children: SubHandle[] = [];
   const notes = new Set<string>();
+  const seenPubkeys = new Set<string>();
   const now = Math.floor(Date.now() / 1000);
   const since = now - ageHours * 60 * 60;
+  const replyDepth = options.replyDepth ?? 1;
 
   children.push(
     registry.subscribe([
@@ -25,8 +95,20 @@ export const subGlobalFeed = (onEvent: SubCallback, ageHours: number): SubHandle
           since,
           limit: 500,
         },
+        relayUrls: options.rootRelayUrls
+          ? [...options.rootRelayUrls]
+          : undefined,
         cb: (evt, relay) => {
-          trackRootNote(notes, evt);
+          if (options.rootFilterDifficulty === undefined) {
+            trackRootNote(notes, evt);
+          } else {
+            trackAcceptedRootNote(
+              notes,
+              seenPubkeys,
+              evt,
+              options.rootFilterDifficulty,
+            );
+          }
           onEvent(evt, relay);
         },
         closeOnEose: true,
@@ -36,17 +118,12 @@ export const subGlobalFeed = (onEvent: SubCallback, ageHours: number): SubHandle
           const noteIds = Array.from(notes);
           notes.clear();
 
-          children.push(
-            registry.subscribe([
-              {
-                filter: {
-                  "#e": noteIds,
-                  kinds: [1],
-                },
-                cb: onEvent,
-                closeOnEose: true,
-              },
-            ]),
+          subRepliesForParents(
+            noteIds,
+            onEvent,
+            options.replyRelayUrls,
+            replyDepth,
+            children,
           );
         },
       },

--- a/src/nostr/subscriptions/index.ts
+++ b/src/nostr/subscriptions/index.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_RELAYS, QUOTE_FALLBACK_RELAYS } from "../../config";
+import { ENRICHMENT_RELAYS, POW_RELAYS } from "../../config";
 import {
   ensureRelaysConnected,
   initNostr,
@@ -12,7 +12,7 @@ import { emptySubHandle } from "./utils";
 
 export type { SubCallback, SubHandle };
 
-export { subGlobalFeed } from "./global-feed";
+export { subGlobalFeed, subRepliesForRootIds } from "./global-feed";
 export { subNote } from "./thread";
 export { subNotifications } from "./notifications";
 
@@ -31,7 +31,7 @@ export const subPoll = (eventId: string, onEvent: SubCallback): SubHandle =>
 export const subNotesOnce = (
   eventIds: string[],
   onEvent: SubCallback,
-  relayUrls: string[] = THREAD_RELAYS,
+  relayUrls: readonly string[] = THREAD_RELAYS,
 ): SubHandle => {
   if (eventIds.length === 0) {
     return emptySubHandle("notes-once:empty");
@@ -77,7 +77,7 @@ export async function subProfilesOnce(
 }
 
 function relayUrlsForQuote(ref: QuotedRef): string[] {
-  return [...new Set([...DEFAULT_RELAYS, ...ref.relays, ...QUOTE_FALLBACK_RELAYS])];
+  return [...new Set([...POW_RELAYS, ...ref.relays, ...ENRICHMENT_RELAYS])];
 }
 
 export async function subQuotedEventsOnce(

--- a/src/nostr/subscriptions/thread.test.ts
+++ b/src/nostr/subscriptions/thread.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { DEFAULT_RELAYS, QUOTE_FALLBACK_RELAYS } from "../../config";
+import { THREAD_RELAYS } from "../../config";
 
 const subscribeMock = vi.fn();
 
@@ -7,12 +7,12 @@ vi.mock("../client", () => ({
   getRegistry: () => ({
     subscribe: subscribeMock,
   }),
-  THREAD_RELAYS: [...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS])],
+  THREAD_RELAYS,
 }));
 
 import { subNote } from "./thread";
 
-const expectedRelays = [...new Set([...DEFAULT_RELAYS, ...QUOTE_FALLBACK_RELAYS])];
+const expectedRelays = [...THREAD_RELAYS];
 
 describe("subNote", () => {
   beforeEach(() => {

--- a/src/shared/ui/routeLabelMap.test.ts
+++ b/src/shared/ui/routeLabelMap.test.ts
@@ -5,6 +5,7 @@ describe("routeLabelMap", () => {
   it("maps known routes to display segments", () => {
     expect(getDisplaySegment("/")).toBe("");
     expect(getDisplaySegment("/notifications")).toBe("activity");
+    expect(getDisplaySegment("/raw")).toBe("raw");
     expect(getDisplaySegment("/settings")).toBe("settings");
     expect(getDisplaySegment("/thread/note1")).toBe("thread");
   });
@@ -12,6 +13,7 @@ describe("routeLabelMap", () => {
   it("builds path display labels", () => {
     expect(getPathDisplay("/")).toBe("/");
     expect(getPathDisplay("/notifications")).toBe("/activity");
+    expect(getPathDisplay("/raw")).toBe("/raw");
     expect(getPathDisplay("/settings")).toBe("/settings");
     expect(getPathDisplay("/thread/note1")).toBe("/thread");
   });

--- a/src/shared/ui/routeLabelMap.ts
+++ b/src/shared/ui/routeLabelMap.ts
@@ -1,6 +1,7 @@
 const ROUTE_LABEL_MAP: Record<string, string> = {
   "/": "",
   "/notifications": "activity",
+  "/raw": "raw",
   "/settings": "settings",
   "/thread": "thread",
 };


### PR DESCRIPTION
## Summary
- add a /raw route that reuses the main feed UI
- skip Cloudflare/Vercel feed bootstrap for /raw
- fetch /raw roots from PoW relays, then enrich replies separately from PoW + enrichment relays for total-work sorting

## Verification
- npm run typecheck
- npm test