### PR TITLE
Keep non-media links inline on media posts

### DIFF
--- a/src/shared/lib/content.test.ts
+++ b/src/shared/lib/content.test.ts
@@ -62,16 +62,36 @@ describe("parseContent", () => {
     });
   });
 
-  it("interleaves media and link attachments in source order", () => {
+  it("keeps non-media URLs in the comment when media exists", () => {
     const content =
       "read https://example.com/article then https://example.com/shot.jpg";
     const event = { content } as Event;
 
     expect(parseContent(event)).toEqual({
-      comment: "read then",
+      comment: "read https://example.com/article then",
       attachments: [
-        { kind: "link", item: { url: "https://example.com/article" } },
         { kind: "media", item: { url: "https://example.com/shot.jpg", type: "image" } },
+      ],
+    });
+  });
+
+  it("keeps non-media URLs in the comment when imeta media exists", () => {
+    const event = {
+      content: "read https://example.com/article",
+      tags: [["imeta", "url https://example.com/tag.png", "m image/png"]],
+    } as Event;
+
+    expect(parseContent(event)).toEqual({
+      comment: "read https://example.com/article",
+      attachments: [
+        {
+          kind: "media",
+          item: {
+            url: "https://example.com/tag.png",
+            type: "image",
+            mime: "image/png",
+          },
+        },
       ],
     });
   });

--- a/src/shared/lib/content.ts
+++ b/src/shared/lib/content.ts
@@ -67,7 +67,8 @@ export function parseContent(event: Event): ParsedContent {
   const media = extractMedia(event);
   const withoutMedia = stripMediaUrls(event.content, media);
   const knownMediaUrls = new Set(media.map((item) => item.url));
-  const links = extractLinkUrls(withoutMedia, knownMediaUrls);
+  const links =
+    media.length > 0 ? [] : extractLinkUrls(withoutMedia, knownMediaUrls);
   const withoutLinks = stripLinkUrls(withoutMedia, links);
   const mediaByUrl = new Map(media.map((item) => [item.url, item]));
   const linkByUrl = new Map(links.map((item) => [item.url, item]));

--- a/src/shared/ui/LinkedBodyText.test.tsx
+++ b/src/shared/ui/LinkedBodyText.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LinkedBodyText } from "./LinkedBodyText";
+
+describe("LinkedBodyText", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders preserved body URLs as clickable hyperlinks", () => {
+    act(() => {
+      root.render(
+        <LinkedBodyText className="body">
+          {"read https://example.com/article now"}
+        </LinkedBodyText>,
+      );
+    });
+
+    const link = container.querySelector("a");
+    expect(link?.textContent).toBe("https://example.com/article");
+    expect(link?.getAttribute("href")).toBe("https://example.com/article");
+    expect(container.textContent).toBe("read https://example.com/article now");
+  });
+});

--- a/src/shared/ui/LinkedBodyText.tsx
+++ b/src/shared/ui/LinkedBodyText.tsx
@@ -1,0 +1,46 @@
+import { normalizeUrl } from "@link/link";
+import { HTTP_URL_PATTERN } from "@lib/url";
+
+type LinkedBodyTextProps = {
+  children: string;
+  className?: string;
+};
+
+export function LinkedBodyText({ children, className }: LinkedBodyTextProps) {
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of children.matchAll(HTTP_URL_PATTERN)) {
+    const rawUrl = match[0];
+    const index = match.index ?? 0;
+    const normalized = normalizeUrl(rawUrl);
+
+    if (index > lastIndex) {
+      parts.push(children.slice(lastIndex, index));
+    }
+
+    if (normalized) {
+      parts.push(
+        <a
+          key={`${normalized}-${index}`}
+          href={normalized}
+          target="_blank"
+          rel="noreferrer"
+          className="underline decoration-ghost underline-offset-2 hover:text-signal"
+        >
+          {rawUrl}
+        </a>,
+      );
+    } else {
+      parts.push(rawUrl);
+    }
+
+    lastIndex = index + rawUrl.length;
+  }
+
+  if (lastIndex < children.length) {
+    parts.push(children.slice(lastIndex));
+  }
+
+  return <p className={className}>{parts}</p>;
+}

--- a/src/shared/ui/QuotePreview.tsx
+++ b/src/shared/ui/QuotePreview.tsx
@@ -4,6 +4,7 @@ import { getDisplayName } from "@lib/profile";
 import { getNoteBodyText } from "@lib/pollUtils";
 import { useProfile } from "../hooks/useProfiles";
 import { AttachmentStack } from "./AttachmentStack";
+import { LinkedBodyText } from "./LinkedBodyText";
 import { PollSummary } from "./PollSummary";
 import { SignalAvatar } from "./SignalAvatar";
 
@@ -34,7 +35,9 @@ export function QuotePreview({ event }: { event: Event }) {
         <span>{authorLabel}</span>
       </div>
       {preview.length > 0 && (
-        <p className="whitespace-pre-wrap text-body text-secondary">{preview}</p>
+        <LinkedBodyText className="whitespace-pre-wrap text-body text-secondary">
+          {preview}
+        </LinkedBodyText>
       )}
       {attachments.length > 0 && (
         <div className="mt-2">

--- a/src/shared/ui/TextContent.tsx
+++ b/src/shared/ui/TextContent.tsx
@@ -8,6 +8,7 @@ import { PollResponder } from "./PollResponder";
 import { QuotePreview } from "./QuotePreview";
 import { QuotePreviewPlaceholder } from "./QuotePreviewPlaceholder";
 import { Button } from "./Button";
+import { LinkedBodyText } from "./LinkedBodyText";
 
 const COLLAPSED_LENGTH = 750;
 
@@ -27,7 +28,9 @@ export function TextContent({
   return (
     <div className="gap-2 flex flex-col break-words text-body text-primary">
       {bodyText.length > 0 && (
-        <p className="whitespace-pre-wrap">{displayedComment}</p>
+        <LinkedBodyText className="whitespace-pre-wrap">
+          {displayedComment}
+        </LinkedBodyText>
       )}
       {bodyText.length > COLLAPSED_LENGTH && (
         <Button


### PR DESCRIPTION
Closes #35

## Root cause
parseContent always extracted non-media URLs into LinkPreview attachments after stripping media URLs. Media posts therefore rendered both the media and a URL preview, while losing the original inline link text.

## Changes
- Skip non-media link preview extraction whenever the post has media.
- Preserve non-media URLs in body text for media posts.
- Linkify preserved body URLs in normal text and quote previews.
- Keep existing LinkPreview behavior for posts without media.
- Add coverage for bare media + link, imeta media + link, and body URL linkification.

## Verification
- npm run typecheck
- npm run lint (passes with existing Fast Refresh warnings in providers/settings)
- npm run test -- src/shared/ui/LinkedBodyText.test.tsx src/shared/lib/content.test.ts
- npm test
- npm run build

Note: bun is not installed in this environment, so npm was used for equivalent scripts.