### PR TITLE
Fix PostCard metadata layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/functions": "^3.7.1",
     "@vercel/speed-insights": "^2.0.0",
+    "lucide-react": "^1.22.0",
     "nostr-tools": "2.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/shared/ui/MetadataRow.tsx
+++ b/src/shared/ui/MetadataRow.tsx
@@ -1,63 +1,27 @@
-import { getDisplayName } from "@lib/profile";
-import { useProfile } from "../hooks/useProfiles";
+import type { MouseEvent } from "react";
+import { Activity, Network } from "lucide-react";
 import { Button } from "./Button";
-import { SignalAvatar } from "./SignalAvatar";
 
 type MetadataRowProps = {
-  pubkey: string;
   signal: number;
   replyCount: number;
   timestamp: string;
   onOpenThread?: () => void;
   forceSecondary?: boolean;
-  avatarPriority?: boolean;
 };
 
-function formatTelemetry({
-  authorLabel,
-  signal,
-  replyCount,
-  timestamp,
-}: {
-  authorLabel: string;
-  signal: number;
-  replyCount: number;
-  timestamp: string;
-}) {
-  const parts: string[] = [authorLabel];
-
-  if (signal > 0) {
-    parts.push(`signal ${signal}`);
-  }
-
-  const replyLabel = `${replyCount} ${replyCount === 1 ? "reply" : "replies"}`;
-  parts.push(replyLabel);
-
-  parts.push(timestamp);
-
-  return parts.join(" · ");
+function getReplyLabel(replyCount: number) {
+  return `${replyCount} ${replyCount === 1 ? "reply" : "replies"}`;
 }
 
 export function MetadataRow({
-  pubkey,
   signal,
   replyCount,
   timestamp,
   onOpenThread,
   forceSecondary = false,
-  avatarPriority = false,
 }: MetadataRowProps) {
-  const profile = useProfile(pubkey);
-  const authorLabel = getDisplayName(profile, pubkey);
-
-  const telemetry = formatTelemetry({
-    authorLabel,
-    signal,
-    replyCount,
-    timestamp,
-  });
-
-  const handleRowClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleRowClick = (event: MouseEvent<HTMLDivElement>) => {
     if (!onOpenThread) return;
     if (event.target === event.currentTarget) {
       onOpenThread();
@@ -67,7 +31,7 @@ export function MetadataRow({
   return (
     <div
       className={[
-        "metadata-row flex items-center gap-2 pt-3 text-meta",
+        "metadata-row flex items-center justify-between gap-3 pt-3 text-meta",
         forceSecondary ? "metadata-row--secondary" : "",
         onOpenThread ? "cursor-pointer" : "",
       ]
@@ -75,14 +39,23 @@ export function MetadataRow({
         .join(" ")}
       onClick={handleRowClick}
     >
-      <SignalAvatar
-        pubkey={pubkey}
-        pictureUrl={profile?.picture}
-        label={`author ${authorLabel}`}
-        size="sm"
-        priority={avatarPriority}
-      />
-      <span className="flex-1 min-w-0 truncate">{telemetry}</span>
+      <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
+        <span
+          className="inline-flex items-center gap-1 whitespace-nowrap text-signal drop-shadow-[0_0_6px_var(--signal-dim)]"
+          aria-label={`signal ${signal}`}
+        >
+          <Activity aria-hidden="true" className="h-3.5 w-3.5" strokeWidth={1.8} />
+          <span aria-hidden="true">{signal}</span>
+        </span>
+        <span
+          className="inline-flex items-center gap-1 whitespace-nowrap"
+          aria-label={getReplyLabel(replyCount)}
+        >
+          <Network aria-hidden="true" className="h-3.5 w-3.5" strokeWidth={1.8} />
+          <span aria-hidden="true">{replyCount}</span>
+        </span>
+        <span className="whitespace-nowrap">{timestamp}</span>
+      </div>
       {onOpenThread && (
         <Button
           type="button"
@@ -90,6 +63,7 @@ export function MetadataRow({
           size="sm"
           onClick={onOpenThread}
           aria-label="open thread"
+          className="shrink-0"
         >
           open
         </Button>

--- a/src/shared/ui/PostCard.tsx
+++ b/src/shared/ui/PostCard.tsx
@@ -6,6 +6,8 @@ import { getDisplayName } from "@lib/profile";
 import { TextContent } from "./TextContent";
 import { MetadataRow } from "./MetadataRow";
 import { ReplyContext } from "./ReplyContext";
+import { SignalAvatar } from "./SignalAvatar";
+import { useProfile } from "../hooks/useProfiles";
 import { useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -53,7 +55,8 @@ export function PostCard({
   const navigate = useNavigate();
 
   const relatedEvents = useMemo(() => [event, ...(replies || [])], [event, replies]);
-  const authorLabel = getDisplayName(undefined, event.pubkey);
+  const profile = useProfile(event.pubkey);
+  const authorLabel = getDisplayName(profile, event.pubkey);
 
   const signal = totalWork ? Math.floor(Math.log2(totalWork)) : verifyPow(event);
   const displayedReplyCount = replyCount ?? replies.length;
@@ -82,6 +85,17 @@ export function PostCard({
         .join(" ")}
       style={animate ? { animationDelay: `${animationIndex * 40}ms` } : undefined}
     >
+      <header className="mb-2 flex min-w-0 items-center gap-2 text-meta text-secondary">
+        <SignalAvatar
+          pubkey={event.pubkey}
+          pictureUrl={profile?.picture}
+          label={`author ${authorLabel}`}
+          size="sm"
+          priority={avatarPriority}
+        />
+        <span className="min-w-0 truncate">{authorLabel}</span>
+      </header>
+
       <div className="post-content flex flex-col gap-2 break-words">
         <TextContent eventdata={event} imagePriority={imagePriority} />
         {repliedTo && repliedTo.length > 0 && (
@@ -90,13 +104,11 @@ export function PostCard({
       </div>
 
       <MetadataRow
-        pubkey={event.pubkey}
         signal={signal}
         replyCount={displayedReplyCount}
         timestamp={timestamp}
         onOpenThread={isNavigable ? handleNavigate : undefined}
         forceSecondary={role === "threadOp"}
-        avatarPriority={avatarPriority}
       />
     </article>
   );


### PR DESCRIPTION
Closes #33

## Root cause
PostCard rendered the post body before author identity, and MetadataRow compressed author, signal, replies, age, and the open action into one footer row. That made the card hierarchy hard to scan and prevented left-aligned compact stats.

## Changes
- Move avatar and display name into a top PostCard header.
- Keep signal, replies, and age as compact left-aligned footer stats.
- Keep the open action on the right and hidden for thread OP cards.
- Replace visible signal/reply words with compact visual marks plus accessible labels.

## Verification
- npm run typecheck
- npm run lint (passes with existing Fast Refresh warnings in providers/settings)
- npm test
- npm run build

Note: bun is not installed in this environment, so npm was used for equivalent scripts.