### PR TITLE
Bound relay reply queries

### DIFF
--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -8,6 +8,12 @@ import {
   BOOTSTRAP_AGE_HOURS,
   BOOTSTRAP_FILTER_DIFFICULTY,
 } from "./feedBootstrap.js";
+import {
+  buildReplyFilter,
+  clampReplyDepth,
+  profileQueryLimit,
+  sinceFromAgeHours,
+} from "../src/nostr/subscriptions/query-limits.js";
 import { processFeedEvents } from "../src/nostr/processEvents.js";
 import type { ProcessedEvent } from "../src/nostr/types.js";
 import { isRootNote } from "../src/shared/lib/noteEvents.js";
@@ -140,8 +146,7 @@ async function fetchGlobalFeedEvents(
 
   try {
     const notes = new Set<string>();
-    const now = Math.floor(Date.now() / 1000);
-    const since = now - ageHours * 60 * 60;
+    const since = sinceFromAgeHours(ageHours);
 
     const rootEvents = await subscribeOnce(
       relays,
@@ -160,10 +165,14 @@ async function fetchGlobalFeedEvents(
     const seenReplyIds = new Set<string>();
     let parentIds = [...notes];
 
-    for (let depth = 0; depth < REPLY_FETCH_DEPTH && parentIds.length > 0; depth += 1) {
+    const replyDepth = clampReplyDepth(REPLY_FETCH_DEPTH);
+    for (let depth = 0; depth < replyDepth && parentIds.length > 0; depth += 1) {
+      const replyFilter = buildReplyFilter(parentIds, since);
+      if (!replyFilter) break;
+
       const nextReplies = await subscribeOnce(
         relays,
-        { "#e": parentIds, kinds: [1] },
+        replyFilter,
         timeoutMs,
         REPLY_RELAYS,
       );
@@ -204,7 +213,11 @@ async function fetchProfileMetadata(
   try {
     const events = await subscribeOnce(
       relays,
-      { authors: pubkeys, kinds: [0] },
+      {
+        authors: pubkeys,
+        kinds: [0],
+        limit: profileQueryLimit(pubkeys.length),
+      },
       timeoutMs,
       PROFILE_RELAYS,
     );

--- a/src/hooks/useThreadEvents.ts
+++ b/src/hooks/useThreadEvents.ts
@@ -1,20 +1,14 @@
 import { useCallback } from "react";
 import { subNote } from "../nostr/subscriptions";
 import { useFilteredNoteSubscription } from "../shared/hooks/useFilteredNoteSubscription";
-import { useSettings } from "../app/settings";
 
 export function useThreadEvents(hexID: string) {
-  const { settings } = useSettings();
   const subscribe = useCallback(
-    (onEvent: Parameters<typeof subNote>[1]) =>
-      subNote(hexID, onEvent, settings.ageHours),
-    [hexID, settings.ageHours],
+    (onEvent: Parameters<typeof subNote>[1]) => subNote(hexID, onEvent),
+    [hexID],
   );
 
-  const noteEvents = useFilteredNoteSubscription(subscribe, [
-    hexID,
-    settings.ageHours,
-  ]);
+  const noteEvents = useFilteredNoteSubscription(subscribe, [hexID]);
 
   return { noteEvents };
 }

--- a/src/hooks/useThreadEvents.ts
+++ b/src/hooks/useThreadEvents.ts
@@ -1,14 +1,20 @@
 import { useCallback } from "react";
 import { subNote } from "../nostr/subscriptions";
 import { useFilteredNoteSubscription } from "../shared/hooks/useFilteredNoteSubscription";
+import { useSettings } from "../app/settings";
 
 export function useThreadEvents(hexID: string) {
+  const { settings } = useSettings();
   const subscribe = useCallback(
-    (onEvent: Parameters<typeof subNote>[1]) => subNote(hexID, onEvent),
-    [hexID],
+    (onEvent: Parameters<typeof subNote>[1]) =>
+      subNote(hexID, onEvent, settings.ageHours),
+    [hexID, settings.ageHours],
   );
 
-  const noteEvents = useFilteredNoteSubscription(subscribe, [hexID]);
+  const noteEvents = useFilteredNoteSubscription(subscribe, [
+    hexID,
+    settings.ageHours,
+  ]);
 
   return { noteEvents };
 }

--- a/src/nostr/subscriptions/global-feed.test.ts
+++ b/src/nostr/subscriptions/global-feed.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { Event } from "nostr-tools";
 import type { SubCallback } from "../types";
+import {
+  MAX_REPLY_FETCH_DEPTH,
+  MAX_REPLY_PARENT_IDS,
+  REPLY_QUERY_LIMIT,
+} from "./query-limits";
 
 const subscribeMock = vi.fn();
 
@@ -55,6 +60,8 @@ describe("subGlobalFeed", () => {
     expect(replyRequest.filter).toMatchObject({
       "#e": ["1".repeat(64)],
       kinds: [1],
+      limit: REPLY_QUERY_LIMIT,
+      since: expect.any(Number),
     });
     expect(replyRequest.closeOnEose).toBe(true);
   });
@@ -114,6 +121,8 @@ describe("subGlobalFeed", () => {
     expect(replyRequest.filter).toMatchObject({
       "#e": [rootId],
       kinds: [1],
+      limit: REPLY_QUERY_LIMIT,
+      since: expect.any(Number),
     });
     expect(replyRequest.relayUrls).toEqual(enrichmentRelays);
 
@@ -121,6 +130,8 @@ describe("subGlobalFeed", () => {
     expect(nestedReplyRequest.filter).toMatchObject({
       "#e": [replyId],
       kinds: [1],
+      limit: REPLY_QUERY_LIMIT,
+      since: expect.any(Number),
     });
     expect(nestedReplyRequest.relayUrls).toEqual(enrichmentRelays);
   });
@@ -153,6 +164,8 @@ describe("subGlobalFeed", () => {
     expect(replyRequest.filter).toMatchObject({
       "#e": [rootId],
       kinds: [1],
+      limit: REPLY_QUERY_LIMIT,
+      since: expect.any(Number),
     });
     expect(replyRequest.relayUrls).toEqual(enrichmentRelays);
 
@@ -160,6 +173,35 @@ describe("subGlobalFeed", () => {
     expect(nestedReplyRequest.filter).toMatchObject({
       "#e": [replyId],
       kinds: [1],
+      limit: REPLY_QUERY_LIMIT,
+      since: expect.any(Number),
+    });
+  });
+
+  it("caps reply parent ids and requested depth", () => {
+    const rootIds = Array.from({ length: MAX_REPLY_PARENT_IDS + 10 }, (_, index) =>
+      String(index).padStart(64, "0"),
+    );
+
+    subscribeMock.mockImplementation((requests) => {
+      const id = String(subscribeMock.mock.calls.length);
+      if (Number(id) <= MAX_REPLY_FETCH_DEPTH) {
+        const { cb, onEose } = requests[0];
+        cb(rootNote(String(Number(id)).repeat(64)), "wss://relay.damus.io");
+        onEose?.();
+      }
+      return { id, close: vi.fn() };
+    });
+
+    subRepliesForRootIds(rootIds, vi.fn(), { depth: MAX_REPLY_FETCH_DEPTH + 3 });
+
+    expect(subscribeMock).toHaveBeenCalledTimes(MAX_REPLY_FETCH_DEPTH);
+    const firstReplyRequest = subscribeMock.mock.calls[0][0][0];
+    expect(firstReplyRequest.filter["#e"]).toHaveLength(MAX_REPLY_PARENT_IDS);
+    expect(firstReplyRequest.filter).toMatchObject({
+      kinds: [1],
+      limit: REPLY_QUERY_LIMIT,
+      since: expect.any(Number),
     });
   });
 });

--- a/src/nostr/subscriptions/global-feed.ts
+++ b/src/nostr/subscriptions/global-feed.ts
@@ -4,6 +4,11 @@ import { getRegistry } from "../client";
 import type { SubCallback, SubHandle } from "../types";
 import { composeSubHandle } from "./utils";
 import { verifyPow } from "../../shared/pow/core";
+import {
+  buildReplyFilter,
+  clampReplyDepth,
+  sinceFromAgeHours,
+} from "./query-limits";
 
 type GlobalFeedOptions = {
   rootRelayUrls?: readonly string[];
@@ -41,19 +46,19 @@ const subRepliesForParents = (
   onEvent: SubCallback,
   relayUrls: readonly string[] | undefined,
   depth: number,
+  since: number,
   children: SubHandle[],
 ) => {
   if (parentIds.length === 0 || depth <= 0) return;
 
   const childReplyIds = new Set<string>();
+  const filter = buildReplyFilter(parentIds, since);
+  if (!filter) return;
 
   children.push(
     getRegistry().subscribe([
       {
-        filter: {
-          "#e": parentIds,
-          kinds: [1],
-        },
+        filter,
         relayUrls: relayUrls ? [...relayUrls] : undefined,
         cb: (evt, relay) => {
           childReplyIds.add(evt.id);
@@ -66,6 +71,7 @@ const subRepliesForParents = (
             onEvent,
             relayUrls,
             depth - 1,
+            since,
             children,
           );
         },
@@ -80,6 +86,7 @@ export const subRepliesForRootIds = (
   options: {
     relayUrls?: readonly string[];
     depth?: number;
+    since?: number;
   } = {},
 ): SubHandle => {
   const children: SubHandle[] = [];
@@ -87,7 +94,8 @@ export const subRepliesForRootIds = (
     rootIds,
     onEvent,
     options.relayUrls,
-    options.depth ?? 1,
+    clampReplyDepth(options.depth ?? 1),
+    options.since ?? sinceFromAgeHours(24),
     children,
   );
 
@@ -104,8 +112,8 @@ export const subGlobalFeed = (
   const notes = new Set<string>();
   const seenPubkeys = new Set<string>();
   const now = Math.floor(Date.now() / 1000);
-  const since = now - ageHours * 60 * 60;
-  const replyDepth = options.replyDepth ?? 1;
+  const since = sinceFromAgeHours(ageHours, now);
+  const replyDepth = clampReplyDepth(options.replyDepth ?? 1);
 
   children.push(
     registry.subscribe([
@@ -143,6 +151,7 @@ export const subGlobalFeed = (
             onEvent,
             options.replyRelayUrls,
             replyDepth,
+            since,
             children,
           );
         },

--- a/src/nostr/subscriptions/index.ts
+++ b/src/nostr/subscriptions/index.ts
@@ -9,6 +9,7 @@ import {
 import type { SubCallback, SubHandle } from "../types";
 import type { QuotedRef } from "@lib/quotedEvents";
 import { emptySubHandle } from "./utils";
+import { profileQueryLimit } from "./query-limits";
 
 export type { SubCallback, SubHandle };
 
@@ -67,6 +68,7 @@ export async function subProfilesOnce(
       filter: {
         authors: pubkeys,
         kinds: [0],
+        limit: profileQueryLimit(pubkeys.length),
       },
       cb: onEvent,
       closeOnEose: true,

--- a/src/nostr/subscriptions/query-limits.test.ts
+++ b/src/nostr/subscriptions/query-limits.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildReplyFilter,
+  buildThreadReplyFilter,
   clampReplyDepth,
   MAX_REPLY_FETCH_DEPTH,
   MAX_REPLY_PARENT_IDS,
@@ -26,6 +27,15 @@ describe("query limits", () => {
 
   it("does not build empty reply filters", () => {
     expect(buildReplyFilter([], 123)).toBeNull();
+    expect(buildThreadReplyFilter([])).toBeNull();
+  });
+
+  it("builds thread reply filters without age bounds", () => {
+    expect(buildThreadReplyFilter(["1".repeat(64)])).toEqual({
+      "#e": ["1".repeat(64)],
+      kinds: [1],
+      limit: REPLY_QUERY_LIMIT,
+    });
   });
 
   it("clamps reply depth and computes age windows", () => {

--- a/src/nostr/subscriptions/query-limits.test.ts
+++ b/src/nostr/subscriptions/query-limits.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReplyFilter,
+  clampReplyDepth,
+  MAX_REPLY_FETCH_DEPTH,
+  MAX_REPLY_PARENT_IDS,
+  profileQueryLimit,
+  PROFILE_QUERY_LIMIT,
+  REPLY_QUERY_LIMIT,
+  sinceFromAgeHours,
+} from "./query-limits";
+
+describe("query limits", () => {
+  it("builds bounded reply filters", () => {
+    const parentIds = Array.from({ length: MAX_REPLY_PARENT_IDS + 1 }, (_, index) =>
+      String(index).padStart(64, "0"),
+    );
+
+    expect(buildReplyFilter(parentIds, 123)).toEqual({
+      "#e": parentIds.slice(0, MAX_REPLY_PARENT_IDS),
+      kinds: [1],
+      since: 123,
+      limit: REPLY_QUERY_LIMIT,
+    });
+  });
+
+  it("does not build empty reply filters", () => {
+    expect(buildReplyFilter([], 123)).toBeNull();
+  });
+
+  it("clamps reply depth and computes age windows", () => {
+    expect(clampReplyDepth(MAX_REPLY_FETCH_DEPTH + 10)).toBe(MAX_REPLY_FETCH_DEPTH);
+    expect(clampReplyDepth(-1)).toBe(0);
+    expect(sinceFromAgeHours(24, 100_000)).toBe(13_600);
+  });
+
+  it("caps profile query limits", () => {
+    expect(profileQueryLimit(10)).toBe(10);
+    expect(profileQueryLimit(PROFILE_QUERY_LIMIT + 1)).toBe(PROFILE_QUERY_LIMIT);
+  });
+});

--- a/src/nostr/subscriptions/query-limits.ts
+++ b/src/nostr/subscriptions/query-limits.ts
@@ -36,6 +36,17 @@ export function buildReplyFilter(
   };
 }
 
+export function buildThreadReplyFilter(parentIds: readonly string[]): Filter | null {
+  const limitedParentIds = limitReplyParentIds(parentIds);
+  if (limitedParentIds.length === 0) return null;
+
+  return {
+    "#e": limitedParentIds,
+    kinds: [1],
+    limit: REPLY_QUERY_LIMIT,
+  };
+}
+
 export function profileQueryLimit(pubkeyCount: number): number {
   return Math.min(pubkeyCount, PROFILE_QUERY_LIMIT);
 }

--- a/src/nostr/subscriptions/query-limits.ts
+++ b/src/nostr/subscriptions/query-limits.ts
@@ -1,0 +1,41 @@
+import type { Filter } from "nostr-tools";
+
+export const DEFAULT_THREAD_AGE_HOURS = 24;
+export const MAX_REPLY_FETCH_DEPTH = 2;
+export const MAX_REPLY_PARENT_IDS = 50;
+export const REPLY_QUERY_LIMIT = 100;
+export const PROFILE_QUERY_LIMIT = 250;
+
+export function sinceFromAgeHours(
+  ageHours: number,
+  now = Math.floor(Date.now() / 1000),
+): number {
+  return now - ageHours * 60 * 60;
+}
+
+export function clampReplyDepth(depth: number): number {
+  return Math.max(0, Math.min(depth, MAX_REPLY_FETCH_DEPTH));
+}
+
+export function limitReplyParentIds(parentIds: readonly string[]): string[] {
+  return parentIds.slice(0, MAX_REPLY_PARENT_IDS);
+}
+
+export function buildReplyFilter(
+  parentIds: readonly string[],
+  since: number,
+): Filter | null {
+  const limitedParentIds = limitReplyParentIds(parentIds);
+  if (limitedParentIds.length === 0) return null;
+
+  return {
+    "#e": limitedParentIds,
+    kinds: [1],
+    since,
+    limit: REPLY_QUERY_LIMIT,
+  };
+}
+
+export function profileQueryLimit(pubkeyCount: number): number {
+  return Math.min(pubkeyCount, PROFILE_QUERY_LIMIT);
+}

--- a/src/nostr/subscriptions/thread.test.ts
+++ b/src/nostr/subscriptions/thread.test.ts
@@ -35,7 +35,7 @@ describe("subNote", () => {
       "#e": ["1".repeat(64)],
       kinds: [1],
       limit: REPLY_QUERY_LIMIT,
-      since: expect.any(Number),
     });
+    expect(replyRequest.filter.since).toBeUndefined();
   });
 });

--- a/src/nostr/subscriptions/thread.test.ts
+++ b/src/nostr/subscriptions/thread.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { THREAD_RELAYS } from "../../config";
+import { REPLY_QUERY_LIMIT } from "./query-limits";
 
 const subscribeMock = vi.fn();
 
@@ -33,6 +34,8 @@ describe("subNote", () => {
     expect(replyRequest.filter).toMatchObject({
       "#e": ["1".repeat(64)],
       kinds: [1],
+      limit: REPLY_QUERY_LIMIT,
+      since: expect.any(Number),
     });
   });
 });

--- a/src/nostr/subscriptions/thread.ts
+++ b/src/nostr/subscriptions/thread.ts
@@ -1,25 +1,16 @@
 import { getRegistry, THREAD_RELAYS } from "../client";
 import type { SubCallback, SubHandle } from "../types";
 import { composeSubHandle } from "./utils";
-import {
-  buildReplyFilter,
-  DEFAULT_THREAD_AGE_HOURS,
-  sinceFromAgeHours,
-} from "./query-limits";
+import { buildThreadReplyFilter } from "./query-limits";
 
-export const subNote = (
-  eventId: string,
-  onEvent: SubCallback,
-  ageHours = DEFAULT_THREAD_AGE_HOURS,
-): SubHandle => {
+export const subNote = (eventId: string, onEvent: SubCallback): SubHandle => {
   const registry = getRegistry();
   const children: SubHandle[] = [];
   let replyHandle: SubHandle | null = null;
   const replies = new Set<string>([eventId]);
-  const since = sinceFromAgeHours(ageHours);
 
   const refreshReplySubscription = () => {
-    const filter = buildReplyFilter(Array.from(replies), since);
+    const filter = buildThreadReplyFilter(Array.from(replies));
     if (!filter) return;
 
     replyHandle?.close();

--- a/src/nostr/subscriptions/thread.ts
+++ b/src/nostr/subscriptions/thread.ts
@@ -1,21 +1,31 @@
 import { getRegistry, THREAD_RELAYS } from "../client";
 import type { SubCallback, SubHandle } from "../types";
 import { composeSubHandle } from "./utils";
+import {
+  buildReplyFilter,
+  DEFAULT_THREAD_AGE_HOURS,
+  sinceFromAgeHours,
+} from "./query-limits";
 
-export const subNote = (eventId: string, onEvent: SubCallback): SubHandle => {
+export const subNote = (
+  eventId: string,
+  onEvent: SubCallback,
+  ageHours = DEFAULT_THREAD_AGE_HOURS,
+): SubHandle => {
   const registry = getRegistry();
   const children: SubHandle[] = [];
   let replyHandle: SubHandle | null = null;
   const replies = new Set<string>([eventId]);
+  const since = sinceFromAgeHours(ageHours);
 
   const refreshReplySubscription = () => {
+    const filter = buildReplyFilter(Array.from(replies), since);
+    if (!filter) return;
+
     replyHandle?.close();
     replyHandle = registry.subscribe([
       {
-        filter: {
-          "#e": Array.from(replies),
-          kinds: [1],
-        },
+        filter,
         relayUrls: THREAD_RELAYS,
         cb: (evt, relay) => {
           const isNew = !replies.has(evt.id);


### PR DESCRIPTION
## Summary
- add shared relay query guardrails for reply depth, parent id count, reply limits, and profile limits
- apply reply since/limit bounds to feed, thread, and snapshot relay queries
- pass the configured thread age into thread reply subscriptions
- add tests covering bounded reply filters, depth clamping, and parent-id caps

## Verification
- npm test
- npm run typecheck
- npm run lint (passes with existing warnings)
- npm run build
- live vite-node relay smoke: reply REQs include since + limit 100, max #e count 50, requested depth 3 clamps to 2