### PR TITLE
Clean up Nostr feed traversal

### DIFF
--- a/src/nostr/feed-candidates.ts
+++ b/src/nostr/feed-candidates.ts
@@ -1,0 +1,40 @@
+import type { Event } from "nostr-tools";
+import { isRootNote } from "../shared/lib/noteEvents.js";
+import { verifyPow } from "../shared/pow/core.js";
+
+export type FeedCandidateDecision = {
+  accepted: boolean;
+  replyRootId: string | null;
+};
+
+export function feedReplyRootId(event: Event): string | null {
+  return event.kind === 1 && isRootNote(event) ? event.id : null;
+}
+
+export function createFeedCandidateTracker(filterDifficulty = 0) {
+  const seenPubkeys = new Set<string>();
+
+  return {
+    check(event: Event): FeedCandidateDecision {
+      if (event.kind !== 1 && event.kind !== 1068) {
+        return { accepted: false, replyRootId: null };
+      }
+
+      const replyRootId = feedReplyRootId(event);
+      if (event.kind === 1 && !replyRootId) {
+        return { accepted: false, replyRootId: null };
+      }
+
+      if (seenPubkeys.has(event.pubkey)) {
+        return { accepted: false, replyRootId: null };
+      }
+
+      if (verifyPow(event) < filterDifficulty) {
+        return { accepted: false, replyRootId: null };
+      }
+
+      seenPubkeys.add(event.pubkey);
+      return { accepted: true, replyRootId };
+    },
+  };
+}

--- a/src/nostr/processEvents.test.ts
+++ b/src/nostr/processEvents.test.ts
@@ -59,6 +59,42 @@ describe("processFeedEvents", () => {
     expect(result[0].threadReplyCount).toBe(1);
   });
 
