### PR TITLE
Consolidate backend API handlers and feed cache

### DIFF
--- a/api/_shared/handlers.test.ts
+++ b/api/_shared/handlers.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleFeedBootstrapApi,
+  handleFeedRefreshApi,
+  handleUnfurlApi,
+} from "./handlers";
+import {
+  FeedBootstrapCacheService,
+  MemoryFeedBootstrapStore,
+} from "../../lib/feedBootstrapCache";
+import type { FeedBootstrapSnapshot } from "../../lib/feedSnapshot";
+
+const postEvent = {
+  id: "note-1",
+  pubkey: "pubkey",
+  created_at: 123,
+  kind: 1,
+  tags: [],
+  content: "hello",
+  sig: "sig",
+};
+
+const snapshot: FeedBootstrapSnapshot = {
+  fetchedAt: 123,
+  processedEvents: [{ postEvent, replies: [], totalWork: 1 }],
+  profiles: { pubkey: { name: "Ada" } },
+};
+
+describe("shared API handlers", () => {
+  it("rejects unsupported methods consistently", async () => {
+    await expect(handleUnfurlApi({ method: "POST" })).resolves.toMatchObject({
+      status: 405,
+      headers: { Allow: "GET" },
+      body: { error: "method not allowed" },
+    });
+  });
+
+  it("serves bootstrap snapshots through the cache service", async () => {
+    const service = new FeedBootstrapCacheService({
+      store: new MemoryFeedBootstrapStore(snapshot),
+    });
+
+    await expect(handleFeedBootstrapApi({ method: "GET" }, { service })).resolves.toMatchObject({
+      status: 200,
+      body: snapshot,
+    });
+  });
+
+  it("returns a refresh summary from the shared cache service", async () => {
+    const service = new FeedBootstrapCacheService({
+      store: new MemoryFeedBootstrapStore(),
+      fetchSnapshot: vi.fn().mockResolvedValue(snapshot),
+    });
+
+    await expect(handleFeedRefreshApi({ method: "GET" }, { service })).resolves.toMatchObject({
+      status: 200,
+      body: {
+        ok: true,
+        fetchedAt: 123,
+        postCount: 1,
+        profileCount: 1,
+      },
+    });
+  });
+});

--- a/api/_shared/handlers.ts
+++ b/api/_shared/handlers.ts
@@ -1,0 +1,132 @@
+import { normalizeUrl } from "../../lib/link.js";
+import {
+  getDefaultFeedBootstrapService,
+  type FeedBootstrapCacheService,
+} from "../../lib/feedBootstrapCache.js";
+import { unfurlUrl } from "../../lib/unfurl.js";
+
+const JSON_HEADERS = { "Content-Type": "application/json" };
+const UNFURL_CACHE_HEADER = "public, max-age=3600";
+export const FEED_BOOTSTRAP_CACHE_HEADER =
+  "public, s-maxage=120, stale-while-revalidate=300";
+
+export type ApiRequest = {
+  method?: string;
+  headers?: Record<string, string | string[] | undefined>;
+  query?: Record<string, string | string[] | undefined>;
+  url?: string;
+};
+
+export type ApiResult = {
+  status: number;
+  headers?: Record<string, string>;
+  body: unknown;
+};
+
+export type FeedApiOptions = {
+  service?: FeedBootstrapCacheService;
+};
+
+function json(status: number, body: unknown, headers: Record<string, string> = {}): ApiResult {
+  return {
+    status,
+    headers: { ...JSON_HEADERS, ...headers },
+    body,
+  };
+}
+
+function methodNotAllowed(): ApiResult {
+  return json(405, { error: "method not allowed" }, { Allow: "GET" });
+}
+
+function firstQueryValue(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) {
+    return value[0] ?? "";
+  }
+
+  return value ?? "";
+}
+
+function getQueryValue(req: ApiRequest, key: string): string {
+  if (req.query && key in req.query) {
+    return firstQueryValue(req.query[key]);
+  }
+
+  const requestUrl = new URL(req.url ?? "", "http://localhost");
+  return requestUrl.searchParams.get(key) ?? "";
+}
+
+function isAuthorized(req: ApiRequest): boolean {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return process.env.NODE_ENV !== "production";
+  }
+
+  const authorization = req.headers?.authorization;
+  return authorization === `Bearer ${cronSecret}`;
+}
+
+function refreshSummary(snapshot: Awaited<ReturnType<FeedBootstrapCacheService["refresh"]>>) {
+  return {
+    ok: true,
+    fetchedAt: snapshot.fetchedAt,
+    postCount: snapshot.processedEvents.length,
+    profileCount: Object.keys(snapshot.profiles).length,
+  };
+}
+
+export async function handleUnfurlApi(req: ApiRequest): Promise<ApiResult> {
+  if (req.method !== "GET") {
+    return methodNotAllowed();
+  }
+
+  const target = normalizeUrl(getQueryValue(req, "url"));
+  if (!target) {
+    return json(400, { error: "invalid url" });
+  }
+
+  const metadata = await unfurlUrl(target);
+  if (!metadata) {
+    return json(502, { error: "fetch failed" });
+  }
+
+  return json(200, metadata, { "Cache-Control": UNFURL_CACHE_HEADER });
+}
+
+export async function handleFeedBootstrapApi(
+  req: ApiRequest,
+  { service = getDefaultFeedBootstrapService() }: FeedApiOptions = {},
+): Promise<ApiResult> {
+  if (req.method !== "GET") {
+    return methodNotAllowed();
+  }
+
+  const snapshot = await service.get();
+  if (!snapshot) {
+    return json(503, {
+      error: "bootstrap unavailable",
+      lastRefreshError: service.getLastRefreshError(),
+    });
+  }
+
+  return json(200, snapshot, { "Cache-Control": FEED_BOOTSTRAP_CACHE_HEADER });
+}
+
+export async function handleFeedRefreshApi(
+  req: ApiRequest,
+  { service = getDefaultFeedBootstrapService() }: FeedApiOptions = {},
+): Promise<ApiResult> {
+  if (req.method !== "GET") {
+    return methodNotAllowed();
+  }
+
+  if (!isAuthorized(req)) {
+    return json(401, { error: "unauthorized" });
+  }
+
+  try {
+    return json(200, refreshSummary(await service.refresh()));
+  } catch {
+    return json(500, { error: service.getLastRefreshError() ?? "refresh failed" });
+  }
+}

