### PR TITLE
Clean up poll shared UI boundary

### DIFF
--- a/src/shared/hooks/usePollResponder.ts
+++ b/src/shared/hooks/usePollResponder.ts
@@ -1,0 +1,102 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import type { Event } from "nostr-tools";
+import { subPoll } from "../../nostr/subscriptions";
+import {
+  buildPollResponseDraft,
+  getPollOptionResults,
+  type PollOptionResult,
+  type PollViewModel,
+} from "@lib/pollUtils";
+import { useSubmitForm } from "./useSubmitForm";
+
+export type PollResponderState = {
+  options: PollOptionResult[];
+  difficulty: string;
+  minDifficulty: string;
+  showResults: boolean;
+  selectedOptionId: string;
+  doingWork: boolean;
+  submitStatus: ReturnType<typeof useSubmitForm>["submitStatus"];
+  submitError: string | null;
+  acceptedRelayCount: number;
+  hashrate: number;
+  bestPow: number;
+  selectOption: (optionId: string) => void;
+  setDifficulty: (difficulty: string) => void;
+  revealResults: () => void;
+  submit: (event: FormEvent) => Promise<void>;
+};
+
+export function usePollResponder(poll: PollViewModel): PollResponderState {
+  const [difficulty, setDifficulty] = useState(poll.minDifficulty);
+  const [showResults, setShowResults] = useState(false);
+  const [voteEvents, setVoteEvents] = useState<Event[]>([]);
+  const [selectedOptionId, setSelectedOptionId] = useState("");
+
+  useEffect(() => {
+    setDifficulty(poll.minDifficulty);
+    setShowResults(false);
+    setVoteEvents([]);
+    setSelectedOptionId("");
+  }, [poll.id, poll.minDifficulty]);
+
+  useEffect(() => {
+    if (!showResults) return;
+
+    const subscription = subPoll(poll.id, (event) => {
+      setVoteEvents((prevEvents) => [...prevEvents, event]);
+    });
+
+    return () => subscription.close();
+  }, [poll.id, showResults]);
+
+  const submitEvent = useMemo(
+    () => buildPollResponseDraft(poll.id, selectedOptionId),
+    [poll.id, selectedOptionId],
+  );
+
+  const {
+    handleSubmit,
+    doingWorkProp,
+    submitStatus,
+    submitError,
+    acceptedRelays,
+    hashrate,
+    bestPow,
+    signedPoWEvent,
+  } = useSubmitForm(submitEvent, difficulty);
+
+  useEffect(() => {
+    if (!signedPoWEvent) return;
+
+    setSelectedOptionId("");
+  }, [signedPoWEvent]);
+
+  const options = useMemo(
+    () => getPollOptionResults(poll.options, voteEvents),
+    [poll.options, voteEvents],
+  );
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    await handleSubmit(event);
+  };
+
+  return {
+    options,
+    difficulty,
+    minDifficulty: poll.minDifficulty,
+    showResults,
+    selectedOptionId,
+    doingWork: doingWorkProp,
+    submitStatus,
+    submitError,
+    acceptedRelayCount: acceptedRelays.length,
+    hashrate,
+    bestPow,
+    selectOption: setSelectedOptionId,
+    setDifficulty,
+    revealResults: () => setShowResults(true),
+    submit,
+  };
+}

