### PR TITLE
Add confess client feature

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from "react-router-dom";
 import FeedPage from "../features/feed/FeedPage";
+import ConfessPage from "../features/confess/ConfessPage";
 import SettingsPage from "../features/settings/SettingsPage";
 import ThreadPage from "../features/thread/ThreadPage";
 import NotificationsPage from "../features/notifications/NotificationsPage";
@@ -10,6 +11,7 @@ export function AppRoutes() {
       <Route path="/settings" element={<SettingsPage />} />
       <Route path="/" element={<FeedPage />} />
       <Route path="/raw" element={<FeedPage mode="raw" />} />
+      <Route path="/confess" element={<ConfessPage />} />
       <Route path="/thread/:id" element={<ThreadPage />} />
       <Route path="/notifications" element={<NotificationsPage />} />
     </Routes>

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,3 +44,7 @@ export const QUOTE_FALLBACK_RELAYS = ENRICHMENT_RELAYS;
 export const THREAD_RELAYS = [
   ...new Set([...POW_RELAYS, ...ENRICHMENT_RELAYS]),
 ] as const;
+
+export const CONFESS_API_BASE = (import.meta.env.VITE_CONFESS_API_BASE || "")
+  .trim()
+  .replace(/\/+$/, "");

--- a/src/features/confess/ConfessPage.tsx
+++ b/src/features/confess/ConfessPage.tsx
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  finalizeEvent,
+  generateSecretKey,
+  getPublicKey,
+  nip19,
+  type Event,
+  type UnsignedEvent,
+} from "nostr-tools";
+import { ContentColumn, PageShell } from "../../shared/ui/PageShell";
+import { Button } from "../../shared/ui/Button";
+import { PowTransmitStatus } from "../../shared/ui/PowTransmitStatus";
+import { Textarea } from "../../shared/ui/Textarea";
+import { PostCard } from "../../shared/ui/PostCard";
+import { usePowMining } from "../../shared/hooks/usePowMining";
+import {
+  fetchConfessStatus,
+  submitConfession,
+  type ConfessStatus,
+  type ConfessSubmitResponse,
+} from "./api";
+
+const EMPTY_STATUS: ConfessStatus = {
+  configured: false,
+  day: "",
+  count: 0,
+  limit: 6,
+  remaining: 0,
+  minimumPow: 16,
+  closed: true,
+  nextResetAt: "",
+};
+
+function buildAdmissionEvent(content: string, pubkey: string): UnsignedEvent {
+  return {
+    kind: 1,
+    tags: [
+      ["client", "wired-confess"],
+      ["t", "confess"],
+    ],
+    content,
+    created_at: Math.floor(Date.now() / 1000),
+    pubkey,
+  };
+}
+
+export default function ConfessPage() {
+  const [comment, setComment] = useState("");
+  const [secretKey, setSecretKey] = useState(() => generateSecretKey());
+  const [status, setStatus] = useState<ConfessStatus>(EMPTY_STATUS);
+  const [submitStatus, setSubmitStatus] = useState<
+    "idle" | "loading" | "mining" | "publishing" | "published" | "failed"
+  >("loading");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [posted, setPosted] = useState<ConfessSubmitResponse | null>(null);
+
+  const difficulty = String(status.minimumPow);
+  const pubkey = useMemo(() => getPublicKey(secretKey), [secretKey]);
+  const unsigned = useMemo(
+    () => buildAdmissionEvent(comment.trim(), pubkey),
+    [comment, pubkey],
+  );
+  const {
+    startWork,
+    messageFromWorker,
+    hashrate,
+    bestPow,
+  } = usePowMining(navigator.hardwareConcurrency || 4, unsigned, difficulty);
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const nextStatus = await fetchConfessStatus();
+      setStatus(nextStatus);
+      setSubmitStatus((current) => (current === "loading" ? "idle" : current));
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : "status unavailable");
+      setSubmitStatus("failed");
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadStatus();
+  }, [loadStatus]);
+
+  useEffect(() => {
+    if (!messageFromWorker || submitStatus !== "mining") return;
+
+    let cancelled = false;
+
+    const publishConfession = async () => {
+      setSubmitStatus("publishing");
+      setSubmitError(null);
+
+      try {
+        const admissionEvent = finalizeEvent(messageFromWorker, secretKey) as Event;
+        const result = await submitConfession(admissionEvent);
+        if (cancelled) return;
+
+        setPosted(result);
+        setComment("");
+        setSecretKey(generateSecretKey());
+        setStatus((current) => ({
+          ...current,
+          count: result.count,
+          remaining: result.remaining,
+          minimumPow: result.minimumPow,
+          closed: result.remaining <= 0,
+          nextResetAt: result.nextResetAt,
+        }));
+        setSubmitStatus("published");
+      } catch (error) {
+        if (cancelled) return;
+        setSubmitError(error instanceof Error ? error.message : "confess failed");
+        setSubmitStatus("failed");
+        void loadStatus();
+      }
+    };
+
+    void publishConfession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadStatus, messageFromWorker, secretKey, submitStatus]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setPosted(null);
+    setSubmitError(null);
+
+    if (!comment.trim() || status.closed || !status.configured) return;
+
+    setSubmitStatus("mining");
+    startWork();
+  };
+
+  const doingWork = submitStatus === "mining" || submitStatus === "publishing";
+  const isUnavailable = !status.configured || status.closed || submitStatus === "loading";
+  const noteLink = posted ? nip19.noteEncode(posted.event.id) : "";
+
+  return (
+    <PageShell>
+      <ContentColumn className="pt-6">
+        <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+          <div className="flex items-center justify-between gap-4 border-b border-ghost pb-3">
+            <div>
+              <h1 className="text-display font-medium">confess</h1>
+              <p className="text-meta text-secondary">
+                minimum signal {status.minimumPow} · {status.remaining}/{status.limit} today
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => void loadStatus()}
+              disabled={doingWork}
+            >
+              refresh
+            </Button>
+          </div>
+
+          <Textarea
+            name="confession"
+            variant="compose"
+            value={comment}
+            onChange={(event) => {
+              setComment(event.target.value);
+              event.target.style.height = "auto";
+              event.target.style.height = `${event.target.scrollHeight}px`;
+            }}
+            rows={Math.max(4, comment.split("\n").length)}
+            maxLength={2000}
+            required
+            disabled={doingWork || isUnavailable}
+          />
+
+          <div className="flex min-h-14 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-meta text-secondary">
+              {status.closed
+                ? "daily cap reached"
+                : status.configured
+                  ? `server will accept signal ${status.minimumPow}+`
+                  : "confess account is not configured"}
+            </p>
+            <Button
+              type="submit"
+              variant="primary"
+              size="sm"
+              disabled={doingWork || isUnavailable || !comment.trim()}
+              loading={doingWork}
+            >
+              post
+            </Button>
+          </div>
+
+          <PowTransmitStatus
+            active={doingWork}
+            difficulty={difficulty}
+            hashrate={hashrate}
+            bestPow={bestPow}
+            status={submitStatus === "loading" ? "idle" : submitStatus}
+            className="text-right"
+          />
+
+          {submitError && <p className="text-meta text-danger text-right">{submitError}</p>}
+          {posted && (
+            <p className="text-meta text-secondary text-right">
+              posted to {posted.acceptedRelays.length} relay
+              {posted.acceptedRelays.length === 1 ? "" : "s"} · {noteLink}
+            </p>
+          )}
+        </form>
+
+        {posted && <PostCard event={posted.event} replies={[]} />}
+      </ContentColumn>
+    </PageShell>
+  );
+}