+  it("uses the same feed root eligibility for articles and root notes", () => {
+    const article = event({
+      id: "1".repeat(64),
+      kind: 1068,
+      pubkey: "a".repeat(64),
+    });
+    const duplicateAuthorRoot = event({
+      id: "2".repeat(64),
+      pubkey: "a".repeat(64),
+    });
+    const acceptedRoot = event({
+      id: "3".repeat(64),
+      pubkey: "b".repeat(64),
+    });
+    const reply = event({
+      id: "4".repeat(64),
+      pubkey: "c".repeat(64),
+      tags: [["e", acceptedRoot.id]],
+    });
+
+    const result = processFeedEvents([
+      article,
+      duplicateAuthorRoot,
+      acceptedRoot,
+      reply,
+    ]);
+
+    expect(result.map((item) => item.postEvent.id)).toEqual([
+      acceptedRoot.id,
+      article.id,
+    ]);
+    expect(result.find((item) => item.postEvent.id === acceptedRoot.id)?.replies).toEqual([
+      reply,
+    ]);
+  });
+
   it("includes nested thread replies in feed reply count and total work", () => {
     const root = event({
       id: "1".repeat(64),

--- a/src/nostr/processEvents.ts
+++ b/src/nostr/processEvents.ts
@@ -1,6 +1,5 @@
 import type { Event } from "nostr-tools";
-import { verifyPow } from "../shared/pow/core.js";
-import { isRootNote } from "../shared/lib/noteEvents.js";
+import { createFeedCandidateTracker } from "./feed-candidates.js";
 import { workScoreBreakdown } from "./processing/pow-score.js";
 import type { ProcessedEvent } from "./types.js";
 
@@ -70,16 +69,11 @@ export function toProcessedEvents(
 
 export const processFeedEvents = (events: Event[], filterDifficulty = 0): ProcessedEvent[] => {
   const repliesByParent = buildRepliesByParent(events);
-  const seenPubkeys = new Set<string>();
+  const candidates = createFeedCandidateTracker(filterDifficulty);
   const posts: Event[] = [];
 
   events.forEach((event) => {
-    if (event.kind !== 1 && event.kind !== 1068) return;
-    if (seenPubkeys.has(event.pubkey)) return;
-    if (event.kind === 1 && !isRootNote(event)) return;
-    if (verifyPow(event) < filterDifficulty) return;
-
-    seenPubkeys.add(event.pubkey);
+    if (!candidates.check(event).accepted) return;
     posts.push(event);
   });
 

--- a/src/nostr/subscriptions/global-feed.test.ts
+++ b/src/nostr/subscriptions/global-feed.test.ts
@@ -136,6 +136,43 @@ describe("subGlobalFeed", () => {
     expect(nestedReplyRequest.relayUrls).toEqual(enrichmentRelays);
   });
 
+  it("uses processable feed root eligibility for PoW reply enrichment", () => {
+    const articleId = `${"1".repeat(64)}`;
+    const duplicateAuthorRootId = `${"2".repeat(64)}`;
+    const acceptedRootId = `${"3".repeat(64)}`;
+
+    const article = {
+      ...rootNoteFromPubkey(articleId, "a".repeat(64)),
+      kind: 1068,
+    };
+    const duplicateAuthorRoot = rootNoteFromPubkey(
+      duplicateAuthorRootId,
+      "a".repeat(64),
+    );
+    const acceptedRoot = rootNoteFromPubkey(acceptedRootId, "b".repeat(64));
+
+    subscribeMock.mockImplementation((requests) => {
+      const id = String(subscribeMock.mock.calls.length);
+
+      if (id === "1") {
+        const { cb, onEose } = requests[0];
+        cb(article, "wss://powrelay.xyz");
+        cb(duplicateAuthorRoot, "wss://powrelay.xyz");
+        cb(acceptedRoot, "wss://powrelay.xyz");
+        onEose?.();
+      }
+
+      return { id, close: vi.fn() };
+    });
+
+    subGlobalFeed(vi.fn(), 24, { rootFilterDifficulty: 0 });
+
+    expect(subscribeMock).toHaveBeenCalledTimes(2);
+    expect(subscribeMock.mock.calls[1][0][0].filter["#e"]).toEqual([
+      acceptedRootId,
+    ]);
+  });
+
   it("can enrich replies for known root ids", () => {
     const rootId = `${"1".repeat(64)}`;
     const replyId = `${"2".repeat(64)}`;
@@ -203,5 +240,29 @@ describe("subGlobalFeed", () => {
       limit: REPLY_QUERY_LIMIT,
       since: expect.any(Number),
     });
+  });
+
+  it("closes reply traversal children that are added after the parent closes", () => {
+    const rootId = `${"1".repeat(64)}`;
+    const replyId = `${"2".repeat(64)}`;
+    const closeMocks: ReturnType<typeof vi.fn>[] = [];
+
+    subscribeMock.mockImplementation(() => {
+      const id = String(subscribeMock.mock.calls.length);
+      const close = vi.fn();
+      closeMocks.push(close);
+      return { id, close };
+    });
+
+    const handle = subRepliesForRootIds([rootId], vi.fn(), { depth: 2 });
+    const firstRequest = subscribeMock.mock.calls[0][0][0];
+
+    handle.close();
+    firstRequest.cb(rootNote(replyId), "wss://relay.damus.io");
+    firstRequest.onEose?.();
+
+    expect(subscribeMock).toHaveBeenCalledTimes(2);
+    expect(closeMocks[0]).toHaveBeenCalledTimes(1);
+    expect(closeMocks[1]).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/nostr/subscriptions/global-feed.ts
+++ b/src/nostr/subscriptions/global-feed.ts
@@ -1,9 +1,11 @@
 import type { Event } from "nostr-tools";
-import { isRootNote } from "@lib/noteEvents";
 import { getRegistry } from "../client";
 import type { SubCallback, SubHandle } from "../types";
-import { composeSubHandle } from "./utils";
-import { verifyPow } from "../../shared/pow/core";
+import {
+  createFeedCandidateTracker,
+  feedReplyRootId,
+} from "../feed-candidates";
+import { createSubHandleOwner } from "./utils";
 import {
   buildReplyFilter,
   clampReplyDepth,
@@ -18,67 +20,53 @@ type GlobalFeedOptions = {
 };
 
 const trackRootNote = (notes: Set<string>, evt: Event) => {
-  if (isRootNote(evt)) {
-    notes.add(evt.id);
+  const replyRootId = feedReplyRootId(evt);
+  if (replyRootId) {
+    notes.add(replyRootId);
   }
 };
 
-const trackAcceptedRootNote = (
-  notes: Set<string>,
-  seenPubkeys: Set<string>,
-  evt: Event,
-  filterDifficulty: number,
-) => {
-  if (evt.kind !== 1 && evt.kind !== 1068) return;
-  if (evt.kind === 1 && !isRootNote(evt)) return;
-  if (seenPubkeys.has(evt.pubkey)) return;
-  if (verifyPow(evt) < filterDifficulty) return;
+class FeedReplyTraversal {
+  private readonly owner = createSubHandleOwner("feed-replies");
 
-  seenPubkeys.add(evt.pubkey);
+  constructor(
+    private readonly onEvent: SubCallback,
+    private readonly relayUrls: readonly string[] | undefined,
+    private readonly depth: number,
+    private readonly since: number,
+  ) {}
 
-  if (evt.kind === 1) {
-    notes.add(evt.id);
+  get handle(): SubHandle {
+    return this.owner.handle();
   }
-};
 
-const subRepliesForParents = (
-  parentIds: string[],
-  onEvent: SubCallback,
-  relayUrls: readonly string[] | undefined,
-  depth: number,
-  since: number,
-  children: SubHandle[],
-) => {
-  if (parentIds.length === 0 || depth <= 0) return;
+  start(parentIds: string[]) {
+    this.subscribeParents(parentIds, this.depth);
+  }
 
-  const childReplyIds = new Set<string>();
-  const filter = buildReplyFilter(parentIds, since);
-  if (!filter) return;
+  private subscribeParents(parentIds: string[], depth: number) {
+    if (parentIds.length === 0 || depth <= 0) return;
 
-  children.push(
-    getRegistry().subscribe([
+    const childReplyIds = new Set<string>();
+    const filter = buildReplyFilter(parentIds, this.since);
+    if (!filter) return;
+
+    this.owner.add(getRegistry().subscribe([
       {
         filter,
-        relayUrls: relayUrls ? [...relayUrls] : undefined,
+        relayUrls: this.relayUrls ? [...this.relayUrls] : undefined,
         cb: (evt, relay) => {
           childReplyIds.add(evt.id);
-          onEvent(evt, relay);
+          this.onEvent(evt, relay);
         },
         closeOnEose: true,
         onEose: () => {
-          subRepliesForParents(
-            Array.from(childReplyIds),
-            onEvent,
-            relayUrls,
-            depth - 1,
-            since,
-            children,
-          );
+          this.subscribeParents(Array.from(childReplyIds), depth - 1);
         },
       },
-    ]),
-  );
-};
+    ]));
+  }
+}
 
 export const subRepliesForRootIds = (
   rootIds: string[],
@@ -89,17 +77,15 @@ export const subRepliesForRootIds = (
     since?: number;
   } = {},
 ): SubHandle => {
-  const children: SubHandle[] = [];
-  subRepliesForParents(
-    rootIds,
+  const traversal = new FeedReplyTraversal(
     onEvent,
     options.relayUrls,
     clampReplyDepth(options.depth ?? 1),
     options.since ?? sinceFromAgeHours(24),
-    children,
   );
 
-  return composeSubHandle("feed-replies", children);
+  traversal.start(rootIds);
+  return traversal.handle;
 };
 
 export const subGlobalFeed = (
@@ -108,14 +94,22 @@ export const subGlobalFeed = (
   options: GlobalFeedOptions = {},
 ): SubHandle => {
   const registry = getRegistry();
-  const children: SubHandle[] = [];
+  const owner = createSubHandleOwner("global-feed");
   const notes = new Set<string>();
-  const seenPubkeys = new Set<string>();
+  const candidates = createFeedCandidateTracker(options.rootFilterDifficulty);
   const now = Math.floor(Date.now() / 1000);
   const since = sinceFromAgeHours(ageHours, now);
   const replyDepth = clampReplyDepth(options.replyDepth ?? 1);
+  const replies = new FeedReplyTraversal(
+    onEvent,
+    options.replyRelayUrls,
+    replyDepth,
+    since,
+  );
 
-  children.push(
+  owner.add(replies.handle);
+
+  owner.add(
     registry.subscribe([
       {
         filter: {
@@ -130,12 +124,10 @@ export const subGlobalFeed = (
           if (options.rootFilterDifficulty === undefined) {
             trackRootNote(notes, evt);
           } else {
-            trackAcceptedRootNote(
-              notes,
-              seenPubkeys,
-              evt,
-              options.rootFilterDifficulty,
-            );
+            const decision = candidates.check(evt);
+            if (decision.replyRootId) {
+              notes.add(decision.replyRootId);
+            }
           }
           onEvent(evt, relay);
         },
@@ -145,22 +137,11 @@ export const subGlobalFeed = (
 
           const noteIds = Array.from(notes);
           notes.clear();
-
-          subRepliesForParents(
-            noteIds,
-            onEvent,
-            options.replyRelayUrls,
-            replyDepth,
-            since,
-            children,
-          );
+          replies.start(noteIds);
         },
       },
     ]),
   );
 
-  return composeSubHandle(
-    `global-feed:${children[0]?.id ?? "pending"}`,
-    children,
-  );
+  return owner.handle();
 };

--- a/src/nostr/subscriptions/utils.ts
+++ b/src/nostr/subscriptions/utils.ts
@@ -17,3 +17,30 @@ export function composeSubHandle(
     },
   };
 }
+
+export function createSubHandleOwner(id: string, onClose?: () => void) {
+  const children: SubHandle[] = [];
+  let closed = false;
+
+  const close = () => {
+    if (closed) return;
+
+    closed = true;
+    onClose?.();
+    children.forEach((child) => child.close());
+  };
+
+  return {
+    add(child: SubHandle) {
+      if (closed) {
+        child.close();
+        return;
+      }
+
+      children.push(child);
+    },
+    handle(): SubHandle {
+      return { id, close };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Extracted a canonical feed candidate tracker used by `processFeedEvents` and PoW-backed global feed reply enrichment.
- Replaced mutable recursive reply child-handle threading with a `FeedReplyTraversal` owner backed by a reusable subscription handle owner.
- Added focused regression coverage for process/subscription feed eligibility and reply traversal close behavior.

## Validation
- `npm test -- --run src/nostr/processEvents.test.ts src/nostr/subscriptions/global-feed.test.ts src/nostr/subscriptions/thread.test.ts src/nostr/subscriptions/query-limits.test.ts` - passed (4 files, 22 tests)
- `npm run typecheck` - passed
- `npm run build` - passed
- `npm test` - passed (26 files, 119 tests; existing React act warnings emitted by hook/UI tests)
- `npm run lint` - passed with existing warnings in `src/app/providers.tsx` and `src/app/settings.tsx`

## Notes
- `npm ci` completed and reported existing dependency audit findings: 15 vulnerabilities (7 moderate, 7 high, 1 critical). No dependency changes were made.