--- a/src/shared/lib/pollUtils.test.ts
+++ b/src/shared/lib/pollUtils.test.ts
@@ -1,0 +1,101 @@
+import type { Event } from "nostr-tools";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildPollResponseDraft,
+  getNoteBodyText,
+  getPollOptionResults,
+  getPollViewModel,
+  POLL_EVENT_KIND,
+  POLL_RESPONSE_KIND,
+} from "./pollUtils";
+
+const baseEvent = {
+  id: "poll-1",
+  pubkey: "pubkey",
+  created_at: 1,
+  sig: "sig",
+  content: "poll content",
+} as Event;
+
+describe("pollUtils", () => {
+  it("builds a poll view model from poll tags", () => {
+    const event = {
+      ...baseEvent,
+      kind: POLL_EVENT_KIND,
+      tags: [
+        ["label", "choose one"],
+        ["PoW", "12"],
+        ["option", "a", "Alpha"],
+        ["option", "b", "Beta"],
+        ["option", "a", "Duplicate Alpha"],
+        ["option", "missing-label"],
+      ],
+    } as Event;
+
+    expect(getPollViewModel(event)).toEqual({
+      id: "poll-1",
+      label: "choose one",
+      minDifficulty: "12",
+      options: [
+        { id: "a", label: "Duplicate Alpha" },
+        { id: "b", label: "Beta" },
+      ],
+    });
+  });
+
+  it("returns null for non-poll events", () => {
+    expect(getPollViewModel({ ...baseEvent, kind: 1, tags: [] } as Event)).toBeNull();
+  });
+
+  it("uses the poll label as body text when parsed content is empty", () => {
+    const event = {
+      ...baseEvent,
+      kind: POLL_EVENT_KIND,
+      content: "fallback content",
+      tags: [["label", "fallback label"]],
+    } as Event;
+
+    expect(getNoteBodyText(event, "   ")).toBe("fallback label");
+    expect(getNoteBodyText(event, "visible body")).toBe("visible body");
+  });
+
+  it("builds response drafts with the selected response tag only when selected", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+    expect(buildPollResponseDraft("poll-1", "")).toEqual({
+      kind: POLL_RESPONSE_KIND,
+      tags: [["client", "getwired.app"], ["e", "poll-1"]],
+      content: "",
+      created_at: 1767225600,
+      pubkey: "",
+    });
+
+    expect(buildPollResponseDraft("poll-1", "a").tags).toEqual([
+      ["client", "getwired.app"],
+      ["e", "poll-1"],
+      ["response", "a"],
+    ]);
+
+    vi.useRealTimers();
+  });
+
+  it("counts unique response events by option id", () => {
+    const options = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ];
+    const votes = [
+      { ...baseEvent, id: "vote-1", tags: [["response", "a"]] },
+      { ...baseEvent, id: "vote-1", tags: [["response", "a"]] },
+      { ...baseEvent, id: "vote-2", tags: [["response", "b"]] },
+      { ...baseEvent, id: "vote-3", tags: [["response", "unknown"]] },
+      { ...baseEvent, id: "vote-4", tags: [] },
+    ] as Event[];
+
+    expect(getPollOptionResults(options, votes)).toEqual([
+      { id: "a", label: "Alpha", voteCount: 1 },
+      { id: "b", label: "Beta", voteCount: 1 },
+    ]);
+  });
+});

--- a/src/shared/lib/pollUtils.ts
+++ b/src/shared/lib/pollUtils.ts
@@ -1,7 +1,27 @@
-import { Event } from "nostr-tools";
+import { Event, UnsignedEvent } from "nostr-tools";
 
