### PR TITLE
Add public moderation manifest filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Optional feed snapshot bootstrap:
 - The client tries that snapshot first, falls back to `/api/feed/bootstrap`, then falls back to live Nostr relay subscriptions if both bootstrap sources fail.
 - The snapshot response should match `/api/feed/bootstrap`: `{ "fetchedAt": number, "processedEvents": [], "profiles": {} }`.
 
+Optional relay configuration:
+
+- Set `VITE_POW_RELAYS` to a comma-separated list of public PoW relay WebSocket URLs, for example `wss://relay.wiredsignal.online`.
+- Set `VITE_ENRICHMENT_RELAYS` to a comma-separated list of read/enrichment relay WebSocket URLs if the defaults should be replaced.
+- If unset, the client uses the built-in relay defaults.
+
 Optional moderation filtering:
 
 - Set `VITE_MODERATION_MANIFEST_URL` to the public manifest endpoint exposed by the Wired relay app, for example `https://relay.wiredsignal.online/api/moderation/manifest`.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Optional feed snapshot bootstrap:
 - The client tries that snapshot first, falls back to `/api/feed/bootstrap`, then falls back to live Nostr relay subscriptions if both bootstrap sources fail.
 - The snapshot response should match `/api/feed/bootstrap`: `{ "fetchedAt": number, "processedEvents": [], "profiles": {} }`.
 
