### PR TITLE
Harden unfurling and security headers

### DIFF
--- a/lib/unfurl.test.ts
+++ b/lib/unfurl.test.ts
@@ -1,0 +1,66 @@
+import { lookup } from "node:dns/promises";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isSafeUrl, unfurlUrl } from "./unfurl";
+
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(),
+}));
+
+const mockedLookup = vi.mocked(lookup);
+
+describe("isSafeUrl", () => {
+  it("rejects private hosts and non-standard ports", () => {
+    expect(isSafeUrl("http://127.0.0.1/page")).toBe(false);
+    expect(isSafeUrl("http://10.0.0.5/page")).toBe(false);
+    expect(isSafeUrl("http://example.com:8080/page")).toBe(false);
+  });
+
+  it("accepts public http and https URLs on standard ports", () => {
+    expect(isSafeUrl("https://example.com/page")).toBe(true);
+    expect(isSafeUrl("http://example.com/page")).toBe(true);
+  });
+});
+
+describe("unfurlUrl", () => {
+  beforeEach(() => {
+    mockedLookup.mockReset();
+    mockedLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("rejects redirects to private hosts", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { Location: "http://127.0.0.1/admin" },
+      }),
+    );
+
+    await expect(unfurlUrl("https://example.com/post")).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows safe redirects and extracts metadata from the final page", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 301,
+          headers: { Location: "/next" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response("<html><head><title>Wired link</title></head></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+      );
+
+    await expect(unfurlUrl("https://example.com/post")).resolves.toMatchObject({
+      title: "Wired link",
+      domain: "example.com",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/lib/unfurl.ts
+++ b/lib/unfurl.ts
@@ -1,9 +1,16 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
 import type { LinkMetadata } from "./link.js";
 
 export type { LinkMetadata };
 
 const FETCH_TIMEOUT_MS = 5000;
 const MAX_HTML_BYTES = 512_000;
+const MAX_REDIRECTS = 5;
+const STANDARD_PORTS: Record<string, string> = {
+  "http:": "80",
+  "https:": "443",
+};
 
 function isBlockedHostname(hostname: string): boolean {
   const lower = hostname.toLowerCase();
@@ -27,16 +34,69 @@ function isBlockedHostname(hostname: string): boolean {
   return false;
 }
 
+function isBlockedIpAddress(address: string): boolean {
+  const normalized = address.toLowerCase();
+
+  if (normalized.startsWith("::ffff:")) {
+    return isBlockedIpAddress(normalized.slice("::ffff:".length));
+  }
+
+  if (isIP(normalized) === 4) {
+    if (normalized.startsWith("127.")) return true;
+    if (normalized.startsWith("10.")) return true;
+    if (normalized.startsWith("192.168.")) return true;
+    if (/^169\.254\./.test(normalized)) return true;
+    if (/^172\.(1[6-9]|2\d|3[0-1])\./.test(normalized)) return true;
+    if (normalized === "0.0.0.0") return true;
+    return false;
+  }
+
+  if (isIP(normalized) === 6) {
+    if (normalized === "::1") return true;
+    if (normalized === "::") return true;
+    if (normalized.startsWith("fe80:")) return true;
+    if (/^f[cd][0-9a-f]{2}:/.test(normalized)) return true;
+  }
+
+  return false;
+}
+
+function usesStandardPort(url: URL): boolean {
+  const defaultPort = STANDARD_PORTS[url.protocol];
+  return Boolean(defaultPort) && (!url.port || url.port === defaultPort);
+}
+
 export function isSafeUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return false;
     }
-    return !isBlockedHostname(parsed.hostname);
+    if (!usesStandardPort(parsed)) return false;
+    if (isBlockedHostname(parsed.hostname)) return false;
+    if (isIP(parsed.hostname) && isBlockedIpAddress(parsed.hostname)) return false;
+    return true;
   } catch {
     return false;
   }
+}
+
+async function resolvesToPublicAddress(hostname: string): Promise<boolean> {
+  if (isIP(hostname)) {
+    return !isBlockedIpAddress(hostname);
+  }
+
+  try {
+    const records = await lookup(hostname, { all: true, verbatim: true });
+    return records.length > 0 && records.every((record) => !isBlockedIpAddress(record.address));
+  } catch {
+    return false;
+  }
+}
+
+async function isSafeFetchUrl(url: string): Promise<boolean> {
+  if (!isSafeUrl(url)) return false;
+  return resolvesToPublicAddress(new URL(url).hostname);
 }
 
 function decodeHtmlEntities(value: string): string {
@@ -134,20 +194,56 @@ async function readLimitedHtml(response: Response): Promise<string> {
   return html;
 }
 
+function isRedirectStatus(status: number): boolean {
+  return status >= 300 && status < 400;
+}
+
+async function fetchWithSafeRedirects(target: string): Promise<Response | null> {
+  let currentUrl = target;
+
+  for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+    if (!(await isSafeFetchUrl(currentUrl))) {
+      return null;
+    }
+
+    const response = await fetch(currentUrl, {
+      headers: {
+        "User-Agent": "Wired-LinkPreview/1.0",
+        Accept: "text/html,application/xhtml+xml",
+      },
+      redirect: "manual",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    if (!isRedirectStatus(response.status)) {
+      return response;
+    }
+
+    const location = response.headers.get("location");
+    if (!location) {
+      return response;
+    }
+
+    try {
+      currentUrl = new URL(location, currentUrl).href;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
 export async function unfurlUrl(target: string): Promise<LinkMetadata | null> {
   if (!isSafeUrl(target)) {
     return null;
   }
 
   try {
-    const response = await fetch(target, {
-      headers: {
-        "User-Agent": "Wired-LinkPreview/1.0",
-        Accept: "text/html,application/xhtml+xml",
-      },
-      redirect: "follow",
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
+    const response = await fetchWithSafeRedirects(target);
+    if (!response) {
+      return null;
+    }
 
     if (!response.ok) {
       return null;

--- a/vercel.json
+++ b/vercel.json
@@ -26,6 +26,33 @@
       { "protocol": "https", "hostname": "^(.*\\.)?blossom\\.band$" }
     ]
   },
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; connect-src 'self' https: wss:; img-src 'self' data: blob: https:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), browsing-topics=()"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/((?!api/|_vercel/|src/|@|node_modules/|assets/|fonts/|favicon\\.svg|robots\\.txt|noise\\.png).*)",


### PR DESCRIPTION
## Summary
- validate unfurl targets on every redirect hop and block private DNS/IP targets
- restrict unfurling to standard HTTP/HTTPS ports
- add Vercel security headers including CSP, frame protection, nosniff, referrer policy, and permissions policy
- add tests for safe redirects and private redirect rejection

## Verification
- npm run typecheck
- npm run test -- lib/unfurl.test.ts lib/link.test.ts
- npm run lint
- npm run test
- npm run build