-export function getPollOptions(event: Event): [string, string][] {
-  if (event.kind !== 1068) return [];
+export const POLL_EVENT_KIND = 1068;
+export const POLL_RESPONSE_KIND = 1018;
+export const POLL_CLIENT_TAG = ["client", "getwired.app"] as const;
+
+export type PollOption = {
+  id: string;
+  label: string;
+};
+
+export type PollViewModel = {
+  id: string;
+  label: string;
+  options: PollOption[];
+  minDifficulty: string;
+};
+
+export type PollOptionResult = PollOption & {
+  voteCount: number;
+};
+
+export function getPollOptions(event: Event): PollOption[] {
+  if (event.kind !== POLL_EVENT_KIND) return [];
 
   const uniqueOptions = new Map<string, string>();
   event.tags.forEach((tag) => {
@@ -10,13 +30,71 @@ export function getPollOptions(event: Event): [string, string][] {
     }
   });
 
-  return Array.from(uniqueOptions.entries());
+  return Array.from(uniqueOptions, ([id, label]) => ({ id, label }));
 }
 
 export function getPollLabel(event: Event): string {
   return event.tags.find((tag) => tag[0] === "label")?.[1] ?? event.content;
 }
 
+export function getPollMinDifficulty(event: Event): string {
+  return event.tags.find((tag) => tag[0] === "PoW")?.[1] || "0";
+}
+
+export function getPollViewModel(event: Event): PollViewModel | null {
+  if (event.kind !== POLL_EVENT_KIND) return null;
+
+  return {
+    id: event.id,
+    label: getPollLabel(event),
+    options: getPollOptions(event),
+    minDifficulty: getPollMinDifficulty(event),
+  };
+}
+
 export function getNoteBodyText(event: Event, comment: string): string {
-  return event.kind === 1068 ? comment.trim() || getPollLabel(event) : comment;
+  const poll = getPollViewModel(event);
+
+  return poll ? comment.trim() || poll.label : comment;
+}
+
+export function buildPollResponseDraft(pollId: string, selectedOptionId: string): UnsignedEvent {
+  const tags: string[][] = [[...POLL_CLIENT_TAG], ["e", pollId]];
+
+  if (selectedOptionId) {
+    tags.push(["response", selectedOptionId]);
+  }
+
+  return {
+    kind: POLL_RESPONSE_KIND,
+    tags,
+    content: "",
+    created_at: Math.floor(Date.now() / 1000),
+    pubkey: "",
+  };
+}
+
+export function getPollResponseOptionId(event: Event): string | null {
+  return event.tags.find((tag) => tag[0] === "response")?.[1] ?? null;
+}
+
+export function getPollOptionResults(options: PollOption[], voteEvents: Event[]): PollOptionResult[] {
+  const optionIds = new Set(options.map((option) => option.id));
+  const voteCounts = new Map(options.map((option) => [option.id, 0]));
+  const seenVoteIds = new Set<string>();
+
+  voteEvents.forEach((event) => {
+    if (seenVoteIds.has(event.id)) return;
+    seenVoteIds.add(event.id);
+
+    const optionId = getPollResponseOptionId(event);
+    if (!optionId || !optionIds.has(optionId)) return;
+
+    voteCounts.set(optionId, (voteCounts.get(optionId) ?? 0) + 1);
+  });
+
+  return options.map((option) => ({
+    ...option,
+    voteCount: voteCounts.get(option.id) ?? 0,
+  }));
 }

--- a/src/shared/ui/PollResponder.tsx
+++ b/src/shared/ui/PollResponder.tsx
@@ -1,137 +1,66 @@
-import { useState, useEffect, useMemo } from "react";
-import { Event, UnsignedEvent } from "nostr-tools";
-import { subPoll } from "../../nostr/subscriptions";
-import { verifyPow } from "../../shared/pow/core";
-import { uniqBy } from "@lib/collections";
-import { getPollOptions } from "@lib/pollUtils";
-import { useSubmitForm } from "../hooks/useSubmitForm";
+import type { PollViewModel } from "@lib/pollUtils";
+import { usePollResponder } from "../hooks/usePollResponder";
 import { Button } from "./Button";
 import { PowTransmitStatus } from "./PowTransmitStatus";
 import { SignalStepper } from "./SignalStepper";
 
-export function PollResponder({ eventdata }: { eventdata: Event }) {
-  const [options, setOptions] = useState<[string, string][]>(() => getPollOptions(eventdata));
-  const [difficulty, setDifficulty] = useState("0");
-  const [minDiff, setMinDiff] = useState("0");
-  const [showResults, setShowResults] = useState(false);
-  const [voteEvents, setVoteEvents] = useState<Event[]>([]);
-  const [unsigned, setUnsigned] = useState<UnsignedEvent>({
-    kind: 1018,
-    tags: [["client", "getwired.app"], ["e", eventdata.id]],
-    content: "",
-    created_at: Math.floor(Date.now() / 1000),
-    pubkey: "",
-  });
-  const [selectedOption, setSelectedOption] = useState<string>("");
-
-  useEffect(() => {
-    setOptions(getPollOptions(eventdata));
-
-    const pollMinDiff = eventdata.tags.find((t) => t[0] === "PoW")?.[1] || "0";
-    if (pollMinDiff !== "0") {
-      setDifficulty(pollMinDiff);
-      setMinDiff(pollMinDiff);
-    }
-
-    if (!showResults) return;
-
-    const onEvent = (event: Event) => {
-      setVoteEvents((prevEvents) => [...prevEvents, event]);
-    };
-
-    const subscription = subPoll(eventdata.id, onEvent);
-    return () => subscription.close();
-  }, [showResults, eventdata]);
-
-  const submitEvent = useMemo(
-    () =>
-      selectedOption
-        ? { ...unsigned, tags: [...unsigned.tags, ["response", selectedOption]] }
-        : unsigned,
-    [unsigned, selectedOption],
-  );
-
-  const uniqVoteEvents = uniqBy(voteEvents, "id");
-  const sortedVoteEvents = uniqVoteEvents.map((event) => {
-    const pow = verifyPow(event);
-    const responseTag = event.tags.find((tag) => tag[0] === "response");
-    const optionLabel = options.find((option) => option[0] === responseTag?.[1])?.[1] || "Unknown";
-    return { voteResponse: pow, optionLabel };
-  });
-
-  const {
-    handleSubmit: originalHandleSubmit,
-    doingWorkProp,
-    submitStatus,
-    submitError,
-    acceptedRelays,
-    hashrate,
-    bestPow,
-    signedPoWEvent,
-  } =
-    useSubmitForm(submitEvent, difficulty);
-
-  const handleSubmit = async (event: React.FormEvent) => {
-    event.preventDefault();
-    await originalHandleSubmit(event);
-  };
-
-  useEffect(() => {
-    if (!signedPoWEvent) return;
-
-    setUnsigned((prevUnsigned) => ({
-      ...prevUnsigned,
-      content: "",
-      created_at: Math.floor(Date.now() / 1000),
-      tags: [["client", "getwired.app"], ["e", eventdata.id]],
-    }));
-    setSelectedOption("");
-  }, [eventdata.id, signedPoWEvent]);
+export function PollResponder({ poll }: { poll: PollViewModel }) {
+  const responder = usePollResponder(poll);
 
   return (
-    <form name="post" method="post" encType="multipart/form-data" onSubmit={handleSubmit}>
+    <form name="post" method="post" encType="multipart/form-data" onSubmit={responder.submit}>
       <div className="flex flex-col items-start gap-3 mt-3">
-        {options.map((option) => {
-          const voteCount = sortedVoteEvents.filter((event) => event.optionLabel === option[1]).length;
-          const isSelected = selectedOption === option[0];
+        {responder.options.map((option) => {
+          const isSelected = responder.selectedOptionId === option.id;
 
           return (
-            <div key={option[0]} className="flex items-center gap-2">
+            <div key={option.id} className="flex items-center gap-2">
               <Button
                 type="button"
                 variant={isSelected ? "primary" : "ghost"}
                 size="sm"
-                onClick={() => setSelectedOption(option[0])}
+                onClick={() => responder.selectOption(option.id)}
                 className="whitespace-nowrap"
               >
-                {option[1]}
+                {option.label}
               </Button>
-              {showResults && (
-                <span className="text-meta text-muted">({voteCount})</span>
+              {responder.showResults && (
+                <span className="text-meta text-muted">({option.voteCount})</span>
               )}
             </div>
           );
         })}
         <div className="flex flex-wrap items-center gap-2">
-          <SignalStepper value={difficulty} onChange={setDifficulty} min={minDiff} />
-          <Button type="button" variant="ghost" size="sm" onClick={() => setShowResults(true)}>
+          <SignalStepper
+            value={responder.difficulty}
+            onChange={responder.setDifficulty}
+            min={responder.minDifficulty}
+          />
+          <Button type="button" variant="ghost" size="sm" onClick={responder.revealResults}>
             results
           </Button>
-          <Button type="submit" variant="primary" size="sm" disabled={doingWorkProp} loading={doingWorkProp}>
+          <Button
+            type="submit"
+            variant="primary"
+            size="sm"
+            disabled={responder.doingWork}
+            loading={responder.doingWork}
+          >
             transmit
           </Button>
         </div>
         <PowTransmitStatus
-          active={doingWorkProp}
-          difficulty={difficulty}
-          hashrate={hashrate}
-          bestPow={bestPow}
-          status={submitStatus}
+          active={responder.doingWork}
+          difficulty={responder.difficulty}
+          hashrate={responder.hashrate}
+          bestPow={responder.bestPow}
+          status={responder.submitStatus}
         />
-        {submitError && <p className="text-danger text-meta">{submitError}</p>}
-        {submitStatus === "published" && acceptedRelays.length > 0 && (
+        {responder.submitError && <p className="text-danger text-meta">{responder.submitError}</p>}
+        {responder.submitStatus === "published" && responder.acceptedRelayCount > 0 && (
           <p className="text-meta text-secondary">
-            posted to {acceptedRelays.length} relay{acceptedRelays.length === 1 ? "" : "s"}
+            posted to {responder.acceptedRelayCount} relay
+            {responder.acceptedRelayCount === 1 ? "" : "s"}
           </p>
         )}
       </div>

--- a/src/shared/ui/PollSummary.tsx
+++ b/src/shared/ui/PollSummary.tsx
@@ -1,17 +1,14 @@
-import { Event } from "nostr-tools";
-import { getPollOptions } from "@lib/pollUtils";
+import type { PollViewModel } from "@lib/pollUtils";
 
-export function PollSummary({ eventdata }: { eventdata: Event }) {
-  const options = getPollOptions(eventdata);
-
-  if (options.length === 0) return null;
+export function PollSummary({ poll }: { poll: PollViewModel }) {
+  if (poll.options.length === 0) return null;
 
   return (
     <div className="mt-2 flex flex-col gap-1">
       <ul className="flex flex-col gap-1">
-        {options.map(([id, text]) => (
-          <li key={id} className="text-meta text-muted">
-            · {text}
+        {poll.options.map((option) => (
+          <li key={option.id} className="text-meta text-muted">
+            · {option.label}
           </li>
         ))}
       </ul>

--- a/src/shared/ui/QuotePreview.tsx
+++ b/src/shared/ui/QuotePreview.tsx
@@ -1,7 +1,7 @@
 import { Event } from "nostr-tools";
 import { parseContent } from "@lib/content";
 import { getDisplayName } from "@lib/profile";
-import { getNoteBodyText } from "@lib/pollUtils";
+import { getNoteBodyText, getPollViewModel } from "@lib/pollUtils";
 import { useProfile } from "../hooks/useProfiles";
 import { AttachmentStack } from "./AttachmentStack";
 import { LinkedBodyText } from "./LinkedBodyText";
@@ -15,6 +15,7 @@ export function QuotePreview({ event }: { event: Event }) {
   const authorLabel = getDisplayName(profile, event.pubkey);
   const { comment, attachments } = parseContent(event);
   const bodyText = getNoteBodyText(event, comment);
+  const poll = getPollViewModel(event);
   const preview =
     bodyText.length > PREVIEW_LENGTH
       ? `${bodyText.slice(0, PREVIEW_LENGTH)}…`
@@ -44,7 +45,7 @@ export function QuotePreview({ event }: { event: Event }) {
           <AttachmentStack attachments={attachments} compact />
         </div>
       )}
-      {event.kind === 1068 && <PollSummary eventdata={event} />}
+      {poll && <PollSummary poll={poll} />}
     </div>
   );
 }

--- a/src/shared/ui/TextContent.tsx
+++ b/src/shared/ui/TextContent.tsx
@@ -1,7 +1,7 @@
 import { Event } from "nostr-tools";
 import { useState } from "react";
 import { parseContent } from "@lib/content";
-import { getNoteBodyText } from "@lib/pollUtils";
+import { getNoteBodyText, getPollViewModel } from "@lib/pollUtils";
 import { useQuotedEvents } from "../hooks/useQuotedEvents";
 import { AttachmentStack } from "./AttachmentStack";
 import { PollResponder } from "./PollResponder";
@@ -21,6 +21,7 @@ export function TextContent({
 }) {
   const { comment, attachments } = parseContent(eventdata);
   const bodyText = getNoteBodyText(eventdata, comment);
+  const poll = getPollViewModel(eventdata);
   const { quotedEvents, pendingRefs, failedRefs } = useQuotedEvents(eventdata);
   const [isExpanded, setIsExpanded] = useState(false);
   const displayedComment = isExpanded ? bodyText : bodyText.slice(0, COLLAPSED_LENGTH);
@@ -54,7 +55,7 @@ export function TextContent({
       {attachments.length > 0 && (
         <AttachmentStack attachments={attachments} imagePriority={imagePriority} />
       )}
-      {eventdata.kind === 1068 && <PollResponder eventdata={eventdata} />}
+      {poll && <PollResponder poll={poll} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- move poll response orchestration into a dedicated usePollResponder hook
- centralize poll kind/body/options/response/result helpers in pollUtils
- update shared poll UI components to render poll view models instead of branching on raw event kinds
- add focused pollUtils coverage for view model, body fallback, response draft, and vote counting behavior

## Validation
- npm test -- src/shared/lib/pollUtils.test.ts
- npm run typecheck
- npm run lint (passes with existing react-refresh warnings in src/app/providers.tsx and src/app/settings.tsx)
- npm test (passes; existing React act warnings from hook/UI tests)
- npm run build