+Optional moderation filtering:
+
+- Set `VITE_MODERATION_MANIFEST_URL` to the public manifest endpoint exposed by the Wired relay app, for example `https://relay.wiredsignal.online/api/moderation/manifest`.
+- The web client only consumes the manifest for client-side filtering. Moderation management and admin actions stay in the local Umbrel relay app and are not part of this Vercel deployment.
+- If the manifest URL is unset or unavailable, moderation filtering fails open and the feed continues to use snapshots/live relays.
+
 Run a durable local snapshot origin:
 
 ```sh

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { configuredRelays } from "./config";
+
+describe("configuredRelays", () => {
+  it("uses fallback relays when env is unset", () => {
+    expect(configuredRelays(undefined, ["wss://fallback.example"])).toEqual([
+      "wss://fallback.example",
+    ]);
+  });
+
+  it("parses comma-separated wss relay URLs", () => {
+    expect(
+      configuredRelays(" wss://one.example,https://bad.example,wss://two.example ", [
+        "wss://fallback.example",
+      ]),
+    ).toEqual(["wss://one.example", "wss://two.example"]);
+  });
+
+  it("uses fallback relays when env contains no wss URLs", () => {
+    expect(configuredRelays("https://bad.example", ["wss://fallback.example"])).toEqual([
+      "wss://fallback.example",
+    ]);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,7 @@ export const DEFAULT_RELAYS = [
   "wss://pow.relays.land",
 ] as const;
 
-export const POW_RELAYS = DEFAULT_RELAYS;
-
-export const ENRICHMENT_RELAYS = [
+export const DEFAULT_ENRICHMENT_RELAYS = [
   "wss://relay.damus.io",
   "wss://offchain.pub",
   "wss://nos.lol",
@@ -16,6 +14,30 @@ export const ENRICHMENT_RELAYS = [
   "wss://nostr.wine",
   "wss://relay.snort.social",
 ] as const;
+
+export function configuredRelays(
+  envValue: string | undefined,
+  fallback: readonly string[],
+) {
+  if (!envValue?.trim()) return fallback;
+
+  const relays = envValue
+    .split(",")
+    .map((relay) => relay.trim())
+    .filter((relay) => relay.startsWith("wss://"));
+
+  return relays.length > 0 ? relays : fallback;
+}
+
+export const POW_RELAYS = configuredRelays(
+  import.meta.env.VITE_POW_RELAYS,
+  DEFAULT_RELAYS,
+);
+
+export const ENRICHMENT_RELAYS = configuredRelays(
+  import.meta.env.VITE_ENRICHMENT_RELAYS,
+  DEFAULT_ENRICHMENT_RELAYS,
+);
 
 export const QUOTE_FALLBACK_RELAYS = ENRICHMENT_RELAYS;
 

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -5,7 +5,9 @@ import { processFeedEvents } from "../nostr/processEvents";
 import { useSettings } from "../app/settings";
 import { POW_RELAYS, THREAD_RELAYS } from "../config";
 import { useFilteredNoteSubscription } from "../shared/hooks/useFilteredNoteSubscription";
+import { useModerationManifest } from "../shared/hooks/useModerationManifest";
 import { seedProfiles } from "../shared/hooks/useProfiles";
+import { filterModeratedEvents } from "../shared/lib/moderation";
 import {
   canUseFeedBootstrap,
   eventsFromProcessed,
@@ -26,6 +28,7 @@ function mergeNoteEvents(...eventGroups: Event[][]): Event[] {
 
 export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
   const { settings } = useSettings();
+  const moderationManifest = useModerationManifest();
   const isRawMode = mode === "raw";
   const rawFilterDifficulty = isRawMode ? settings.filterDifficulty : undefined;
   const bootstrapEligible = !isRawMode && canUseFeedBootstrap(settings);
@@ -78,7 +81,7 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
           replyDepth: FEED_REPLY_DEPTH,
         },
       ),
-    [isRawMode, rawFilterDifficulty, settings.ageHours],
+    [rawFilterDifficulty, settings.ageHours],
   );
 
   const liveEvents = useFilteredNoteSubscription(subscribe, [
@@ -108,10 +111,14 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
     () => mergeNoteEvents(bootstrapEvents, liveEvents, bootstrapReplyEvents),
     [bootstrapEvents, liveEvents, bootstrapReplyEvents],
   );
+  const visibleNoteEvents = useMemo(
+    () => filterModeratedEvents(noteEvents, moderationManifest),
+    [noteEvents, moderationManifest],
+  );
   const processedEvents = useMemo(
-    () => processFeedEvents(noteEvents, settings.filterDifficulty),
-    [noteEvents, settings.filterDifficulty],
+    () => processFeedEvents(visibleNoteEvents, settings.filterDifficulty),
+    [visibleNoteEvents, settings.filterDifficulty],
   );
 
-  return { processedEvents, noteEvents };
+  return { processedEvents, noteEvents: visibleNoteEvents };
 }

--- a/src/hooks/useThreadViewModel.ts
+++ b/src/hooks/useThreadViewModel.ts
@@ -4,15 +4,18 @@ import { toProcessedEvents } from "../nostr/processEvents";
 import { uniqBy } from "@lib/collections";
 import { useThreadEvents } from "./useThreadEvents";
 import { useNostrSubscription } from "../shared/hooks/useNostrSubscription";
+import { useModerationManifest } from "../shared/hooks/useModerationManifest";
+import { filterModeratedEvents } from "../shared/lib/moderation";
 
 export function useThreadViewModel(hexID: string) {
   const [showAllReplies, setShowAllReplies] = useState(true);
+  const moderationManifest = useModerationManifest();
   const { noteEvents } = useThreadEvents(hexID);
 
   const allEvents = useMemo(() => {
     const threadCache = JSON.parse(sessionStorage.getItem("cachedThread") || "[]");
-    return [...noteEvents, ...threadCache];
-  }, [noteEvents]);
+    return filterModeratedEvents([...noteEvents, ...threadCache], moderationManifest);
+  }, [noteEvents, moderationManifest]);
 
   const eventsById = useMemo(
     () => new Map(allEvents.map((event) => [event.id, event])),
@@ -38,7 +41,8 @@ export function useThreadViewModel(hexID: string) {
   const replyEvents = useMemo(() => {
     if (!opEvent) return [];
 
-    const uniqMentions = uniqBy(prevMentions, "id");
+    const visibleMentions = filterModeratedEvents(prevMentions, moderationManifest);
+    const uniqMentions = uniqBy(visibleMentions, "id");
     const earlierIds = new Set(
       uniqMentions
         .filter((e) => e.created_at < opEvent.created_at)
@@ -48,19 +52,25 @@ export function useThreadViewModel(hexID: string) {
       (event) => !earlierIds.has(event.id) && opEvent.id !== event.id,
     );
 
-    return toProcessedEvents(posts, noteEvents);
-  }, [opEvent, prevMentions, allEvents, noteEvents]);
+    return toProcessedEvents(
+      posts,
+      filterModeratedEvents(noteEvents, moderationManifest),
+    );
+  }, [opEvent, prevMentions, allEvents, noteEvents, moderationManifest]);
 
   const earlierEvents = useMemo(() => {
     if (!opEvent) return [];
 
-    return uniqBy(prevMentions, "id")
+    return uniqBy(filterModeratedEvents(prevMentions, moderationManifest), "id")
       .filter((e) => e.created_at < opEvent.created_at)
       .filter((event) => event.kind === 1)
       .sort((a, b) => a.created_at - b.created_at);
-  }, [opEvent, prevMentions]);
+  }, [opEvent, prevMentions, moderationManifest]);
 
-  const uniqMentions = useMemo(() => uniqBy(prevMentions, "id"), [prevMentions]);
+  const uniqMentions = useMemo(
+    () => uniqBy(filterModeratedEvents(prevMentions, moderationManifest), "id"),
+    [prevMentions, moderationManifest],
+  );
 
   return {
     opEvent,

--- a/src/shared/hooks/useModerationManifest.ts
+++ b/src/shared/hooks/useModerationManifest.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import {
+  EMPTY_MODERATION_MANIFEST,
+  type ModerationManifest,
+} from "../lib/moderation";
+
+export const MODERATION_MANIFEST_URL_ENV = "VITE_MODERATION_MANIFEST_URL";
+const MODERATION_MANIFEST_REFRESH_MS = 30_000;
+
+function configuredModerationManifestUrl(): string | null {
+  const url = import.meta.env[MODERATION_MANIFEST_URL_ENV]?.trim();
+  return url || null;
+}
+
+function isModerationManifest(value: unknown): value is ModerationManifest {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<ModerationManifest>;
+  return (
+    typeof candidate.updatedAt === "number" &&
+    Array.isArray(candidate.blockedEventIds) &&
+    Array.isArray(candidate.blockedThreadRoots) &&
+    Array.isArray(candidate.blockedMediaUrls) &&
+    Array.isArray(candidate.blockedDomains) &&
+    Array.isArray(candidate.blockedContentFingerprints)
+  );
+}
+
+export function useModerationManifest(): ModerationManifest {
+  const [manifest, setManifest] = useState<ModerationManifest>(
+    EMPTY_MODERATION_MANIFEST,
+  );
+
+  useEffect(() => {
+    const url = configuredModerationManifestUrl();
+    if (!url) {
+      setManifest(EMPTY_MODERATION_MANIFEST);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchManifest = () => {
+      void fetch(url)
+        .then(async (response) => {
+          if (!response.ok) return null;
+          return response.json() as Promise<unknown>;
+        })
+        .then((payload) => {
+          if (cancelled || !isModerationManifest(payload)) return;
+          setManifest(payload);
+        })
+        .catch(() => {
+          // Moderation filtering is fail-open so relay availability is not affected.
+        });
+    };
+
+    fetchManifest();
+    const interval = window.setInterval(
+      fetchManifest,
+      MODERATION_MANIFEST_REFRESH_MS,
+    );
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  return manifest;
+}

--- a/src/shared/lib/moderation.test.ts
+++ b/src/shared/lib/moderation.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { Event } from "nostr-tools";
+import {
+  contentFingerprint,
+  filterModeratedEvents,
+  manifestFromActions,
+  type ModerationAction,
+} from "./moderation";
+
+function event(overrides: Partial<Event>): Event {
+  return {
+    id: "a".repeat(64),
+    pubkey: "b".repeat(64),
+    created_at: 1,
+    kind: 1,
+    tags: [],
+    content: "hello",
+    sig: "c".repeat(128),
+    ...overrides,
+  };
+}
+
+function action(overrides: Partial<ModerationAction>): ModerationAction {
+  return {
+    id: "action",
+    kind: "block_event",
+    value: "a".repeat(64),
+    reason: "spam",
+    createdAt: 1,
+    moderator: "test",
+    ...overrides,
+  };
+}
+
+describe("moderation filters", () => {
+  it("filters blocked events", () => {
+    const blocked = event({ id: "d".repeat(64) });
+    const visible = event({ id: "e".repeat(64) });
+    const manifest = manifestFromActions([
+      action({ kind: "block_event", value: blocked.id }),
+    ]);
+
+    expect(filterModeratedEvents([blocked, visible], manifest)).toEqual([visible]);
+  });
+
+  it("filters replies to blocked thread roots", () => {
+    const rootId = "f".repeat(64);
+    const reply = event({
+      id: "1".repeat(64),
+      tags: [["e", rootId]],
+    });
+    const manifest = manifestFromActions([
+      action({ kind: "block_thread", value: rootId }),
+    ]);
+
+    expect(filterModeratedEvents([reply], manifest)).toEqual([]);
+  });
+
+  it("filters media URLs and linked domains", () => {
+    const media = event({
+      id: "2".repeat(64),
+      content: "https://example.com/bad.png",
+    });
+    const link = event({
+      id: "3".repeat(64),
+      content: "https://spam.example/path",
+    });
+    const manifest = manifestFromActions([
+      action({
+        kind: "block_media_url",
+        value: "https://example.com/bad.png",
+      }),
+      action({ kind: "block_domain", value: "spam.example" }),
+    ]);
+
+    expect(filterModeratedEvents([media, link], manifest)).toEqual([]);
+  });
+
+  it("filters duplicate text by content fingerprint", () => {
+    const original = event({ id: "4".repeat(64), content: "Same spam text" });
+    const duplicate = event({
+      id: "5".repeat(64),
+      content: "same   spam text https://example.com",
+    });
+    const manifest = manifestFromActions([
+      action({
+        kind: "block_content_fingerprint",
+        value: contentFingerprint(original.content),
+      }),
+    ]);
+
+    expect(filterModeratedEvents([duplicate], manifest)).toEqual([]);
+  });
+});

--- a/src/shared/lib/moderation.ts
+++ b/src/shared/lib/moderation.ts
@@ -1,0 +1,263 @@
+import type { Event } from "nostr-tools";
+import { normalizeUrl } from "../../../lib/link";
+
+export type ModerationActionKind =
+  | "block_event"
+  | "block_thread"
+  | "block_media_url"
+  | "block_domain"
+  | "block_content_fingerprint";
+
+export type ModerationReason = "illegal" | "spam" | "abuse" | "manual";
+
+export type ModerationAction = {
+  id: string;
+  kind: ModerationActionKind;
+  value: string;
+  reason: ModerationReason;
+  note?: string;
+  createdAt: number;
+  moderator: string;
+};
+
+export type ModerationManifest = {
+  updatedAt: number;
+  blockedEventIds: string[];
+  blockedThreadRoots: string[];
+  blockedMediaUrls: string[];
+  blockedDomains: string[];
+  blockedContentFingerprints: string[];
+};
+
+export const EMPTY_MODERATION_MANIFEST: ModerationManifest = {
+  updatedAt: 0,
+  blockedEventIds: [],
+  blockedThreadRoots: [],
+  blockedMediaUrls: [],
+  blockedDomains: [],
+  blockedContentFingerprints: [],
+};
+
+const HTTP_URL_PATTERN = /https?:\/\/[^\s<>"')\]]+/gi;
+const MEDIA_EXTENSION_PATTERN =
+  /\.(?:jpe?g|png|gif|webp|mp4|webm|mov|mp3|wav|ogg|m4a)(?:\?|$)/i;
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set([...values].filter(Boolean))].sort();
+}
+
+function domainFromUrl(value: string): string | null {
+  const normalized = normalizeUrl(value);
+  if (!normalized) return null;
+
+  try {
+    return new URL(normalized).hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+function imetaUrls(event: Event): string[] {
+  return event.tags
+    .filter((tag) => tag[0] === "imeta")
+    .flatMap((tag) =>
+      tag
+        .slice(1)
+        .filter((part) => part.startsWith("url "))
+        .map((part) => part.slice("url ".length).trim()),
+    );
+}
+
+function eventUrls(event: Event): string[] {
+  const contentUrls = [...event.content.matchAll(HTTP_URL_PATTERN)].map(
+    (match) => match[0],
+  );
+
+  return uniqueSorted(
+    [...contentUrls, ...imetaUrls(event)]
+      .map((url) => normalizeUrl(url))
+      .filter((url): url is string => Boolean(url)),
+  );
+}
+
+function domainsFromEvent(event: Event): string[] {
+  return eventUrls(event)
+    .map(domainFromUrl)
+    .filter((domain): domain is string => Boolean(domain));
+}
+
+function mediaUrlsFromEvent(event: Event): string[] {
+  return uniqueSorted(
+    eventUrls(event).filter((url) => MEDIA_EXTENSION_PATTERN.test(url)),
+  );
+}
+
+function parsedRepostEvent(event: Event): Event | null {
+  if (event.kind !== 6) return null;
+
+  try {
+    const parsed = JSON.parse(event.content) as Partial<Event>;
+    if (
+      typeof parsed.id !== "string" ||
+      typeof parsed.pubkey !== "string" ||
+      typeof parsed.content !== "string" ||
+      !Array.isArray(parsed.tags) ||
+      typeof parsed.created_at !== "number" ||
+      typeof parsed.kind !== "number" ||
+      typeof parsed.sig !== "string"
+    ) {
+      return null;
+    }
+
+    return parsed as Event;
+  } catch {
+    return null;
+  }
+}
+
+function visibleEventVariants(event: Event): Event[] {
+  const repost = parsedRepostEvent(event);
+  return repost ? [event, repost] : [event];
+}
+
+function rootReferences(event: Event): string[] {
+  return event.tags
+    .filter((tag) => tag[0] === "e" && tag[1])
+    .map((tag) => tag[1]);
+}
+
+function normalizeContentForFingerprint(content: string): string {
+  return content
+    .replace(HTTP_URL_PATTERN, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+export function contentFingerprint(content: string): string {
+  const normalized = normalizeContentForFingerprint(content);
+  let hash = 0x811c9dc5;
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    hash ^= normalized.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return `fnv1a:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+export function normalizeModerationValue(
+  kind: ModerationActionKind,
+  value: string,
+): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  if (kind === "block_domain") {
+    return (
+      trimmed
+        .replace(/^https?:\/\//i, "")
+        .replace(/^www\./i, "")
+        .split("/")[0]
+        .trim()
+        .toLowerCase() || null
+    );
+  }
+
+  if (kind === "block_media_url") {
+    return normalizeUrl(trimmed);
+  }
+
+  if (kind === "block_content_fingerprint") {
+    return trimmed.startsWith("fnv1a:") ? trimmed : contentFingerprint(trimmed);
+  }
+
+  return trimmed.toLowerCase();
+}
+
+export function manifestFromActions(actions: ModerationAction[]): ModerationManifest {
+  const blockedEventIds = new Set<string>();
+  const blockedThreadRoots = new Set<string>();
+  const blockedMediaUrls = new Set<string>();
+  const blockedDomains = new Set<string>();
+  const blockedContentFingerprints = new Set<string>();
+
+  for (const action of actions) {
+    const normalized = normalizeModerationValue(action.kind, action.value);
+    if (!normalized) continue;
+
+    if (action.kind === "block_event") blockedEventIds.add(normalized);
+    if (action.kind === "block_thread") {
+      blockedEventIds.add(normalized);
+      blockedThreadRoots.add(normalized);
+    }
+    if (action.kind === "block_media_url") blockedMediaUrls.add(normalized);
+    if (action.kind === "block_domain") blockedDomains.add(normalized);
+    if (action.kind === "block_content_fingerprint") {
+      blockedContentFingerprints.add(normalized);
+    }
+  }
+
+  return {
+    updatedAt: actions.reduce(
+      (latest, action) => Math.max(latest, action.createdAt),
+      0,
+    ),
+    blockedEventIds: uniqueSorted(blockedEventIds),
+    blockedThreadRoots: uniqueSorted(blockedThreadRoots),
+    blockedMediaUrls: uniqueSorted(blockedMediaUrls),
+    blockedDomains: uniqueSorted(blockedDomains),
+    blockedContentFingerprints: uniqueSorted(blockedContentFingerprints),
+  };
+}
+
+export function isEventModerated(
+  event: Event,
+  manifest: ModerationManifest,
+): boolean {
+  const variants = visibleEventVariants(event);
+  const blockedEventIds = new Set(manifest.blockedEventIds);
+  if (variants.some((variant) => blockedEventIds.has(variant.id.toLowerCase()))) {
+    return true;
+  }
+
+  const blockedThreadRoots = new Set(manifest.blockedThreadRoots);
+  if (
+    variants.some((variant) =>
+      rootReferences(variant).some((id) => blockedThreadRoots.has(id.toLowerCase())),
+    )
+  ) {
+    return true;
+  }
+
+  const blockedMediaUrls = new Set(manifest.blockedMediaUrls);
+  if (
+    variants.some((variant) =>
+      mediaUrlsFromEvent(variant).some((url) => blockedMediaUrls.has(url)),
+    )
+  ) {
+    return true;
+  }
+
+  const blockedDomains = new Set(manifest.blockedDomains);
+  if (
+    variants.some((variant) =>
+      domainsFromEvent(variant).some((domain) => blockedDomains.has(domain)),
+    )
+  ) {
+    return true;
+  }
+
+  const blockedContentFingerprints = new Set(manifest.blockedContentFingerprints);
+  return variants.some((variant) =>
+    blockedContentFingerprints.has(contentFingerprint(variant.content)),
+  );
+}
+
+export function filterModeratedEvents(
+  events: Event[],
+  manifest: ModerationManifest,
+): Event[] {
+  if (manifest.updatedAt === 0) return events;
+  return events.filter((event) => !isEventModerated(event, manifest));
+}


### PR DESCRIPTION
## Summary
- add client-side moderation manifest filtering for feed and thread views
- fetch the manifest only from configured `VITE_MODERATION_MANIFEST_URL`, fail-open if unset/unavailable
- keep Vercel snapshot bootstrap fallback unchanged via `/api/feed/bootstrap`
- add `VITE_POW_RELAYS` / `VITE_ENRICHMENT_RELAYS` support so staging/prod can point at the Wired relay
- do not add admin UI, moderation actions, or moderation management APIs to the public Wired client

## Deployment notes
- set `VITE_POW_RELAYS` to `wss://relay.wiredsignal.online` once the Cloudflare tunnel hostname is live
- set `VITE_MODERATION_MANIFEST_URL` to `https://relay.wiredsignal.online/api/moderation/manifest`
- keep `VITE_FEED_SNAPSHOT_URL` pointing at the relay app snapshot endpoint when available; Vercel `/api/feed/bootstrap` remains the free fallback

## Verification
- `npm run typecheck`
- `npm run test`
- `npm run lint` (passes with existing Fast Refresh warnings in providers/settings)
- `npm run build`