### PR TITLE
Move thread seed cache behind thread boundary

### DIFF
--- a/src/features/compose/PostForm.tsx
+++ b/src/features/compose/PostForm.tsx
@@ -10,6 +10,7 @@ import { PowTransmitStatus } from "../../shared/ui/PowTransmitStatus";
 import { Input } from "../../shared/ui/Input";
 import { Textarea } from "../../shared/ui/Textarea";
 import { SignalStepper } from "../../shared/ui/SignalStepper";
+import { useThreadNavigation } from "../thread/useThreadNavigation";
 
 interface PostFormProps {
   refEvent?: NostrEvent;
@@ -18,6 +19,7 @@ interface PostFormProps {
 
 export function PostForm({ refEvent, tagType }: PostFormProps) {
   const { settings } = useSettings();
+  const openThread = useThreadNavigation();
   const [comment, setComment] = useState("");
   const [difficulty, setDifficulty] = useState(String(settings.difficulty));
   const [pollOptions, setPollOptions] = useState(["", ""]);
@@ -143,7 +145,9 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
             posted to {acceptedRelays.length} relay{acceptedRelays.length === 1 ? "" : "s"}
           </p>
         )}
-        {signedPoWEvent && <PostCard event={signedPoWEvent} replies={[]} />}
+        {signedPoWEvent && (
+          <PostCard event={signedPoWEvent} replies={[]} onOpenThread={openThread} />
+        )}
       </div>
     </form>
   );

--- a/src/features/feed/FeedPage.tsx
+++ b/src/features/feed/FeedPage.tsx
@@ -6,6 +6,7 @@ import { PostForm } from "../compose/PostForm";
 import { PostCard } from "../../shared/ui/PostCard";
 import { FeedSortToggle } from "./FeedSortToggle";
 import { ContentColumn, PageShell } from "../../shared/ui/PageShell";
+import { useThreadNavigation } from "../thread/useThreadNavigation";
 
 const SKIP_RESOLVE_COUNT = 3;
 const INITIAL_RESOLVE_COUNT = 20;
@@ -20,6 +21,7 @@ export default function FeedPage({ mode = "default" }: FeedPageProps) {
   const { settings, updateSettings } = useSettings();
   const { processedEvents } = useFeed({ mode });
   const visibleCount = useInfiniteScroll();
+  const openThread = useThreadNavigation();
   const [resolveWindowOpen, setResolveWindowOpen] = useState(true);
 
   useEffect(() => {
@@ -73,6 +75,7 @@ export default function FeedPage({ mode = "default" }: FeedPageProps) {
               fadeIn={shouldFadeIn}
               imagePriority={index < SKIP_RESOLVE_COUNT}
               avatarPriority={index < SKIP_RESOLVE_COUNT}
+              onOpenThread={openThread}
             />
           );
         })}

--- a/src/features/notifications/NotificationsPage.tsx
+++ b/src/features/notifications/NotificationsPage.tsx
@@ -4,10 +4,12 @@ import { Event } from "nostr-tools";
 import { useNotificationEvents } from "../../hooks/useNotificationEvents";
 import { SegmentedControl } from "../../shared/ui/SegmentedControl";
 import { PageShell } from "../../shared/ui/PageShell";