--- a/api/_shared/node.ts
+++ b/api/_shared/node.ts
@@ -1,0 +1,45 @@
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http";
+import type { ApiRequest, ApiResult } from "./handlers.js";
+
+export function setCorsHeaders(res: ServerResponse): void {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+}
+
+export function toApiRequest(req: IncomingMessage): ApiRequest {
+  return {
+    method: req.method,
+    headers: normalizeHeaders(req.headers),
+    url: req.url,
+  };
+}
+
+export function writeJson(res: ServerResponse, result: ApiResult): void {
+  res.statusCode = result.status;
+
+  for (const [name, value] of Object.entries(result.headers ?? {})) {
+    res.setHeader(name, value);
+  }
+
+  res.end(JSON.stringify(result.body));
+}
+
+export function handleOptions(req: IncomingMessage, res: ServerResponse): boolean {
+  if (req.method !== "OPTIONS") {
+    return false;
+  }
+
+  res.statusCode = 204;
+  res.end();
+  return true;
+}
+
+function normalizeHeaders(headers: IncomingHttpHeaders): Record<string, string | string[] | undefined> {
+  return Object.fromEntries(
+    Object.entries(headers).filter((entry): entry is [string, string | string[]] => {
+      const [, value] = entry;
+      return typeof value === "string" || Array.isArray(value);
+    }),
+  );
+}

--- a/api/_shared/vercel.ts
+++ b/api/_shared/vercel.ts
@@ -1,0 +1,10 @@
+import type { VercelResponse } from "@vercel/node";
+import type { ApiResult } from "./handlers.js";
+
+export function sendJson(res: VercelResponse, result: ApiResult) {
+  for (const [name, value] of Object.entries(result.headers ?? {})) {
+    res.setHeader(name, value);
+  }
+
+  return res.status(result.status).json(result.body);
+}