--- a/src/features/confess/ConfessPage.tsx
+++ b/src/features/confess/ConfessPage.tsx
@@ -31,6 +31,13 @@ const EMPTY_STATUS: ConfessStatus = {
   nextResetAt: "",
 };
 
+const disallowedContentPattern =
+  /\b(?:(?:https?|wss?|ftp|ipfs):\/\/|(?:magnet|nostr):|www\.)[^\s<>"')\]]+|\b[a-z0-9.-]+\.(?:app|band|biz|blog|cloud|co|com|dev|fm|gg|info|io|is|land|link|lol|me|media|net|news|online|onion|org|site|social|to|tv|wine|xyz)(?:\/[^\s<>"')\]]*)?|\b[^\s<>"')\]]+\.(?:avif|gif|jpe?g|m4a|mov|mp3|mp4|ogg|png|svg|wav|webm|webp)(?:\?[^\s<>"')\]]*)?/i;
+
+function hasDisallowedContent(content: string): boolean {
+  return disallowedContentPattern.test(content);
+}
+
 function buildAdmissionEvent(content: string, pubkey: string): UnsignedEvent {
   return {
     kind: 1,
@@ -55,6 +62,9 @@ export default function ConfessPage() {
   const [posted, setPosted] = useState<ConfessSubmitResponse | null>(null);
 
   const difficulty = String(status.minimumPow);
+  const contentError = hasDisallowedContent(comment)
+    ? "links and media are not allowed"
+    : null;
   const pubkey = useMemo(() => getPublicKey(secretKey), [secretKey]);
   const unsigned = useMemo(
     () => buildAdmissionEvent(comment.trim(), pubkey),
@@ -128,7 +138,7 @@ export default function ConfessPage() {
     setPosted(null);
     setSubmitError(null);
 
-    if (!comment.trim() || status.closed || !status.configured) return;
+    if (!comment.trim() || contentError || status.closed || !status.configured) return;
 
     setSubmitStatus("mining");
     startWork();
@@ -173,6 +183,7 @@ export default function ConfessPage() {
             maxLength={2000}
             required
             disabled={doingWork || isUnavailable}
+            aria-invalid={contentError ? true : undefined}
           />
 
           <div className="flex min-h-14 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -187,7 +198,7 @@ export default function ConfessPage() {
               type="submit"
               variant="primary"
               size="sm"
-              disabled={doingWork || isUnavailable || !comment.trim()}
+              disabled={doingWork || isUnavailable || !comment.trim() || Boolean(contentError)}
               loading={doingWork}
             >
               post
@@ -204,6 +215,9 @@ export default function ConfessPage() {
           />
 
           {submitError && <p className="text-meta text-danger text-right">{submitError}</p>}
+          {contentError && !submitError && (
+            <p className="text-meta text-danger text-right">{contentError}</p>
+          )}
           {posted && (
             <p className="text-meta text-secondary text-right">
               posted to {posted.acceptedRelays.length} relay

--- a/src/features/confess/api.ts
+++ b/src/features/confess/api.ts
@@ -1,0 +1,55 @@
+import type { Event } from "nostr-tools";
+import { CONFESS_API_BASE } from "../../config";
+
+export type ConfessStatus = {
+  configured: boolean;
+  day: string;
+  count: number;
+  limit: number;
+  remaining: number;
+  minimumPow: number;
+  closed: boolean;
+  nextResetAt: string;
+};
+
+export type ConfessSubmitResponse = {
+  ok: true;
+  event: Event;
+  acceptedRelays: string[];
+  count: number;
+  remaining: number;
+  minimumPow: number;
+  nextResetAt: string;
+};
+
+function confessUrl(path: string): string {
+  return `${CONFESS_API_BASE}${path}`;
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const message =
+      typeof data?.error === "string" ? data.error : `HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return data as T;
+}
+
+export async function fetchConfessStatus(): Promise<ConfessStatus> {
+  const response = await fetch(confessUrl("/api/confess/status"), {
+    cache: "no-store",
+  });
+  return readJson<ConfessStatus>(response);
+}
+
+export async function submitConfession(event: Event): Promise<ConfessSubmitResponse> {
+  const response = await fetch(confessUrl("/api/confess"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ event }),
+  });
+  return readJson<ConfessSubmitResponse>(response);
+}

--- a/src/shared/hooks/usePowMining.ts
+++ b/src/shared/hooks/usePowMining.ts
@@ -7,6 +7,10 @@ export function usePowMining(numCores: number, unsigned: UnsignedEvent, difficul
   const [bestPow, setBestPow] = useState(0);
 
   const startWork = () => {
+    setMessageFromWorker(null);
+    setHashrate(0);
+    setBestPow(0);
+
     const startTime = Date.now();
     const workers = Array(numCores)
       .fill(null)
@@ -16,9 +20,7 @@ export function usePowMining(numCores: number, unsigned: UnsignedEvent, difficul
       worker.onmessage = (event) => {
         if (event.data.status === "progress") {
           setHashrate(Math.floor(event.data.currentNonce / ((Date.now() - startTime) / 1000)));
-          if (event.data.bestPoW > bestPow) {
-            setBestPow(event.data.bestPoW);
-          }
+          setBestPow((current) => Math.max(current, event.data.bestPoW));
         } else if (event.data.found) {
           setMessageFromWorker(event.data.event);
           workers.forEach((w) => w.terminate());

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -56,6 +56,11 @@ export function Header() {
             isActive={pathname === "/notifications"}
           />
           <NavLink
+            to="/confess"
+            label="confess"
+            isActive={pathname === "/confess"}
+          />
+          <NavLink
             to="/settings"
             label="settings"
             isActive={pathname === "/settings"}

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -5,10 +5,12 @@ function NavLink({
   to,
   label,
   isActive,
+  signalGlow = false,
 }: {
   to: string;
   label: string;
   isActive: boolean;
+  signalGlow?: boolean;
 }) {
   return (
     <Link
@@ -18,7 +20,9 @@ function NavLink({
         "text-meta transition-colors duration-hover border-b-2 pb-0.5",
         isActive
           ? "text-signal font-medium border-signal"
-          : "text-secondary border-transparent hover:text-primary",
+          : signalGlow
+            ? "text-signal border-transparent drop-shadow-[0_0_6px_var(--signal-dim)] hover:text-primary"
+            : "text-secondary border-transparent hover:text-primary",
       ].join(" ")}
     >
       {label}
@@ -51,14 +55,15 @@ export function Header() {
         </Link>
         <nav className="flex shrink-0 gap-4" aria-label="Primary navigation">
           <NavLink
-            to="/notifications"
-            label="activity"
-            isActive={pathname === "/notifications"}
-          />
-          <NavLink
             to="/confess"
             label="confess"
             isActive={pathname === "/confess"}
+            signalGlow
+          />
+          <NavLink
+            to="/notifications"
+            label="activity"
+            isActive={pathname === "/notifications"}
           />
           <NavLink
             to="/settings"

--- a/src/shared/ui/routeLabelMap.test.ts
+++ b/src/shared/ui/routeLabelMap.test.ts
@@ -4,6 +4,7 @@ import { getDisplaySegment, getPathDisplay } from "./routeLabelMap";
 describe("routeLabelMap", () => {
   it("maps known routes to display segments", () => {
     expect(getDisplaySegment("/")).toBe("");
+    expect(getDisplaySegment("/confess")).toBe("confess");
     expect(getDisplaySegment("/notifications")).toBe("activity");
     expect(getDisplaySegment("/raw")).toBe("raw");
     expect(getDisplaySegment("/settings")).toBe("settings");
@@ -12,6 +13,7 @@ describe("routeLabelMap", () => {
 
   it("builds path display labels", () => {
     expect(getPathDisplay("/")).toBe("/");
+    expect(getPathDisplay("/confess")).toBe("/confess");
     expect(getPathDisplay("/notifications")).toBe("/activity");
     expect(getPathDisplay("/raw")).toBe("/raw");
     expect(getPathDisplay("/settings")).toBe("/settings");

--- a/src/shared/ui/routeLabelMap.ts
+++ b/src/shared/ui/routeLabelMap.ts
@@ -1,5 +1,6 @@
 const ROUTE_LABEL_MAP: Record<string, string> = {
   "/": "",
+  "/confess": "confess",
   "/notifications": "activity",
   "/raw": "raw",
   "/settings": "settings",


### PR DESCRIPTION
## Summary
- add a /confess route and header navigation item
- add a single-panel confess composer that displays backend PoW requirements
- mine a client PoW admission event and submit it to wired-admin instead of publishing directly

## Tests
- npm test
- npm run build