### PR TITLE
Clean up PoW submit mining flow

### DIFF
--- a/src/shared/hooks/usePowMining.ts
+++ b/src/shared/hooks/usePowMining.ts
@@ -1,38 +1,85 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { UnsignedEvent } from "nostr-tools";
+import type { MinedPowEvent, PowWorkerRequest, PowWorkerResponse } from "../../workers/powWorker";
+
+type StartWorkOptions = {
+  onMined: (event: MinedPowEvent) => void;
+  onError?: () => void;
+};
 
 export function usePowMining(numCores: number, unsigned: UnsignedEvent, difficulty: string) {
-  const [messageFromWorker, setMessageFromWorker] = useState<UnsignedEvent | null>(null);
   const [hashrate, setHashrate] = useState(0);
   const [bestPow, setBestPow] = useState(0);
+  const activeJobId = useRef(0);
+  const workers = useRef<Worker[]>([]);
 
-  const startWork = () => {
+  const cancelWork = useCallback(() => {
+    activeJobId.current += 1;
+    workers.current.forEach((worker) => worker.terminate());
+    workers.current = [];
+  }, []);
+
+  useEffect(() => cancelWork, [cancelWork]);
+
+  const startWork = useCallback(({ onMined, onError }: StartWorkOptions) => {
+    cancelWork();
+    setHashrate(0);
+    setBestPow(0);
+
+    const jobId = activeJobId.current;
+    const parsedDifficulty = Number.parseInt(difficulty, 10);
     const startTime = Date.now();
-    const workers = Array(numCores)
+    const nextWorkers = Array(numCores)
       .fill(null)
       .map(() => new Worker(new URL("../../workers/powWorker.ts", import.meta.url), { type: "module" }));
 
-    workers.forEach((worker, index) => {
-      worker.onmessage = (event) => {
-        if (event.data.status === "progress") {
-          setHashrate(Math.floor(event.data.currentNonce / ((Date.now() - startTime) / 1000)));
-          if (event.data.bestPoW > bestPow) {
-            setBestPow(event.data.bestPoW);
-          }
-        } else if (event.data.found) {
-          setMessageFromWorker(event.data.event);
-          workers.forEach((w) => w.terminate());
+    workers.current = nextWorkers;
+
+    const finishJob = () => {
+      if (activeJobId.current !== jobId) return false;
+
+      workers.current.forEach((worker) => worker.terminate());
+      workers.current = [];
+      activeJobId.current += 1;
+
+      return true;
+    };
+
+    nextWorkers.forEach((worker, index) => {
+      worker.onmessage = (event: MessageEvent<PowWorkerResponse>) => {
+        if (activeJobId.current !== jobId) return;
+
+        const response = event.data;
+
+        if (response.type === "progress") {
+          const elapsedSeconds = (Date.now() - startTime) / 1000;
+          setHashrate(Math.floor(response.currentNonce / (elapsedSeconds || 1)));
+          setBestPow((currentBestPow) => Math.max(currentBestPow, response.bestPow));
+          return;
+        }
+
+        if (finishJob()) {
+          onMined(response.event);
         }
       };
 
-      worker.postMessage({
+      worker.onerror = () => {
+        if (finishJob()) {
+          onError?.();
+        }
+      };
+
+      const request: PowWorkerRequest = {
+        type: "mine",
         unsigned,
-        difficulty,
+        difficulty: parsedDifficulty,
         nonceStart: index,
         nonceStep: numCores,
-      });
-    });
-  };
+      };
 
-  return { startWork, messageFromWorker, hashrate, bestPow };
+      worker.postMessage(request);
+    });
+  }, [cancelWork, difficulty, numCores, unsigned]);
+
+  return { startWork, cancelWork, hashrate, bestPow };
 }

--- a/src/shared/hooks/useSubmitForm.test.tsx
+++ b/src/shared/hooks/useSubmitForm.test.tsx
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
   appendKey: vi.fn(),
   publish: vi.fn(),
 }));
