### PR TITLE
Stabilize video media previews

### DIFF
--- a/src/shared/lib/mediaUtils.test.ts
+++ b/src/shared/lib/mediaUtils.test.ts
@@ -41,6 +41,44 @@ describe("parseImetaTags", () => {
     ]);
   });
 
+  it("parses video poster images from imeta tags", () => {
+    const tags = [
+      [
+        "imeta",
+        "url https://example.com/clip.mp4",
+        "m video/mp4",
+        "dim 1280x720",
+        "image https://example.com/poster.jpg",
+      ],
+    ];
+
+    expect(parseImetaTags(tags)).toEqual([
+      {
+        url: "https://example.com/clip.mp4",
+        type: "video",
+        mime: "video/mp4",
+        width: 1280,
+        height: 720,
+        posterUrl: "https://example.com/poster.jpg",
+      },
+    ]);
+  });
+
+  it("rejects non-http poster images", () => {
+    const tags = [
+      [
+        "imeta",
+        "url https://example.com/clip.mp4",
+        "m video/mp4",
+        "image javascript:alert(1)",
+      ],
+    ];
+
+    expect(parseImetaTags(tags)).toEqual([
+      { url: "https://example.com/clip.mp4", type: "video", mime: "video/mp4" },
+    ]);
+  });
+
   it("rejects non-http schemes", () => {
     const tags = [["imeta", "url javascript:alert(1)", "m image/png"]];
     expect(parseImetaTags(tags)).toEqual([]);

--- a/src/shared/lib/mediaUtils.ts
+++ b/src/shared/lib/mediaUtils.ts
@@ -10,6 +10,7 @@ export type MediaItem = {
   mime?: string;
   width?: number;
   height?: number;
+  posterUrl?: string;
 };
 
 const MEDIA_URL_PATTERN =
@@ -64,6 +65,7 @@ function parseImetaFields(tag: string[]): {
   mime?: string;
   width?: number;
   height?: number;
+  posterUrl?: string;
 } {
   const fields: Record<string, string> = {};
 
@@ -81,6 +83,7 @@ function parseImetaFields(tag: string[]): {
     mime: fields.m,
     width: dim ? Number(dim[1]) : undefined,
     height: dim ? Number(dim[2]) : undefined,
+    posterUrl: fields.image ?? fields.thumb,
   };
 }
 
@@ -90,7 +93,7 @@ export function parseImetaTags(tags: string[][]): MediaItem[] {
   for (const tag of tags) {
     if (tag[0] !== "imeta") continue;
 
-    const { url, mime, width, height } = parseImetaFields(tag);
+    const { url, mime, width, height, posterUrl } = parseImetaFields(tag);
     if (!url) continue;
 
     const normalized = normalizeUrl(url);
@@ -99,7 +102,15 @@ export function parseImetaTags(tags: string[][]): MediaItem[] {
     const type = resolveMediaType(normalized, mime);
     if (!type) continue;
 
-    items.push({ url: normalized, type, mime, width, height });
+    const normalizedPosterUrl = posterUrl ? normalizeUrl(posterUrl) : "";
+    items.push({
+      url: normalized,
+      type,
+      mime,
+      ...(width ? { width } : {}),
+      ...(height ? { height } : {}),
+      ...(normalizedPosterUrl ? { posterUrl: normalizedPosterUrl } : {}),
+    });
   }
 
   return items;

--- a/src/shared/ui/NoteMedia.tsx
+++ b/src/shared/ui/NoteMedia.tsx
@@ -135,20 +135,52 @@ function GridImage({
   );
 }
 
-function MediaVideo({ item }: { item: MediaItem }) {
+function MediaVideo({
+  item,
+  compact,
+}: {
+  item: MediaItem;
+  compact?: boolean;
+}) {
   const [failed, setFailed] = useState(false);
+  const [started, setStarted] = useState(false);
 
   if (failed) return <MediaFallback />;
 
+  const hasDimensions = Boolean(item.width && item.height);
+  const aspectRatio = hasDimensions ? `${item.width} / ${item.height}` : "16 / 9";
+
   return (
-    <video
-      src={item.url}
-      controls
-      preload="metadata"
-      playsInline
-      onError={() => setFailed(true)}
-      className="max-h-[32rem] w-full rounded border border-ghost"
-    />
+    <div
+      className={[
+        "relative overflow-hidden rounded border border-ghost bg-surface",
+        compact ? "max-h-[120px]" : "max-h-[min(60vh,24rem)]",
+      ].join(" ")}
+      style={{ aspectRatio }}
+    >
+      <video
+        src={item.url}
+        poster={item.posterUrl}
+        controls
+        preload="metadata"
+        playsInline
+        onPlay={() => setStarted(true)}
+        onLoadedData={() => setStarted(true)}
+        onError={() => setFailed(true)}
+        className="h-full w-full object-contain"
+      />
+      {!item.posterUrl && !started && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-surface text-meta text-muted">
+          <span
+            aria-hidden="true"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-ghost bg-void/60 text-primary"
+          >
+            <span className="ml-0.5 h-0 w-0 border-y-[7px] border-l-[11px] border-y-transparent border-l-current" />
+          </span>
+          <span className="sr-only">video preview</span>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -181,7 +213,7 @@ export function MediaAttachment({
     case "image":
       return <MediaImage item={item} compact={compact} priority={priority} />;
     case "video":
-      return <MediaVideo item={item} />;
+      return <MediaVideo item={item} compact={compact} />;
     case "audio":
       return <MediaAudio item={item} />;
   }


### PR DESCRIPTION
Closes #34

## Root cause
Video attachments rendered as bare video elements with no poster, no reserved aspect ratio, no compact mode, and a large max height. Mobile browsers can show a black tile before interaction and update intrinsic video dimensions after metadata loads, causing scroll jank.

## Changes
- Parse optional imeta image/thumb fields as sanitized video poster URLs.
- Render videos in a stable aspect-ratio wrapper using metadata dimensions or a 16:9 default.
- Use poster images when available and a non-black preview affordance when not.
- Respect compact mode for videos and reduce the normal max height to a mobile-friendlier bound.

## Verification
- npm test -- src/shared/lib/mediaUtils.test.ts
- npm test
- npm run typecheck
- npm run lint (passes with existing Fast Refresh warnings in providers/settings)
- npm run build

Note: bun is not installed in this environment, so npm was used for equivalent scripts.