--- a/api/cron/refresh-feed.ts
+++ b/api/cron/refresh-feed.ts
@@ -1,35 +1,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { refreshFeedBootstrapSnapshot } from "../../lib/feedBootstrapCache.js";
-
-function isAuthorized(req: VercelRequest): boolean {
-  const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret) {
-    return process.env.NODE_ENV !== "production";
-  }
-
-  return req.headers.authorization === `Bearer ${cronSecret}`;
-}
+import { handleFeedRefreshApi } from "../_shared/handlers.js";
+import { sendJson } from "../_shared/vercel.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  if (req.method !== "GET") {
-    res.setHeader("Allow", "GET");
-    return res.status(405).json({ error: "method not allowed" });
-  }
-
-  if (!isAuthorized(req)) {
-    return res.status(401).json({ error: "unauthorized" });
-  }
-
-  try {
-    const snapshot = await refreshFeedBootstrapSnapshot();
-    return res.status(200).json({
-      ok: true,
-      fetchedAt: snapshot.fetchedAt,
-      postCount: snapshot.processedEvents.length,
-      profileCount: Object.keys(snapshot.profiles).length,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "refresh failed";
-    return res.status(500).json({ error: message });
-  }
+  return sendJson(res, await handleFeedRefreshApi(req));
 }

--- a/api/feed/bootstrap.ts
+++ b/api/feed/bootstrap.ts
@@ -1,19 +1,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { getFeedBootstrapSnapshot } from "../../lib/feedBootstrapCache.js";
-
-const CACHE_HEADER = "public, s-maxage=120, stale-while-revalidate=300";
+import { handleFeedBootstrapApi } from "../_shared/handlers.js";
+import { sendJson } from "../_shared/vercel.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  if (req.method !== "GET") {
-    res.setHeader("Allow", "GET");
-    return res.status(405).json({ error: "method not allowed" });
-  }
-
-  const snapshot = await getFeedBootstrapSnapshot();
-  if (!snapshot) {
-    return res.status(503).json({ error: "bootstrap unavailable" });
-  }
-
-  res.setHeader("Cache-Control", CACHE_HEADER);
-  return res.status(200).json(snapshot);
+  return sendJson(res, await handleFeedBootstrapApi(req));
 }

--- a/api/unfurl.ts
+++ b/api/unfurl.ts
@@ -1,25 +1,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { normalizeUrl } from "../lib/link.js";
-import { unfurlUrl } from "../lib/unfurl.js";
+import { handleUnfurlApi } from "./_shared/handlers.js";
+import { sendJson } from "./_shared/vercel.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  if (req.method !== "GET") {
-    res.setHeader("Allow", "GET");
-    return res.status(405).json({ error: "method not allowed" });
-  }
-
-  const rawUrl = req.query.url;
-  const target = typeof rawUrl === "string" ? normalizeUrl(rawUrl) : "";
-
-  if (!target) {
-    return res.status(400).json({ error: "invalid url" });
-  }
-
-  const metadata = await unfurlUrl(target);
-  if (!metadata) {
-    return res.status(502).json({ error: "fetch failed" });
-  }
-
-  res.setHeader("Cache-Control", "public, max-age=3600");
-  return res.status(200).json(metadata);
+  return sendJson(res, await handleUnfurlApi(req));
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,12 @@ export default tseslint.config(
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2022,
+    },
+  },
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: 2022,
       globals: globals.browser,
     },
     plugins: {
@@ -20,6 +26,15 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+    },
+  },
+  {
+    files: ["api/**/*.ts", "lib/**/*.ts", "scripts/**/*.ts", "*.config.{js,ts}"],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
     },
   },
 );

--- a/lib/feedBootstrapCache.test.ts
+++ b/lib/feedBootstrapCache.test.ts
@@ -74,4 +74,20 @@ describe("getFeedBootstrapSnapshot", () => {
     await expect(getFeedBootstrapSnapshot()).resolves.toEqual(snapshot);
     expect(mocks.fetchFeedSnapshot).not.toHaveBeenCalled();
   });
+
+  it("de-dupes concurrent refreshes through the cache service", async () => {
+    const { FeedBootstrapCacheService, MemoryFeedBootstrapStore } = await loadCacheModule();
+    const fetchSnapshot = vi.fn().mockResolvedValue(snapshot);
+    const service = new FeedBootstrapCacheService({
+      store: new MemoryFeedBootstrapStore(),
+      fetchSnapshot,
+    });
+
+    await expect(Promise.all([service.refresh(), service.refresh()])).resolves.toEqual([
+      snapshot,
+      snapshot,
+    ]);
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+    await expect(service.read()).resolves.toEqual(snapshot);
+  });
 });