-let workerMessageHandler: ((event: MessageEvent) => void) | null = null;
+let mockWorkers: MockWorker[] = [];
 
 vi.mock("nostr-tools", async (importOriginal) => {
   const actual = await importOriginal<typeof import("nostr-tools")>();
@@ -37,14 +37,21 @@ vi.mock("./useStoredKeys", () => ({
 
 class MockWorker {
   onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  postMessage = vi.fn();
+  terminate = vi.fn();
 
   constructor() {
-    workerMessageHandler = (event: MessageEvent) => this.onmessage?.(event);
+    mockWorkers.push(this);
   }
 
-  postMessage() {}
+  emit(data: unknown) {
+    this.onmessage?.({ data } as MessageEvent);
+  }
 
-  terminate() {}
+  fail() {
+    this.onerror?.({} as ErrorEvent);
+  }
 }
 
 const unsigned: UnsignedEvent = {
@@ -53,6 +60,13 @@ const unsigned: UnsignedEvent = {
   content: "test reply",
   created_at: 1,
   pubkey: "",
+};
+
+const minedEvent = {
+  ...unsigned,
+  id: "1".repeat(64),
+  pubkey: "f".repeat(64),
+  tags: [...unsigned.tags, ["nonce", "1", "1"]],
 };
 
 function Probe({ onState }: { onState: (state: ReturnType<typeof useSubmitForm>) => void }) {
@@ -75,7 +89,7 @@ describe("useSubmitForm", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
-    workerMessageHandler = null;
+    mockWorkers = [];
     mocks.appendKey.mockReset();
     mocks.publish.mockReset();
     vi.stubGlobal("Worker", MockWorker);
@@ -93,6 +107,12 @@ describe("useSubmitForm", () => {
     vi.unstubAllGlobals();
   });
 
+  async function submitForm() {
+    await act(async () => {
+      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+  }
+
   it("does not expose a posted event when no relay accepts the publish", async () => {
     mocks.publish.mockResolvedValue(new Set<string>());
 
@@ -100,18 +120,10 @@ describe("useSubmitForm", () => {
       root.render(<Probe onState={(nextState) => (state = nextState)} />);
     });
 
-    await act(async () => {
-      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
-    });
-
-    const minedEvent = {
-      ...unsigned,
-      pubkey: "f".repeat(64),
-      tags: [...unsigned.tags, ["nonce", "1", "1"]],
-    } as UnsignedEvent;
+    await submitForm();
 
     await act(async () => {
-      workerMessageHandler?.({ data: { found: true, event: minedEvent } } as MessageEvent);
+      mockWorkers[0].emit({ type: "found", event: minedEvent });
     });
 
     expect(mocks.publish).toHaveBeenCalledTimes(1);
@@ -129,18 +141,10 @@ describe("useSubmitForm", () => {
       root.render(<Probe onState={(nextState) => (state = nextState)} />);
     });
 
-    await act(async () => {
-      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
-    });
-
-    const minedEvent = {
-      ...unsigned,
-      pubkey: "f".repeat(64),
-      tags: [...unsigned.tags, ["nonce", "1", "1"]],
-    } as UnsignedEvent;
+    await submitForm();
 
     await act(async () => {
-      workerMessageHandler?.({ data: { found: true, event: minedEvent } } as MessageEvent);
+      mockWorkers[0].emit({ type: "found", event: minedEvent });
     });
 
     expect(mocks.publish).toHaveBeenCalledTimes(1);
@@ -158,18 +162,10 @@ describe("useSubmitForm", () => {
       root.render(<Probe onState={(nextState) => (state = nextState)} />);
     });
 
-    await act(async () => {
-      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
-    });
-
-    const minedEvent = {
-      ...unsigned,
-      pubkey: "f".repeat(64),
-      tags: [...unsigned.tags, ["nonce", "1", "1"]],
-    } as UnsignedEvent;
+    await submitForm();
 
     await act(async () => {
-      workerMessageHandler?.({ data: { found: true, event: minedEvent } } as MessageEvent);
+      mockWorkers[0].emit({ type: "found", event: minedEvent });
     });
 
     expect(mocks.publish).toHaveBeenCalledTimes(1);
@@ -178,5 +174,69 @@ describe("useSubmitForm", () => {
     expect(state.submitError).toMatch(/Publishing failed/);
     expect(state.acceptedRelays).toEqual([]);
     expect(mocks.appendKey).not.toHaveBeenCalled();
+  });
+
+  it("terminates active mining workers on unmount", async () => {
+    mocks.publish.mockResolvedValue(new Set<string>(["wss://relay.example"]));
+
+    act(() => {
+      root.render(<Probe onState={(nextState) => (state = nextState)} />);
+    });
+
+    await submitForm();
+
+    const worker = mockWorkers[0];
+
+    act(() => {
+      root.unmount();
+    });
+
+    await act(async () => {
+      worker.emit({ type: "found", event: minedEvent });
+    });
+
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(mocks.publish).not.toHaveBeenCalled();
+  });
+
+  it("ignores superseded mining work", async () => {
+    mocks.publish.mockResolvedValue(new Set<string>(["wss://relay.example"]));
+
+    act(() => {
+      root.render(<Probe onState={(nextState) => (state = nextState)} />);
+    });
+
+    await submitForm();
+    const firstWorker = mockWorkers[0];
+
+    await submitForm();
+    const secondWorker = mockWorkers[1];
+
+    await act(async () => {
+      firstWorker.emit({ type: "found", event: { ...minedEvent, content: "old" } });
+      secondWorker.emit({ type: "found", event: minedEvent });
+    });
+
+    expect(firstWorker.terminate).toHaveBeenCalledTimes(1);
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    expect((state.signedPoWEvent as Event | undefined)?.content).toBe("test reply");
+    expect(state.submitStatus).toBe("published");
+  });
+
+  it("reports mining worker failures", async () => {
+    act(() => {
+      root.render(<Probe onState={(nextState) => (state = nextState)} />);
+    });
+
+    await submitForm();
+
+    act(() => {
+      mockWorkers[0].fail();
+    });
+
+    expect(mocks.publish).not.toHaveBeenCalled();
+    expect(state.submitStatus).toBe("failed");
+    expect(state.submitError).toMatch(/Mining failed/);
+    expect(state.acceptedRelays).toEqual([]);
   });
 });

--- a/src/shared/hooks/useSubmitForm.ts
+++ b/src/shared/hooks/useSubmitForm.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import { generateSecretKey, getPublicKey, finalizeEvent, type UnsignedEvent, type Event } from "nostr-tools";
 import { publish } from "../../nostr/client";
 import { bytesToHex } from "@noble/hashes/utils";
@@ -14,74 +14,72 @@ export const useSubmitForm = (unsigned: UnsignedEvent, difficulty: string) => {
   const [acceptedRelays, setAcceptedRelays] = useState<string[]>([]);
   const [sk, setSk] = useState(generateSecretKey());
   const unsignedWithPubkey = { ...unsigned, pubkey: getPublicKey(sk) };
-  const [unsignedPoWEvent, setUnsignedPoWEvent] = useState<UnsignedEvent>();
   const [signedPoWEvent, setSignedPoWEvent] = useState<Event>();
+  const activeSubmitId = useRef(0);
 
   const numCores = navigator.hardwareConcurrency || 4;
-  const { startWork, messageFromWorker, hashrate, bestPow } = usePowMining(numCores, unsignedWithPubkey, difficulty);
+  const { startWork, hashrate, bestPow } = usePowMining(numCores, unsignedWithPubkey, difficulty);
   const doingWorkProp = submitStatus === "mining" || submitStatus === "publishing";
 
   useEffect(() => {
-    if (!unsignedPoWEvent) return;
-
-    let cancelled = false;
-
-    const publishMinedEvent = async () => {
-      setSubmitStatus("publishing");
-      setSubmitError(null);
-
-      try {
-        const signedEvent = finalizeEvent(unsignedPoWEvent, sk);
-        const accepted = await publish(signedEvent);
-        if (cancelled) return;
-
-        if (accepted.size === 0) {
-          setSubmitStatus("failed");
-          setSubmitError("No relay accepted the event. Your draft was not posted.");
-          setSignedPoWEvent(undefined);
-          setAcceptedRelays([]);
-          return;
-        }
-
-        setAcceptedRelays([...accepted]);
-        setSignedPoWEvent(signedEvent);
-        appendKey(bytesToHex(sk), getPublicKey(sk));
-        setSk(generateSecretKey());
-        setSubmitStatus("published");
-      } catch {
-        if (cancelled) return;
-        setSubmitStatus("failed");
-        setSubmitError("Publishing failed. Your draft was not posted.");
-        setSignedPoWEvent(undefined);
-        setAcceptedRelays([]);
-      } finally {
-        if (!cancelled) {
-          setUnsignedPoWEvent(undefined);
-        }
-      }
-    };
-
-    void publishMinedEvent();
-
     return () => {
-      cancelled = true;
+      activeSubmitId.current += 1;
     };
-  }, [appendKey, sk, unsignedPoWEvent]);
+  }, []);
 
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
+    const submitId = activeSubmitId.current + 1;
+    activeSubmitId.current = submitId;
     setSubmitStatus("mining");
     setSubmitError(null);
     setAcceptedRelays([]);
     setSignedPoWEvent(undefined);
-    startWork();
-  };
 
-  useEffect(() => {
-    if (messageFromWorker) {
-      setUnsignedPoWEvent(messageFromWorker);
-    }
-  }, [messageFromWorker]);
+    startWork({
+      onMined: async (minedEvent) => {
+        if (activeSubmitId.current !== submitId) return;
+
+        setSubmitStatus("publishing");
+        setSubmitError(null);
+
+        try {
+          const signedEvent = finalizeEvent(minedEvent, sk);
+          const accepted = await publish(signedEvent);
+          if (activeSubmitId.current !== submitId) return;
+
+          if (accepted.size === 0) {
+            setSubmitStatus("failed");
+            setSubmitError("No relay accepted the event. Your draft was not posted.");
+            setSignedPoWEvent(undefined);
+            setAcceptedRelays([]);
+            return;
+          }
+
+          setAcceptedRelays([...accepted]);
+          setSignedPoWEvent(signedEvent);
+          appendKey(bytesToHex(sk), getPublicKey(sk));
+          setSk(generateSecretKey());
+          setSubmitStatus("published");
+        } catch {
+          if (activeSubmitId.current !== submitId) return;
+
+          setSubmitStatus("failed");
+          setSubmitError("Publishing failed. Your draft was not posted.");
+          setSignedPoWEvent(undefined);
+          setAcceptedRelays([]);
+        }
+      },
+      onError: () => {
+        if (activeSubmitId.current !== submitId) return;
+
+        setSubmitStatus("failed");
+        setSubmitError("Mining failed. Your draft was not posted.");
+        setSignedPoWEvent(undefined);
+        setAcceptedRelays([]);
+      },
+    });
+  };
 
   return {
     handleSubmit,

--- a/src/workers/powWorker.ts
+++ b/src/workers/powWorker.ts
@@ -1,24 +1,42 @@
 import { type UnsignedEvent, type Event, getEventHash } from "nostr-tools";
 import { getPow } from "../shared/pow/core";
 
-const ctx: Worker = self as unknown as Worker;
+export type MinedPowEvent = UnsignedEvent & Pick<Event, "id">;
 
-ctx.addEventListener("message", (event) => {
+export type PowWorkerRequest = {
+  type: "mine";
+  unsigned: UnsignedEvent;
+  difficulty: number;
+  nonceStart: number;
+  nonceStep: number;
+};
+
+export type PowWorkerResponse =
+  | {
+      type: "progress";
+      currentNonce: number;
+      bestPow: number;
+    }
+  | {
+      type: "found";
+      event: MinedPowEvent;
+    };
+
+const ctx = self as DedicatedWorkerGlobalScope;
+
+ctx.addEventListener("message", (event: MessageEvent<PowWorkerRequest>) => {
+  if (event.data.type !== "mine") return;
+
   const { unsigned, difficulty, nonceStart, nonceStep } = event.data;
   const result = minePow(unsigned, difficulty, nonceStart, nonceStep);
   ctx.postMessage(result);
 });
 
-function minePow(
-  unsigned: UnsignedEvent,
-  difficulty: number,
-  nonceStart: number,
-  nonceStep: number,
-): { found: boolean; event?: Omit<Event, "sig">; status?: string; currentNonce?: number; bestPoW?: number } {
+function minePow(unsigned: UnsignedEvent, difficulty: number, nonceStart: number, nonceStep: number): PowWorkerResponse {
   let nonce = nonceStart;
   let bestPoW = 0;
 
-  const event = unsigned as Omit<Event, "sig">;
+  const event: MinedPowEvent = { ...unsigned, tags: [...unsigned.tags], id: "" };
   const tag = ["nonce", nonce.toString(), difficulty.toString()];
   event.tags.push(tag);
 
@@ -32,13 +50,13 @@ function minePow(
     }
 
     if (leadingZeroes >= difficulty) {
-      return { found: true, event };
+      return { type: "found", event };
     }
 
     nonce += nonceStep;
 
     if (nonce % (nonceStep * 10000) === 0) {
-      ctx.postMessage({ status: "progress", currentNonce: nonce, bestPoW });
+      ctx.postMessage({ type: "progress", currentNonce: nonce, bestPow: bestPoW } satisfies PowWorkerResponse);
     }
   }
 }


### PR DESCRIPTION
## Summary
- collapse submit mining handoff into a direct mined-event callback that publishes within the active submit transaction
- make usePowMining own worker cancellation/termination for unmounts, superseded jobs, found events, and worker failures
- define typed PoW worker request/response messages and update submit hook tests for success, failures, unmount cleanup, and superseded work

## Validation
- npm test -- --run src/shared/hooks/useSubmitForm.test.tsx (passes; existing React act environment warnings are printed)
- npm run typecheck (passes)
- npm run build (passes)

## Notes
- npm ci reports existing audit findings: 7 moderate, 7 high, 1 critical; no dependency changes were made.