+import { useThreadNavigation } from "../thread/useThreadNavigation";
 
 export default function NotificationsPage() {
   const [notifsView, setNotifsView] = useState<"yours" | "mentions">("yours");
   const { noteEvents, pubkeys } = useNotificationEvents();
+  const openThread = useThreadNavigation();
 
   const postEvents = noteEvents.filter(
     (event) => event.kind !== 0 && pubkeys.includes(event.pubkey),
@@ -43,13 +45,23 @@ export default function NotificationsPage() {
         <div className={`grid grid-cols-1 gap-4 flex-grow ${notifsView === "mentions" ? "hidden sm:grid" : ""}`}>
           <span className="text-meta text-muted">your transmissions</span>
           {sortedEvents.map((event) => (
-            <PostCard key={event.id} event={event} replies={countReplies(event)} />
+            <PostCard
+              key={event.id}
+              event={event}
+              replies={countReplies(event)}
+              onOpenThread={openThread}
+            />
           ))}
         </div>
         <div className={`grid grid-cols-1 gap-4 flex-grow ${notifsView === "yours" ? "hidden sm:grid" : ""}`}>
           <span className="text-meta text-muted">mentions</span>
           {sortedMentions.map((event) => (
-            <PostCard key={event.id} event={event} replies={countReplies(event)} />
+            <PostCard
+              key={event.id}
+              event={event}
+              replies={countReplies(event)}
+              onOpenThread={openThread}
+            />
           ))}
         </div>
       </div>

--- a/src/features/thread/ThreadPage.tsx
+++ b/src/features/thread/ThreadPage.tsx
@@ -1,4 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
+import { useMemo } from "react";
 import { Event, nip19 } from "nostr-tools";
 import { getThreadDepth } from "@lib/getThreadDepth";
 import { Placeholder } from "../../shared/ui/Placeholder";
@@ -9,6 +10,8 @@ import { ThreadComposer } from "../compose/ThreadComposer";
 import { useInfiniteScroll } from "../../shared/hooks/useInfiniteScroll";
 import { useThreadViewModel } from "../../hooks/useThreadViewModel";
 import { eventWork } from "../../nostr/processing/pow-score";
+import { readThreadSeedEvents } from "./threadSeedCache";
+import { useThreadNavigation } from "./useThreadNavigation";
 
 function decodeNoteId(id: string | undefined): string | null {
   if (!id) return null;
@@ -22,6 +25,8 @@ function decodeNoteId(id: string | undefined): string | null {
 
 function ThreadView({ hexID }: { hexID: string }) {
   const visibleReplyEvents = useInfiniteScroll();
+  const seedEvents = useMemo(() => readThreadSeedEvents(hexID), [hexID]);
+  const openThread = useThreadNavigation();
   const {
     opEvent,
     earlierEvents,
@@ -30,7 +35,7 @@ function ThreadView({ hexID }: { hexID: string }) {
     showAllReplies,
     setShowAllReplies,
     uniqMentions,
-  } = useThreadViewModel(hexID);
+  } = useThreadViewModel(hexID, seedEvents);
   const directReplyEvents = replyEvents.filter((event) =>
     event.postEvent.tags.some((tag) => tag[0] === "e" && tag[1] === hexID),
   );
@@ -51,6 +56,7 @@ function ThreadView({ hexID }: { hexID: string }) {
               replies={uniqMentions.filter((e: Event) =>
                 e.tags.some((tag) => tag[0] === "e" && tag[1] === event.id),
               )}
+              onOpenThread={openThread}
             />
           ))}
           <PostCard
@@ -89,6 +95,7 @@ function ThreadView({ hexID }: { hexID: string }) {
                 totalWork={event.totalWork}
                 replyCount={event.threadReplyCount}
                 depth={getThreadDepth(event.postEvent, opEvent.id, eventsById)}
+                onOpenThread={openThread}
               />
             ))}
         </ContentColumn>

--- a/src/features/thread/threadSeedCache.test.ts
+++ b/src/features/thread/threadSeedCache.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Event } from "nostr-tools";
+import { readThreadSeedEvents, writeThreadSeedEvents } from "./threadSeedCache";
+
+function event(overrides: Partial<Event> = {}): Event {
+  return {
+    id: "1".repeat(64),
+    pubkey: "2".repeat(64),
+    created_at: 1,
+    kind: 1,
+    tags: [],
+    content: "hello",
+    sig: "3".repeat(128),
+    ...overrides,
+  };
+}
+
+describe("threadSeedCache", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("stores and reads seed events by thread id", () => {
+    const first = event({ id: "a".repeat(64) });
+    const second = event({ id: "b".repeat(64) });
+
+    writeThreadSeedEvents(first.id, [first]);
+    writeThreadSeedEvents(second.id, [second]);
+
+    expect(readThreadSeedEvents(first.id)).toEqual([first]);
+    expect(readThreadSeedEvents(second.id)).toEqual([second]);
+  });
+
+  it("ignores corrupted seed data", () => {
+    sessionStorage.setItem(`threadSeed:${"a".repeat(64)}`, "{not json");
+
+    expect(readThreadSeedEvents("a".repeat(64))).toEqual([]);
+  });
+
+  it("filters invalid event shapes", () => {
+    const valid = event({ id: "a".repeat(64) });
+    sessionStorage.setItem(
+      `threadSeed:${valid.id}`,
+      JSON.stringify({ events: [valid, { id: "missing-fields" }] }),
+    );
+
+    expect(readThreadSeedEvents(valid.id)).toEqual([valid]);
+  });
+});

