### PR TITLE
Reset scroll on route changes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Link, MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { ScrollToTop } from "./App";
+
+type ReactActGlobal = typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+function RouteProbe() {
+  return (
+    <>
+      <ScrollToTop />
+      <Routes>
+        <Route path="/" element={<Link to="/thread/note1">open thread</Link>} />
+        <Route path="/thread/:id" element={<button type="button">thread</button>} />
+      </Routes>
+    </>
+  );
+}
+
+function BackProbe() {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <ScrollToTop />
+      <button type="button" onClick={() => navigate(-1)}>
+        back
+      </button>
+    </>
+  );
+}
+
+describe("ScrollToTop", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let scrollTo: ReturnType<typeof vi.fn>;
+
+  beforeAll(() => {
+    (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    scrollTo = vi.fn();
+    vi.stubGlobal("scrollTo", scrollTo);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("resets scroll when pushing a thread route from the feed", () => {
+    act(() => {
+      root.render(
+        <MemoryRouter
+          initialEntries={["/"]}
+          future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+        >
+          <RouteProbe />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    act(() => {
+      container
+        .querySelector("a")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "auto" });
+  });
+
+  it("does not reset scroll on browser-style back navigation", () => {
+    act(() => {
+      root.render(
+        <MemoryRouter
+          initialEntries={["/", "/thread/note1"]}
+          initialIndex={1}
+          future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+        >
+          <BackProbe />
+        </MemoryRouter>,
+      );
+    });
+
+    act(() => {
+      container
+        .querySelector("button")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { BrowserRouter as Router, useLocation } from "react-router-dom";
+import { useEffect } from "react";
+import { BrowserRouter as Router, useLocation, useNavigationType } from "react-router-dom";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { AppProviders } from "./app/providers";
@@ -12,11 +13,27 @@ function AppSpeedInsights() {
   return <SpeedInsights route={getPathDisplay(pathname)} />;
 }
 
+export function ScrollToTop() {
+  const { pathname } = useLocation();
+  const navigationType = useNavigationType();
+
+  useEffect(() => {
+    if (navigationType === "POP") {
+      return;
+    }
+
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, [navigationType, pathname]);
+
+  return null;
+}
+
 function App() {
   return (
     <AppProviders>
       <NoiseOverlay />
       <Router>
+        <ScrollToTop />
         <Header />
         <AppRoutes />
         <Analytics />


### PR DESCRIPTION
Closes #36

## Root cause
React Router route changes reused the current document scroll position. Opening a thread from a scrolled feed therefore mounted the thread at the old feed offset.

## Changes
- Add a ScrollToTop route helper inside BrowserRouter.
- Reset window scroll on non-POP pathname changes.
- Preserve browser-style back/forward navigation when React Router reports POP.
- Add focused jsdom regression coverage for feed-to-thread reset and back preservation.

## Verification
- npx vitest run src/App.test.tsx
- npm run typecheck
- npm run lint (passes with existing Fast Refresh warnings in providers/settings)
- npm test
- npm run build

Note: bun is not installed in this environment, so npm/npx were used for equivalent scripts.