### PR TITLE
Fix confess submit status

### DIFF
--- a/src/features/confess/ConfessPage.test.tsx
+++ b/src/features/confess/ConfessPage.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Event as NostrEvent, UnsignedEvent } from "nostr-tools";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import ConfessPage from "./ConfessPage";
+import type { ConfessStatus, ConfessSubmitResponse } from "./api";
+
+type ReactActGlobal = typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+const mocks = vi.hoisted(() => ({
+  fetchConfessStatus: vi.fn(),
+  submitConfession: vi.fn(),
+  startWork: vi.fn(),
+  powState: {
+    messageFromWorker: undefined as UnsignedEvent | undefined,
+    hashrate: 0,
+    bestPow: 0,
+  },
+}));
+
+vi.mock("nostr-tools", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("nostr-tools")>();
+  return {
+    ...actual,
+    generateSecretKey: () => new Uint8Array(32).fill(1),
+    getPublicKey: () => "f".repeat(64),
+    finalizeEvent: (event: UnsignedEvent) => ({
+      ...event,
+      id: "1".repeat(64),
+      pubkey: "f".repeat(64),
+      sig: "2".repeat(128),
+    }),
+  };
+});
+
+vi.mock("../../shared/hooks/usePowMining", () => ({
+  usePowMining: () => ({
+    startWork: mocks.startWork,
+    messageFromWorker: mocks.powState.messageFromWorker,
+    hashrate: mocks.powState.hashrate,
+    bestPow: mocks.powState.bestPow,
+  }),
+}));
+
+vi.mock("../../shared/ui/PostCard", () => ({
+  PostCard: () => null,
+}));
+
+vi.mock("./api", () => ({
+  fetchConfessStatus: mocks.fetchConfessStatus,
+  submitConfession: mocks.submitConfession,
+}));
+
+const openStatus: ConfessStatus = {
+  configured: true,
+  day: "2026-06-30",
+  count: 0,
+  limit: 6,
+  remaining: 6,
+  minimumPow: 1,
+  closed: false,
+  nextResetAt: "2026-07-01T00:00:00.000Z",
+};
+
+const postedEvent: NostrEvent = {
+  id: "1".repeat(64),
+  pubkey: "f".repeat(64),
+  created_at: 1,
+  kind: 1,
+  tags: [
+    ["client", "wired-confess"],
+    ["t", "confess"],
+  ],
+  content: "test confession",
+  sig: "2".repeat(128),
+};
+
+const submitResponse: ConfessSubmitResponse = {
+  ok: true,
+  event: postedEvent,
+  acceptedRelays: ["wss://relay.example"],
+  count: 1,
+  remaining: 5,
+  minimumPow: 1,
+  nextResetAt: "2026-07-01T00:00:00.000Z",
+};
+
+function flushPromises() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function updateTextarea(textarea: HTMLTextAreaElement, value: string) {
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  valueSetter?.call(textarea, value);
+  textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
+}
+
+describe("ConfessPage", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.fetchConfessStatus.mockReset();
+    mocks.submitConfession.mockReset();
+    mocks.startWork.mockReset();
+    mocks.powState.messageFromWorker = undefined;
+    mocks.powState.hashrate = 0;
+    mocks.powState.bestPow = 0;
+    mocks.fetchConfessStatus.mockResolvedValue(openStatus);
+    Object.defineProperty(window.navigator, "hardwareConcurrency", {
+      configurable: true,
+      value: 1,
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("shows backend submit status after mining instead of relay publishing status", async () => {
+    let resolveSubmit: (response: ConfessSubmitResponse) => void = () => {};
+    const pendingSubmit = new Promise<ConfessSubmitResponse>((resolve) => {
+      resolveSubmit = resolve;
+    });
+    mocks.submitConfession.mockReturnValue(pendingSubmit);
+
+    await act(async () => {
+      root.render(<ConfessPage />);
+      await flushPromises();
+    });
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+
+    await act(async () => {
+      updateTextarea(textarea!, "test confession");
+      await flushPromises();
+    });
+
+    await act(async () => {
+      container
+        .querySelector("form")
+        ?.dispatchEvent(new globalThis.Event("submit", { bubbles: true, cancelable: true }));
+    });
+
+    expect(mocks.startWork).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("computing signal");
+
+    mocks.powState.messageFromWorker = {
+      kind: postedEvent.kind,
+      pubkey: postedEvent.pubkey,
+      created_at: postedEvent.created_at,
+      tags: [...postedEvent.tags, ["nonce", "1", "1"]],
+      content: postedEvent.content,
+    };
+
+    await act(async () => {
+      root.render(<ConfessPage />);
+      await flushPromises();
+    });
+
+    expect(mocks.submitConfession).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("submitting to wired backend...");
+    expect(container.textContent).not.toContain("publishing to relays");
+
+    await act(async () => {
+      resolveSubmit(submitResponse);
+      await pendingSubmit;
+      await flushPromises();
+    });
+
+    expect(container.textContent).toContain("posted to 1 relay");
+    expect(container.textContent).not.toContain("submitting to wired backend...");
+  });
+});

--- a/src/features/confess/ConfessPage.tsx
+++ b/src/features/confess/ConfessPage.tsx
@@ -31,6 +31,14 @@ const EMPTY_STATUS: ConfessStatus = {
   nextResetAt: "",
 };
 
+type ConfessSubmitStatus =
+  | "idle"
+  | "loading"
+  | "mining"
+  | "submitting"
+  | "published"
+  | "failed";
+
 const disallowedContentPattern =
   /\b(?:(?:https?|wss?|ftp|ipfs):\/\/|(?:magnet|nostr):|www\.)[^\s<>"')\]]+|\b[a-z0-9.-]+\.(?:app|band|biz|blog|cloud|co|com|dev|fm|gg|info|io|is|land|link|lol|me|media|net|news|online|onion|org|site|social|to|tv|wine|xyz)(?:\/[^\s<>"')\]]*)?|\b[^\s<>"')\]]+\.(?:avif|gif|jpe?g|m4a|mov|mp3|mp4|ogg|png|svg|wav|webm|webp)(?:\?[^\s<>"')\]]*)?/i;
 
@@ -55,11 +63,10 @@ export default function ConfessPage() {
   const [comment, setComment] = useState("");
   const [secretKey, setSecretKey] = useState(() => generateSecretKey());
   const [status, setStatus] = useState<ConfessStatus>(EMPTY_STATUS);
-  const [submitStatus, setSubmitStatus] = useState<
-    "idle" | "loading" | "mining" | "publishing" | "published" | "failed"
-  >("loading");
+  const [submitStatus, setSubmitStatus] = useState<ConfessSubmitStatus>("loading");
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [posted, setPosted] = useState<ConfessSubmitResponse | null>(null);
+  const [minedEvent, setMinedEvent] = useState<UnsignedEvent>();
 
   const difficulty = String(status.minimumPow);
   const contentError = hasDisallowedContent(comment)
@@ -93,16 +100,22 @@ export default function ConfessPage() {
   }, [loadStatus]);
 
   useEffect(() => {
-    if (!messageFromWorker || submitStatus !== "mining") return;
+    if (messageFromWorker && submitStatus === "mining") {
+      setMinedEvent(messageFromWorker);
+    }
+  }, [messageFromWorker, submitStatus]);
+
+  useEffect(() => {
+    if (!minedEvent) return;
 
     let cancelled = false;
 
     const publishConfession = async () => {
-      setSubmitStatus("publishing");
+      setSubmitStatus("submitting");
       setSubmitError(null);
 
       try {
-        const admissionEvent = finalizeEvent(messageFromWorker, secretKey) as Event;
+        const admissionEvent = finalizeEvent(minedEvent, secretKey) as Event;
         const result = await submitConfession(admissionEvent);
         if (cancelled) return;
 
@@ -123,6 +136,10 @@ export default function ConfessPage() {
         setSubmitError(error instanceof Error ? error.message : "confess failed");
         setSubmitStatus("failed");
         void loadStatus();
+      } finally {
+        if (!cancelled) {
+          setMinedEvent(undefined);
+        }
       }
     };
 
@@ -131,7 +148,7 @@ export default function ConfessPage() {
     return () => {
       cancelled = true;
     };
-  }, [loadStatus, messageFromWorker, secretKey, submitStatus]);
+  }, [loadStatus, minedEvent, secretKey]);
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
@@ -144,7 +161,7 @@ export default function ConfessPage() {
     startWork();
   };
 
-  const doingWork = submitStatus === "mining" || submitStatus === "publishing";
+  const doingWork = submitStatus === "mining" || submitStatus === "submitting";
   const isUnavailable = !status.configured || status.closed || submitStatus === "loading";
   const noteLink = posted ? nip19.noteEncode(posted.event.id) : "";
 
@@ -206,13 +223,18 @@ export default function ConfessPage() {
           </div>
 
           <PowTransmitStatus
-            active={doingWork}
+            active={submitStatus === "mining"}
             difficulty={difficulty}
             hashrate={hashrate}
             bestPow={bestPow}
-            status={submitStatus === "loading" ? "idle" : submitStatus}
+            status="mining"
             className="text-right"
           />
+          {submitStatus === "submitting" && (
+            <p className="text-meta text-secondary text-right" role="status">
+              submitting to wired backend...
+            </p>
+          )}
 
           {submitError && <p className="text-meta text-danger text-right">{submitError}</p>}
           {contentError && !submitError && (


### PR DESCRIPTION
## Summary
- keep the confess backend submit request alive after switching out of mining status
- show backend-specific submitting copy instead of the shared relay publishing status
- add a jsdom regression test for the confess submit transition

Closes #55

## Verification
- npm test -- src/features/confess/ConfessPage.test.tsx
- npm test
- npm run lint
- npm run build