--- a/src/features/thread/threadSeedCache.ts
+++ b/src/features/thread/threadSeedCache.ts
@@ -1,0 +1,66 @@
+import type { Event } from "nostr-tools";
+
+const THREAD_SEED_PREFIX = "threadSeed:";
+
+type ThreadSeed = {
+  events: Event[];
+};
+
+function storageKey(threadId: string): string {
+  return `${THREAD_SEED_PREFIX}${threadId}`;
+}
+
+function getSessionStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isEvent(value: unknown): value is Event {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<Event>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.pubkey === "string" &&
+    typeof candidate.created_at === "number" &&
+    typeof candidate.kind === "number" &&
+    Array.isArray(candidate.tags) &&
+    typeof candidate.content === "string" &&
+    typeof candidate.sig === "string"
+  );
+}
+
+function parseThreadSeed(value: string | null): Event[] {
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(value) as Partial<ThreadSeed>;
+    return Array.isArray(parsed.events) ? parsed.events.filter(isEvent) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function readThreadSeedEvents(threadId: string): Event[] {
+  return parseThreadSeed(getSessionStorage()?.getItem(storageKey(threadId)) ?? null);
+}
+
+export function writeThreadSeedEvents(threadId: string, events: Event[]): void {
+  const storage = getSessionStorage();
+  if (!storage) return;
+
+  const seed: ThreadSeed = {
+    events: events.filter(isEvent),
+  };
+
+  try {
+    storage.setItem(storageKey(threadId), JSON.stringify(seed));
+  } catch {
+    // Seed persistence is an optimization; navigation should still work.
+  }
+}

--- a/src/features/thread/useThreadNavigation.ts
+++ b/src/features/thread/useThreadNavigation.ts
@@ -1,0 +1,16 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { nip19, type Event } from "nostr-tools";
+import { writeThreadSeedEvents } from "./threadSeedCache";
+
+export function useThreadNavigation() {
+  const navigate = useNavigate();
+
+  return useCallback(
+    (event: Event, relatedEvents: Event[]) => {
+      writeThreadSeedEvents(event.id, relatedEvents);
+      navigate(`/thread/${nip19.noteEncode(event.id)}`);
+    },
+    [navigate],
+  );
+}

--- a/src/hooks/useThreadViewModel.ts
+++ b/src/hooks/useThreadViewModel.ts
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import type { Event } from "nostr-tools";
 import { subNotesOnce } from "../nostr/subscriptions";
 import { toProcessedEvents } from "../nostr/processEvents";
 import { uniqBy } from "@lib/collections";
@@ -7,15 +8,14 @@ import { useNostrSubscription } from "../shared/hooks/useNostrSubscription";
 import { useModerationManifest } from "../shared/hooks/useModerationManifest";
 import { filterModeratedEvents } from "../shared/lib/moderation";
 
-export function useThreadViewModel(hexID: string) {
+export function useThreadViewModel(hexID: string, seedEvents: Event[] = []) {
   const [showAllReplies, setShowAllReplies] = useState(true);
   const moderationManifest = useModerationManifest();
   const { noteEvents } = useThreadEvents(hexID);
 
   const allEvents = useMemo(() => {
-    const threadCache = JSON.parse(sessionStorage.getItem("cachedThread") || "[]");
-    return filterModeratedEvents([...noteEvents, ...threadCache], moderationManifest);
-  }, [noteEvents, moderationManifest]);
+    return filterModeratedEvents([...noteEvents, ...seedEvents], moderationManifest);
+  }, [noteEvents, seedEvents, moderationManifest]);
 
   const eventsById = useMemo(
     () => new Map(allEvents.map((event) => [event.id, event])),

--- a/src/shared/ui/PostCard.tsx
+++ b/src/shared/ui/PostCard.tsx
@@ -24,6 +24,7 @@ interface PostCardProps {
   avatarPriority?: boolean;
   totalWork?: number;
   replyCount?: number;
+  onOpenThread?: (event: Event, relatedEvents: Event[]) => void;
 }
 
 const depthClasses: Record<number, string> = {
@@ -51,6 +52,7 @@ export function PostCard({
   avatarPriority = false,
   totalWork,
   replyCount,
+  onOpenThread,
 }: PostCardProps) {
   const navigate = useNavigate();
 
@@ -64,9 +66,13 @@ export function PostCard({
   const isNavigable = role !== "threadOp";
 
   const handleNavigate = useCallback(() => {
-    sessionStorage.setItem("cachedThread", JSON.stringify(relatedEvents));
+    if (onOpenThread) {
+      onOpenThread(event, relatedEvents);
+      return;
+    }
+
     navigate(`/thread/${nip19.noteEncode(event.id)}`);
-  }, [relatedEvents, navigate, event.id]);
+  }, [event, onOpenThread, relatedEvents, navigate]);
 
   const roleClass = role === "threadContext" ? "opacity-70" : "";
 


### PR DESCRIPTION
## Summary
- remove hidden sessionStorage writes from shared PostCard
- add thread-owned seed cache and navigation hook keyed per thread id
- pass seed events into useThreadViewModel explicitly instead of reading storage inside the hook
- add focused tests for per-thread seed isolation and corrupted storage handling

## Validation
- npm test -- src/features/thread/threadSeedCache.test.ts
- npm run typecheck
- npm run build
- npm test
- npm run lint (passes with existing fast-refresh warnings in src/app/providers.tsx and src/app/settings.tsx)