--- a/lib/feedBootstrapCache.ts
+++ b/lib/feedBootstrapCache.ts
@@ -1,4 +1,6 @@
 import { getCache } from "@vercel/functions";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 import {
   BOOTSTRAP_CACHE_KEY,
   BOOTSTRAP_CACHE_TAG,
@@ -6,63 +8,207 @@ import {
 } from "./feedBootstrap.js";
 import { fetchFeedSnapshot, type FeedBootstrapSnapshot } from "./feedSnapshot.js";
 
-let memorySnapshot: FeedBootstrapSnapshot | null = null;
+export type FeedBootstrapStore = {
+  read(): Promise<FeedBootstrapSnapshot | null>;
+  write(snapshot: FeedBootstrapSnapshot): Promise<void>;
+};
+
+function isFeedBootstrapSnapshot(value: unknown): value is FeedBootstrapSnapshot {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    typeof (value as FeedBootstrapSnapshot).fetchedAt === "number" &&
+    Array.isArray((value as FeedBootstrapSnapshot).processedEvents) &&
+    !!(value as FeedBootstrapSnapshot).profiles &&
+    typeof (value as FeedBootstrapSnapshot).profiles === "object"
+  );
+}
+
+export class MemoryFeedBootstrapStore implements FeedBootstrapStore {
+  private snapshot: FeedBootstrapSnapshot | null;
+
+  constructor(snapshot: FeedBootstrapSnapshot | null = null) {
+    this.snapshot = snapshot;
+  }
+
+  async read(): Promise<FeedBootstrapSnapshot | null> {
+    return this.snapshot;
+  }
+
+  async write(snapshot: FeedBootstrapSnapshot): Promise<void> {
+    this.snapshot = snapshot;
+  }
+}
+
+export class VercelFeedBootstrapStore implements FeedBootstrapStore {
+  async read(): Promise<FeedBootstrapSnapshot | null> {
+    try {
+      const cached = await getCache().get(BOOTSTRAP_CACHE_KEY);
+      return isFeedBootstrapSnapshot(cached) ? cached : null;
+    } catch {
+      // Runtime cache is unavailable outside Vercel.
+      return null;
+    }
+  }
+
+  async write(snapshot: FeedBootstrapSnapshot): Promise<void> {
+    try {
+      await getCache().set(BOOTSTRAP_CACHE_KEY, snapshot, {
+        ttl: BOOTSTRAP_CACHE_TTL_SECONDS,
+        tags: [BOOTSTRAP_CACHE_TAG],
+        name: "feed-bootstrap",
+      });
+    } catch {
+      // Runtime cache is unavailable outside Vercel.
+    }
+  }
+}
+
+export class FileFeedBootstrapStore implements FeedBootstrapStore {
+  constructor(private readonly cacheFile: string) {}
+
+  async read(): Promise<FeedBootstrapSnapshot | null> {
+    try {
+      const cached = JSON.parse(await readFile(this.cacheFile, "utf8")) as unknown;
+      return isFeedBootstrapSnapshot(cached) ? cached : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async write(snapshot: FeedBootstrapSnapshot): Promise<void> {
+    await mkdir(path.dirname(this.cacheFile), { recursive: true });
+    await writeFile(this.cacheFile, JSON.stringify(snapshot), "utf8");
+  }
+}
+
+export class CompositeFeedBootstrapStore implements FeedBootstrapStore {
+  constructor(private readonly stores: readonly FeedBootstrapStore[]) {}
+
+  async read(): Promise<FeedBootstrapSnapshot | null> {
+    for (const [index, store] of this.stores.entries()) {
+      const snapshot = await store.read();
+      if (snapshot) {
+        await Promise.all(
+          this.stores.slice(0, index).map((previousStore) => previousStore.write(snapshot)),
+        );
+        return snapshot;
+      }
+    }
+
+    return null;
+  }
+
+  async write(snapshot: FeedBootstrapSnapshot): Promise<void> {
+    await Promise.all(this.stores.map((store) => store.write(snapshot)));
+  }
+}
+
+export type FeedBootstrapCacheServiceOptions = {
+  store: FeedBootstrapStore;
+  fetchSnapshot?: () => Promise<FeedBootstrapSnapshot>;
+  allowRefreshOnRead?: () => boolean;
+};
+
+export class FeedBootstrapCacheService {
+  private refreshPromise: Promise<FeedBootstrapSnapshot> | null = null;
+  private lastRefreshError: string | null = null;
+
+  private readonly store: FeedBootstrapStore;
+  private readonly fetchSnapshot: () => Promise<FeedBootstrapSnapshot>;
+  private readonly allowRefreshOnRead: () => boolean;
+
+  constructor({
+    store,
+    fetchSnapshot: fetchSnapshotOption = fetchFeedSnapshot,
+    allowRefreshOnRead = () => process.env.NODE_ENV !== "production",
+  }: FeedBootstrapCacheServiceOptions) {
+    this.store = store;
+    this.fetchSnapshot = fetchSnapshotOption;
+    this.allowRefreshOnRead = allowRefreshOnRead;
+  }
+
+  isRefreshing(): boolean {
+    return !!this.refreshPromise;
+  }
+
+  getLastRefreshError(): string | null {
+    return this.lastRefreshError;
+  }
+
+  read(): Promise<FeedBootstrapSnapshot | null> {
+    return this.store.read();
+  }
+
+  write(snapshot: FeedBootstrapSnapshot): Promise<void> {
+    return this.store.write(snapshot);
+  }
+
+  refresh(): Promise<FeedBootstrapSnapshot> {
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+
+    this.refreshPromise = this.fetchSnapshot()
+      .then(async (snapshot) => {
+        await this.write(snapshot);
+        this.lastRefreshError = null;
+        return snapshot;
+      })
+      .catch((error: unknown) => {
+        this.lastRefreshError = error instanceof Error ? error.message : "refresh failed";
+        throw error;
+      })
+      .finally(() => {
+        this.refreshPromise = null;
+      });
+
+    return this.refreshPromise;
+  }
+
+  async get(): Promise<FeedBootstrapSnapshot | null> {
+    const cached = await this.read();
+    if (cached) {
+      return cached;
+    }
+
+    if (!this.allowRefreshOnRead()) {
+      return null;
+    }
+
+    try {
+      return await this.refresh();
+    } catch {
+      return null;
+    }
+  }
+}
+
+const defaultFeedBootstrapService = new FeedBootstrapCacheService({
+  store: new CompositeFeedBootstrapStore([
+    new MemoryFeedBootstrapStore(),
+    new VercelFeedBootstrapStore(),
+  ]),
+});
+
+export function getDefaultFeedBootstrapService(): FeedBootstrapCacheService {
+  return defaultFeedBootstrapService;
+}
 
 export async function readFeedBootstrapSnapshot(): Promise<FeedBootstrapSnapshot | null> {
-  if (memorySnapshot) {
-    return memorySnapshot;
-  }
-
-  try {
-    const cache = getCache();
-    const cached = await cache.get(BOOTSTRAP_CACHE_KEY);
-    if (cached && typeof cached === "object" && "processedEvents" in cached) {
-      memorySnapshot = cached as FeedBootstrapSnapshot;
-      return memorySnapshot;
-    }
-  } catch {
-    // Runtime cache is unavailable outside Vercel.
-  }
-
-  return null;
+  return defaultFeedBootstrapService.read();
 }
 
 export async function writeFeedBootstrapSnapshot(
   snapshot: FeedBootstrapSnapshot,
 ): Promise<void> {
-  memorySnapshot = snapshot;
-
-  try {
-    const cache = getCache();
-    await cache.set(BOOTSTRAP_CACHE_KEY, snapshot, {
-      ttl: BOOTSTRAP_CACHE_TTL_SECONDS,
-      tags: [BOOTSTRAP_CACHE_TAG],
-      name: "feed-bootstrap",
-    });
-  } catch {
-    // Runtime cache is unavailable outside Vercel.
-  }
+  return defaultFeedBootstrapService.write(snapshot);
 }
 
 export async function refreshFeedBootstrapSnapshot(): Promise<FeedBootstrapSnapshot> {
-  const snapshot = await fetchFeedSnapshot();
-  await writeFeedBootstrapSnapshot(snapshot);
-  return snapshot;
+  return defaultFeedBootstrapService.refresh();
 }
 
 export async function getFeedBootstrapSnapshot(): Promise<FeedBootstrapSnapshot | null> {
-  const cached = await readFeedBootstrapSnapshot();
-  if (cached) {
-    return cached;
-  }
-
-  if (process.env.NODE_ENV === "production") {
-    return null;
-  }
-
-  try {
-    return await refreshFeedBootstrapSnapshot();
-  } catch {
-    return null;
-  }
+  return defaultFeedBootstrapService.get();
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "snapshot:serve": "vite-node scripts/feed-snapshot-server.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "lint": "eslint src"
+    "lint": "eslint src lib/feedBootstrapCache.ts api scripts vite.config.ts eslint.config.js"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/scripts/feed-snapshot-server.ts
+++ b/scripts/feed-snapshot-server.ts
@@ -1,11 +1,22 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  fetchFeedSnapshot,
-  type FeedBootstrapSnapshot,
-} from "../lib/feedSnapshot.js";
+  handleFeedBootstrapApi,
+  handleFeedRefreshApi,
+} from "../api/_shared/handlers.js";
+import {
+  handleOptions,
+  setCorsHeaders,
+  toApiRequest,
+  writeJson,
+} from "../api/_shared/node.js";
+import {
+  CompositeFeedBootstrapStore,
+  FeedBootstrapCacheService,
+  FileFeedBootstrapStore,
+  MemoryFeedBootstrapStore,
+} from "../lib/feedBootstrapCache.js";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(dirname, "..");
@@ -18,123 +29,35 @@ const cacheFile = path.resolve(
   process.env.FEED_SNAPSHOT_CACHE_FILE ?? ".cache/feed-bootstrap.json",
 );
 
-let snapshot: FeedBootstrapSnapshot | null = null;
-let lastRefreshError: string | null = null;
-let refreshPromise: Promise<FeedBootstrapSnapshot> | null = null;
-
-function writeJson(res: ServerResponse, statusCode: number, body: unknown): void {
-  res.statusCode = statusCode;
-  res.setHeader("Content-Type", "application/json");
-  res.end(JSON.stringify(body));
-}
-
-function setCorsHeaders(res: ServerResponse): void {
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
-}
-
-async function loadSnapshotFromDisk(): Promise<void> {
-  try {
-    const raw = await readFile(cacheFile, "utf8");
-    const cached = JSON.parse(raw) as FeedBootstrapSnapshot;
-
-    if (
-      typeof cached.fetchedAt === "number" &&
-      Array.isArray(cached.processedEvents) &&
-      cached.profiles &&
-      typeof cached.profiles === "object"
-    ) {
-      snapshot = cached;
-    }
-  } catch {
-    // The cache is optional. The first refresh will populate it.
-  }
-}
-
-async function persistSnapshot(nextSnapshot: FeedBootstrapSnapshot): Promise<void> {
-  await mkdir(path.dirname(cacheFile), { recursive: true });
-  await writeFile(cacheFile, JSON.stringify(nextSnapshot), "utf8");
-}
-
-async function refreshSnapshot(): Promise<FeedBootstrapSnapshot> {
-  if (refreshPromise) {
-    return refreshPromise;
-  }
-
-  refreshPromise = fetchFeedSnapshot()
-    .then(async (nextSnapshot) => {
-      snapshot = nextSnapshot;
-      lastRefreshError = null;
-      await persistSnapshot(nextSnapshot);
-      return nextSnapshot;
-    })
-    .catch((error: unknown) => {
-      lastRefreshError = error instanceof Error ? error.message : "refresh failed";
-      throw error;
-    })
-    .finally(() => {
-      refreshPromise = null;
-    });
-
-  return refreshPromise;
-}
-
-function isAuthorized(req: IncomingMessage): boolean {
-  const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret) return true;
-
-  return req.headers.authorization === `Bearer ${cronSecret}`;
-}
+const service = new FeedBootstrapCacheService({
+  store: new CompositeFeedBootstrapStore([
+    new MemoryFeedBootstrapStore(),
+    new FileFeedBootstrapStore(cacheFile),
+  ]),
+  allowRefreshOnRead: () => true,
+});
 
 async function handleBootstrap(res: ServerResponse): Promise<void> {
-  setCorsHeaders(res);
-  res.setHeader("Cache-Control", "public, max-age=120, stale-while-revalidate=300");
-
-  if (snapshot) {
-    writeJson(res, 200, snapshot);
-    return;
-  }
-
-  try {
-    writeJson(res, 200, await refreshSnapshot());
-  } catch {
-    writeJson(res, 503, {
-      error: "bootstrap unavailable",
-      lastRefreshError,
-    });
-  }
+  writeJson(res, await handleFeedBootstrapApi({ method: "GET" }, { service }));
 }
 
 async function handleRefresh(req: IncomingMessage, res: ServerResponse): Promise<void> {
-  if (!isAuthorized(req)) {
-    writeJson(res, 401, { error: "unauthorized" });
-    return;
-  }
-
-  try {
-    const nextSnapshot = await refreshSnapshot();
-    writeJson(res, 200, {
-      ok: true,
-      fetchedAt: nextSnapshot.fetchedAt,
-      postCount: nextSnapshot.processedEvents.length,
-      profileCount: Object.keys(nextSnapshot.profiles).length,
-    });
-  } catch {
-    writeJson(res, 500, {
-      error: lastRefreshError ?? "refresh failed",
-    });
-  }
+  writeJson(res, await handleFeedRefreshApi(toApiRequest(req), { service }));
 }
 
