### PR TITLE
Fix confess NIP-13 submission flow

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { configuredRelays } from "./config";
+import { DEFAULT_RELAYS, configuredRelays } from "./config";
+
+describe("DEFAULT_RELAYS", () => {
+  it("includes the Wired relay in the main feed relay list", () => {
+    expect(DEFAULT_RELAYS).toContain("wss://relay.wiredsignal.online");
+  });
+});
 
 describe("configuredRelays", () => {
   it("uses fallback relays when env is unset", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_DIFFICULTY = 16;
 
 export const DEFAULT_RELAYS = [
+  "wss://relay.wiredsignal.online",
   "wss://powrelay.xyz",
   "wss://pow.relays.land",
 ] as const;

--- a/src/features/confess/ConfessPage.test.tsx
+++ b/src/features/confess/ConfessPage.test.tsx
@@ -2,10 +2,10 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import type { Event as NostrEvent, UnsignedEvent } from "nostr-tools";
+import type { Event as NostrEvent } from "nostr-tools";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import ConfessPage from "./ConfessPage";
-import type { ConfessStatus, ConfessSubmitResponse } from "./api";
+import type { ConfessAdmissionEvent, ConfessStatus, ConfessSubmitResponse } from "./api";
 
 type ReactActGlobal = typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
 
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   submitConfession: vi.fn(),
   startWork: vi.fn(),
   powState: {
-    messageFromWorker: undefined as UnsignedEvent | undefined,
+    messageFromWorker: undefined as ConfessAdmissionEvent | undefined,
     hashrate: 0,
     bestPow: 0,
   },
@@ -24,14 +24,6 @@ vi.mock("nostr-tools", async (importOriginal) => {
   const actual = await importOriginal<typeof import("nostr-tools")>();
   return {
     ...actual,
-    generateSecretKey: () => new Uint8Array(32).fill(1),
-    getPublicKey: () => "f".repeat(64),
-    finalizeEvent: (event: UnsignedEvent) => ({
-      ...event,
-      id: "1".repeat(64),
-      pubkey: "f".repeat(64),
-      sig: "2".repeat(128),
-    }),
   };
 });
 
@@ -55,6 +47,7 @@ vi.mock("./api", () => ({
 
 const openStatus: ConfessStatus = {
   configured: true,
+  pubkey: "f".repeat(64),
   day: "2026-06-30",
   count: 0,
   limit: 6,
@@ -166,6 +159,7 @@ describe("ConfessPage", () => {
     expect(container.textContent).toContain("computing signal");
 
     mocks.powState.messageFromWorker = {
+      id: postedEvent.id,
       kind: postedEvent.kind,
       pubkey: postedEvent.pubkey,
       created_at: postedEvent.created_at,
@@ -179,6 +173,15 @@ describe("ConfessPage", () => {
     });
 
     expect(mocks.submitConfession).toHaveBeenCalledTimes(1);
+    expect(mocks.submitConfession).toHaveBeenCalledWith({
+      id: postedEvent.id,
+      kind: postedEvent.kind,
+      pubkey: openStatus.pubkey,
+      created_at: postedEvent.created_at,
+      tags: [...postedEvent.tags, ["nonce", "1", "1"]],
+      content: postedEvent.content,
+    });
+    expect(mocks.submitConfession.mock.calls[0][0]).not.toHaveProperty("sig");
     expect(container.textContent).toContain("submitting to wired backend...");
     expect(container.textContent).not.toContain("publishing to relays");
 

--- a/src/features/confess/ConfessPage.tsx
+++ b/src/features/confess/ConfessPage.tsx
@@ -1,9 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  finalizeEvent,
-  generateSecretKey,
-  getPublicKey,
-  type Event,
   type UnsignedEvent,
 } from "nostr-tools";
 import { ContentColumn, PageShell } from "../../shared/ui/PageShell";
@@ -16,12 +12,14 @@ import { encodeThreadRef } from "@lib/threadRefs";
 import {
   fetchConfessStatus,
   submitConfession,
+  type ConfessAdmissionEvent,
   type ConfessStatus,
   type ConfessSubmitResponse,
 } from "./api";
 
 const EMPTY_STATUS: ConfessStatus = {
   configured: false,
+  pubkey: "",
   day: "",
   count: 0,
   limit: 6,
@@ -61,21 +59,19 @@ function buildAdmissionEvent(content: string, pubkey: string): UnsignedEvent {
 
 export default function ConfessPage() {
   const [comment, setComment] = useState("");
-  const [secretKey, setSecretKey] = useState(() => generateSecretKey());
   const [status, setStatus] = useState<ConfessStatus>(EMPTY_STATUS);
   const [submitStatus, setSubmitStatus] = useState<ConfessSubmitStatus>("loading");
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [posted, setPosted] = useState<ConfessSubmitResponse | null>(null);
-  const [minedEvent, setMinedEvent] = useState<UnsignedEvent>();
+  const [minedEvent, setMinedEvent] = useState<ConfessAdmissionEvent>();
 
   const difficulty = String(status.minimumPow);
   const contentError = hasDisallowedContent(comment)
     ? "links and media are not allowed"
     : null;
-  const pubkey = useMemo(() => getPublicKey(secretKey), [secretKey]);
   const unsigned = useMemo(
-    () => buildAdmissionEvent(comment.trim(), pubkey),
-    [comment, pubkey],
+    () => buildAdmissionEvent(comment.trim(), status.pubkey),
+    [comment, status.pubkey],
   );
   const {
     startWork,
@@ -115,15 +111,14 @@ export default function ConfessPage() {
       setSubmitError(null);
 
       try {
-        const admissionEvent = finalizeEvent(minedEvent, secretKey) as Event;
-        const result = await submitConfession(admissionEvent);
+        const result = await submitConfession(minedEvent);
         if (cancelled) return;
 
         setPosted(result);
         setComment("");
-        setSecretKey(generateSecretKey());
         setStatus((current) => ({
           ...current,
+          pubkey: result.event.pubkey,
           count: result.count,
           remaining: result.remaining,
           minimumPow: result.minimumPow,
@@ -148,21 +143,21 @@ export default function ConfessPage() {
     return () => {
       cancelled = true;
     };
-  }, [loadStatus, minedEvent, secretKey]);
+  }, [loadStatus, minedEvent]);
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     setPosted(null);
     setSubmitError(null);
 
-    if (!comment.trim() || contentError || status.closed || !status.configured) return;
+    if (!comment.trim() || contentError || status.closed || !status.configured || !status.pubkey) return;
 
     setSubmitStatus("mining");
     startWork();
   };
 
   const doingWork = submitStatus === "mining" || submitStatus === "submitting";
-  const isUnavailable = !status.configured || status.closed || submitStatus === "loading";
+  const isUnavailable = !status.configured || !status.pubkey || status.closed || submitStatus === "loading";
   const threadRef = posted ? encodeThreadRef(posted.event.id, posted.acceptedRelays) : "";
 
   return (
@@ -207,7 +202,7 @@ export default function ConfessPage() {
             <p className="text-meta text-secondary">
               {status.closed
                 ? "daily cap reached"
-                : status.configured
+                : status.configured && status.pubkey
                   ? `server will accept signal ${status.minimumPow}+`
                   : "confess account is not configured"}
             </p>

--- a/src/features/confess/api.ts
+++ b/src/features/confess/api.ts
@@ -1,8 +1,11 @@
-import type { Event } from "nostr-tools";
+import type { Event, UnsignedEvent } from "nostr-tools";
 import { CONFESS_API_BASE } from "../../config";
+
+export type ConfessAdmissionEvent = UnsignedEvent & Pick<Event, "id">;
 
 export type ConfessStatus = {
   configured: boolean;
+  pubkey: string;
   day: string;
   count: number;
   limit: number;
@@ -43,7 +46,7 @@ export async function fetchConfessStatus(): Promise<ConfessStatus> {
   return readJson<ConfessStatus>(response);
 }
 
-export async function submitConfession(event: Event): Promise<ConfessSubmitResponse> {
+export async function submitConfession(event: ConfessAdmissionEvent): Promise<ConfessSubmitResponse> {
   const response = await fetch(confessUrl("/api/confess"), {
     method: "POST",
     headers: {


### PR DESCRIPTION
## Summary
- mine confess admissions on the client against the server pubkey returned by `/api/confess/status`
- submit the mined unsigned NIP-13 event to the confess backend so the server can sign and publish it
- remove client-side confess signing from the UI flow
- add `wss://relay.wiredsignal.online` to the normal main feed PoW relay list

Closes #56

## Root Cause
The reported confess event was not a normal Wired PoW feed event: it had no NIP-13 `nonce` tag, its event id scored PoW 0, and it carried a custom `proof` tag instead. Wired main feed filtering expects NIP-13 event-id PoW, so the fix is to preserve normal NIP-13 mining and server-side signing rather than adding a confess-specific feed subscription.

## Backend Contract
`/api/confess/status` must return `pubkey`, the server signing pubkey. `/api/confess` now receives the mined unsigned event and returns the server-signed event in the existing response shape.

## Verification
- `npm test -- src/features/confess/ConfessPage.test.tsx src/config.test.ts src/nostr/subscriptions/global-feed.test.ts src/nostr/processEvents.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passes with existing Fast Refresh warnings in `src/app/providers.tsx` and `src/app/settings.tsx`)
- `npm run build`