### PR TITLE
Simplify content URL parsing

### DIFF
--- a/src/shared/lib/content.test.ts
+++ b/src/shared/lib/content.test.ts
@@ -27,6 +27,18 @@ describe("parseContent", () => {
     });
   });
 
+  it("strips original URL tokens after normalization changes the URL", () => {
+    const content = "visit https://example.com then stay";
+    const event = { content } as Event;
+
+    expect(parseContent(event)).toEqual({
+      comment: "visit then stay",
+      attachments: [
+        { kind: "link", item: { url: "https://example.com/" } },
+      ],
+    });
+  });
+
   it("strips nostr bech32 identifiers from displayed content", () => {
     const content =
       "Wem nützt diese Näherung mehr?\nnostr:nevent1qqsyfzfk3zkvvmuyqd8hzu9008efyn4n53ucvx2353wknnltte0d33spz4mhxue69uhkummnw3ezuerpw3sju6rpw4esygy86n6j2pxy0rmwdj062z5y7mjngl2pyrz334pptd2jwjkh8slxwu6szplm";
@@ -72,6 +84,43 @@ describe("parseContent", () => {
       attachments: [
         { kind: "link", item: { url: "https://example.com/article" } },
         { kind: "media", item: { url: "https://example.com/shot.jpg", type: "image" } },
+      ],
+    });
+  });
+
+  it("orders mixed links, bare media, and imeta media by source token", () => {
+    const event = {
+      content:
+        "one https://example.com/a two https://example.com/tag.png three https://example.com/b four https://example.com/clip.mp4",
+      tags: [
+        [
+          "imeta",
+          "url https://example.com/tag.png",
+          "m image/png",
+          "dim 640x480",
+        ],
+      ],
+    } as Event;
+
+    expect(parseContent(event)).toEqual({
+      comment: "one two three four",
+      attachments: [
+        { kind: "link", item: { url: "https://example.com/a" } },
+        {
+          kind: "media",
+          item: {
+            url: "https://example.com/tag.png",
+            type: "image",
+            mime: "image/png",
+            width: 640,
+            height: 480,
+          },
+        },
+        { kind: "link", item: { url: "https://example.com/b" } },
+        {
+          kind: "media",
+          item: { url: "https://example.com/clip.mp4", type: "video" },
+        },
       ],
     });
   });

--- a/src/shared/lib/content.ts
+++ b/src/shared/lib/content.ts
@@ -1,12 +1,11 @@
 import { Event } from "nostr-tools";
 import { normalizeUrl } from "@link/link";
 import {
-  extractMedia,
   parseImetaTags,
-  stripMediaUrls,
   type MediaItem,
+  typeFromMediaExtension,
 } from "@lib/mediaUtils";
-import { extractLinkUrls, stripLinkUrls, type LinkItem } from "@lib/linkUtils";
+import { type LinkItem } from "@lib/linkUtils";
 import { normalizeStrippedContent } from "@lib/textCleanup";
 import { HTTP_URL_PATTERN } from "@lib/url";
 import { NOSTR_REF_PATTERN } from "./quotedEvents";
@@ -27,29 +26,76 @@ export type ParsedContent = {
   attachments: Attachment[];
 };
 