-function handleHealth(res: ServerResponse): void {
-  writeJson(res, snapshot ? 200 : 503, {
-    ok: !!snapshot,
-    fetchedAt: snapshot?.fetchedAt ?? null,
-    postCount: snapshot?.processedEvents.length ?? 0,
-    profileCount: snapshot ? Object.keys(snapshot.profiles).length : 0,
-    refreshing: !!refreshPromise,
-    lastRefreshError,
+async function handleHealth(res: ServerResponse): Promise<void> {
+  const snapshot = await service.read();
+
+  writeJson(res, {
+    status: snapshot ? 200 : 503,
+    body: {
+      ok: !!snapshot,
+      fetchedAt: snapshot?.fetchedAt ?? null,
+      postCount: snapshot?.processedEvents.length ?? 0,
+      profileCount: snapshot ? Object.keys(snapshot.profiles).length : 0,
+      refreshing: service.isRefreshing(),
+      lastRefreshError: service.getLastRefreshError(),
+    },
   });
 }
 
@@ -143,15 +66,19 @@ const server = createServer((req, res) => {
 
   setCorsHeaders(res);
 
-  if (req.method === "OPTIONS") {
-    res.statusCode = 204;
-    res.end();
+  if (handleOptions(req, res)) {
     return;
   }
 
   if (req.method !== "GET") {
-    res.setHeader("Allow", "GET");
-    writeJson(res, 405, { error: "method not allowed" });
+    writeJson(res, {
+      status: 405,
+      headers: {
+        "Allow": "GET",
+        "Content-Type": "application/json",
+      },
+      body: { error: "method not allowed" },
+    });
     return;
   }
 
@@ -167,33 +94,37 @@ const server = createServer((req, res) => {
     }
 
     if (url.pathname === "/healthz") {
-      handleHealth(res);
+      await handleHealth(res);
       return;
     }
 
-    writeJson(res, 404, { error: "not found" });
+    writeJson(res, {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+      body: { error: "not found" },
+    });
   })();
 });
 
-await loadSnapshotFromDisk();
+const loadedSnapshot = await service.read();
 
 server.listen(port, host, () => {
   console.log(`feed snapshot server listening on http://${host}:${port}`);
-  if (snapshot) {
+  if (loadedSnapshot) {
     console.log(`loaded cached snapshot from ${cacheFile}`);
   }
 });
 
-void refreshSnapshot().catch(() => {
-  if (!snapshot) {
-    console.error(lastRefreshError ?? "initial refresh failed");
+void service.refresh().catch(() => {
+  if (!loadedSnapshot) {
+    console.error(service.getLastRefreshError() ?? "initial refresh failed");
   }
 });
 
 if (refreshSeconds > 0) {
   setInterval(() => {
-    void refreshSnapshot().catch(() => {
-      console.error(lastRefreshError ?? "scheduled refresh failed");
+    void service.refresh().catch(() => {
+      console.error(service.getLastRefreshError() ?? "scheduled refresh failed");
     });
   }, refreshSeconds * 1000).unref();
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,120 +2,38 @@ import path from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
-import { normalizeUrl } from "./lib/link";
-import { unfurlUrl } from "./lib/unfurl";
+import { handleOptions, setCorsHeaders, toApiRequest, writeJson } from "./api/_shared/node";
 
 function unfurlDevApi(): Plugin {
   return {
     name: "unfurl-dev-api",
     configureServer(server) {
-      const setSnapshotCorsHeaders = (res: ServerResponse) => {
-        res.setHeader("Access-Control-Allow-Origin", "*");
-        res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
-        res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-      };
-
       server.middlewares.use(
         "/api/unfurl",
-        async (req: IncomingMessage, res: ServerResponse, next) => {
-          if (req.method !== "GET") {
-            res.statusCode = 405;
-            res.setHeader("Allow", "GET");
-            res.end(JSON.stringify({ error: "method not allowed" }));
-            return;
-          }
-
-          const requestUrl = new URL(req.url ?? "", "http://localhost");
-          const target = normalizeUrl(requestUrl.searchParams.get("url") ?? "");
-
-          if (!target) {
-            res.statusCode = 400;
-            res.setHeader("Content-Type", "application/json");
-            res.end(JSON.stringify({ error: "invalid url" }));
-            return;
-          }
-
-          const metadata = await unfurlUrl(target);
-          res.setHeader("Content-Type", "application/json");
-
-          if (!metadata) {
-            res.statusCode = 502;
-            res.end(JSON.stringify({ error: "fetch failed" }));
-            return;
-          }
-
-          res.statusCode = 200;
-          res.setHeader("Cache-Control", "public, max-age=3600");
-          res.end(JSON.stringify(metadata));
+        async (req: IncomingMessage, res: ServerResponse) => {
+          const { handleUnfurlApi } = await import("./api/_shared/handlers");
+          writeJson(res, await handleUnfurlApi(toApiRequest(req)));
         },
       );
 
       server.middlewares.use(
         "/api/feed/bootstrap",
         async (req: IncomingMessage, res: ServerResponse) => {
-          setSnapshotCorsHeaders(res);
-
-          if (req.method === "OPTIONS") {
-            res.statusCode = 204;
-            res.end();
+          setCorsHeaders(res);
+          if (handleOptions(req, res)) {
             return;
           }
 
-          if (req.method !== "GET") {
-            res.statusCode = 405;
-            res.setHeader("Allow", "GET");
-            res.end(JSON.stringify({ error: "method not allowed" }));
-            return;
-          }
-
-          const { getFeedBootstrapSnapshot } = await import("./lib/feedBootstrapCache");
-          const snapshot = await getFeedBootstrapSnapshot();
-          res.setHeader("Content-Type", "application/json");
-
-          if (!snapshot) {
-            res.statusCode = 503;
-            res.end(JSON.stringify({ error: "bootstrap unavailable" }));
-            return;
-          }
-
-          res.statusCode = 200;
-          res.setHeader("Cache-Control", "public, s-maxage=120, stale-while-revalidate=300");
-          res.end(JSON.stringify(snapshot));
+          const { handleFeedBootstrapApi } = await import("./api/_shared/handlers");
+          writeJson(res, await handleFeedBootstrapApi(toApiRequest(req)));
         },
       );
 
       server.middlewares.use(
         "/api/cron/refresh-feed",
         async (req: IncomingMessage, res: ServerResponse) => {
-          if (req.method !== "GET") {
-            res.statusCode = 405;
-            res.setHeader("Allow", "GET");
-            res.end(JSON.stringify({ error: "method not allowed" }));
-            return;
-          }
-
-          res.setHeader("Content-Type", "application/json");
-
-          try {
-            const { refreshFeedBootstrapSnapshot } = await import("./lib/feedBootstrapCache");
-            const snapshot = await refreshFeedBootstrapSnapshot();
-            res.statusCode = 200;
-            res.end(
-              JSON.stringify({
-                ok: true,
-                fetchedAt: snapshot.fetchedAt,
-                postCount: snapshot.processedEvents.length,
-                profileCount: Object.keys(snapshot.profiles).length,
-              }),
-            );
-          } catch (error) {
-            res.statusCode = 500;
-            res.end(
-              JSON.stringify({
-                error: error instanceof Error ? error.message : "refresh failed",
-              }),
-            );
-          }
+          const { handleFeedRefreshApi } = await import("./api/_shared/handlers");
+          writeJson(res, await handleFeedRefreshApi(toApiRequest(req)));
         },
       );
     },


### PR DESCRIPTION
## Summary
- Added transport-neutral handlers for unfurl, feed bootstrap, and feed refresh, with thin Vercel/Node adapters.
- Consolidated feed bootstrap cache ownership behind a service/store boundary with memory, Vercel, file, and composite stores plus single-flight refresh de-dupe.
- Rewired Vercel API routes, Vite dev middleware, and the standalone feed snapshot server to share the same handler/cache behavior.
- Expanded lint coverage to owned backend/build surfaces and added focused handler/cache tests.

## Validation
- `npm run lint` - passes with existing Fast Refresh warnings in `src/app/providers.tsx` and `src/app/settings.tsx`.
- `npm test` - passes, 27 files / 120 tests. Existing React act warnings appear in hook/UI tests.
- `npm run build` - passes (`tsc --noEmit && vite build`).
- `git diff --check` - passes.

## Notes
- `npm ci` completed successfully but reported existing dependency audit findings: 15 vulnerabilities (7 moderate, 7 high, 1 critical). No dependency changes were made.