-function buildAttachmentsInOrder(
-  content: string,
-  imetaItems: MediaItem[],
-  mediaByUrl: Map<string, MediaItem>,
-  linkByUrl: Map<string, LinkItem>,
-): Attachment[] {
-  const attachments: Attachment[] = [];
-  const seen = new Set<string>();
+type UrlToken = {
+  raw: string;
+  url: string;
+  start: number;
+  end: number;
+};
+
+function extractUrlTokens(content: string): UrlToken[] {
+  const tokens: UrlToken[] = [];
 
   for (const match of content.matchAll(HTTP_URL_PATTERN)) {
-    const normalized = normalizeUrl(match[0]);
-    if (!normalized || seen.has(normalized)) continue;
-    seen.add(normalized);
+    const raw = match[0];
+    const url = normalizeUrl(raw);
+    if (!url || match.index === undefined) continue;
 
-    const mediaItem = mediaByUrl.get(normalized);
+    tokens.push({
+      raw,
+      url,
+      start: match.index,
+      end: match.index + raw.length,
+    });
+  }
+
+  return tokens;
+}
+
+function stripUrlTokens(content: string, tokens: UrlToken[]): string {
+  if (tokens.length === 0) return content;
+
+  let result = "";
+  let cursor = 0;
+  for (const token of tokens) {
+    result += content.slice(cursor, token.start);
+    cursor = token.end;
+  }
+  result += content.slice(cursor);
+
+  return normalizeStrippedContent(result);
+}
+
+function parseContentUrls(
+  content: string,
+  imetaItems: MediaItem[],
+): { attachments: Attachment[]; strippedContent: string } {
+  const attachments: Attachment[] = [];
+  const seen = new Set<string>();
+  const strippedTokens: UrlToken[] = [];
+  const imetaByUrl = new Map(imetaItems.map((item) => [item.url, item]));
+
+  for (const token of extractUrlTokens(content)) {
+    const imetaItem = imetaByUrl.get(token.url);
+    const mediaType = imetaItem
+      ? imetaItem.type
+      : typeFromMediaExtension(token.url);
+    const mediaItem =
+      imetaItem ?? (mediaType ? { url: token.url, type: mediaType } : null);
+
     if (mediaItem) {
-      attachments.push({ kind: "media", item: mediaItem });
+      strippedTokens.push(token);
+      if (!seen.has(token.url)) {
+        seen.add(token.url);
+        attachments.push({ kind: "media", item: mediaItem });
+      }
       continue;
     }
 
-    const linkItem = linkByUrl.get(normalized);
-    if (linkItem) {
-      attachments.push({ kind: "link", item: linkItem });
+    strippedTokens.push(token);
+    if (!seen.has(token.url)) {
+      seen.add(token.url);
+      attachments.push({ kind: "link", item: { url: token.url } });
     }
   }
 
@@ -59,27 +105,21 @@ function buildAttachmentsInOrder(
     attachments.push({ kind: "media", item });
   }
 
-  return attachments;
+  return {
+    attachments,
+    strippedContent: stripUrlTokens(content, strippedTokens),
+  };
 }
 
 export function parseContent(event: Event): ParsedContent {
   const imetaItems = parseImetaTags(event.tags ?? []);
-  const media = extractMedia(event);
-  const withoutMedia = stripMediaUrls(event.content, media);
-  const knownMediaUrls = new Set(media.map((item) => item.url));
-  const links = extractLinkUrls(withoutMedia, knownMediaUrls);
-  const withoutLinks = stripLinkUrls(withoutMedia, links);
-  const mediaByUrl = new Map(media.map((item) => [item.url, item]));
-  const linkByUrl = new Map(links.map((item) => [item.url, item]));
-  const attachments = buildAttachmentsInOrder(
+  const { attachments, strippedContent } = parseContentUrls(
     event.content,
     imetaItems,
-    mediaByUrl,
-    linkByUrl,
   );
 
   return {
-    comment: stripNostrRefs(withoutLinks),
+    comment: stripNostrRefs(strippedContent),
     attachments,
   };
 }

--- a/src/shared/lib/linkUtils.ts
+++ b/src/shared/lib/linkUtils.ts
@@ -1,14 +1,12 @@
 import { normalizeUrl } from "@link/link";
+import { typeFromMediaExtension } from "@lib/mediaUtils";
 import { normalizeStrippedContent } from "@lib/textCleanup";
 import { HTTP_URL_PATTERN } from "@lib/url";
 
 export type LinkItem = { url: string };
 
-const MEDIA_EXTENSION_PATTERN =
-  /\.(?:jpe?g|png|gif|webp|mp4|webm|mov|mp3|wav|ogg|m4a)(?:\?|$)/i;
-
 function isMediaUrl(url: string): boolean {
-  return MEDIA_EXTENSION_PATTERN.test(url);
+  return typeFromMediaExtension(url) !== null;
 }
 
 export function extractLinkUrls(

--- a/src/shared/lib/mediaUtils.ts
+++ b/src/shared/lib/mediaUtils.ts
@@ -45,7 +45,7 @@ const MIME_TYPE: Record<string, MediaType> = {
   "audio/mp4": "audio",
 };
 
-function typeFromExtension(url: string): MediaType | null {
+export function typeFromMediaExtension(url: string): MediaType | null {
   const match = url.match(/\.([a-z0-9]+)(?:\?|$)/i);
   if (!match) return null;
   return EXTENSION_TYPE[match[1].toLowerCase()] ?? null;
@@ -57,7 +57,7 @@ function typeFromMime(mime?: string): MediaType | null {
 }
 
 function resolveMediaType(url: string, mime?: string): MediaType | null {
-  return typeFromMime(mime) ?? typeFromExtension(url);
+  return typeFromMime(mime) ?? typeFromMediaExtension(url);
 }
 
 function parseImetaFields(tag: string[]): {
@@ -125,7 +125,7 @@ export function parseBareMediaUrls(content: string): MediaItem[] {
     const normalized = normalizeUrl(raw);
     if (!normalized || seen.has(normalized)) continue;
 
-    const type = typeFromExtension(normalized);
+    const type = typeFromMediaExtension(normalized);
     if (!type) continue;
 
     seen.add(normalized);


### PR DESCRIPTION
## Summary
- Parse content URLs once into ordered tokens that keep the original source span for stripping.
- Classify tokens as imeta media, bare media, or links while preserving attachment ordering and appending imeta-only media.
- Share media-extension classification with link extraction and add focused parser tests for normalized URL stripping and mixed media/link ordering.

## Validation
- `npm test -- src/shared/lib/content.test.ts src/shared/lib/mediaUtils.test.ts src/shared/lib/linkUtils.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run lint` (passes with existing Fast Refresh warnings in `src/app/providers.tsx` and `src/app/settings.tsx`)
- `git diff --check`

## Notes
- `npm ci` reports existing audit findings: 7 moderate, 7 high, 1 critical.