### PR TITLE
Use nevent refs for thread routes

### DIFF
--- a/src/features/confess/ConfessPage.tsx
+++ b/src/features/confess/ConfessPage.tsx
@@ -3,7 +3,6 @@ import {
   finalizeEvent,
   generateSecretKey,
   getPublicKey,
-  nip19,
   type Event,
   type UnsignedEvent,
 } from "nostr-tools";
@@ -13,6 +12,7 @@ import { PowTransmitStatus } from "../../shared/ui/PowTransmitStatus";
 import { Textarea } from "../../shared/ui/Textarea";
 import { PostCard } from "../../shared/ui/PostCard";
 import { usePowMining } from "../../shared/hooks/usePowMining";
+import { encodeThreadRef } from "@lib/threadRefs";
 import {
   fetchConfessStatus,
   submitConfession,
@@ -146,7 +146,7 @@ export default function ConfessPage() {
 
   const doingWork = submitStatus === "mining" || submitStatus === "publishing";
   const isUnavailable = !status.configured || status.closed || submitStatus === "loading";
-  const noteLink = posted ? nip19.noteEncode(posted.event.id) : "";
+  const threadRef = posted ? encodeThreadRef(posted.event.id, posted.acceptedRelays) : "";
 
   return (
     <PageShell>
@@ -221,7 +221,7 @@ export default function ConfessPage() {
           {posted && (
             <p className="text-meta text-secondary text-right">
               posted to {posted.acceptedRelays.length} relay
-              {posted.acceptedRelays.length === 1 ? "" : "s"} · {noteLink}
+              {posted.acceptedRelays.length === 1 ? "" : "s"} · {threadRef}
             </p>
           )}
         </form>

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -10,7 +10,7 @@ export default function SettingsPage() {
   const [filterDifficulty, setFilterDifficulty] = useState(String(settings.filterDifficulty));
   const [difficulty, setDifficulty] = useState(String(settings.difficulty));
   const [age, setAge] = useState(String(settings.ageHours));
-  const [noteLink, setNoteLink] = useState("");
+  const [threadRef, setThreadRef] = useState("");
   const navigate = useNavigate();
   const filterDifficultyValue = Number(filterDifficulty);
   const filterDifficultyError =
@@ -62,20 +62,20 @@ export default function SettingsPage() {
         </Button>
       </form>
       <div className="pt-10">
-        <h2 className="text-body font-medium mb-4">open note</h2>
+        <h2 className="text-body font-medium mb-4">open thread</h2>
         <form
           className="flex flex-col gap-4 max-w-md"
           onSubmit={(e) => {
             e.preventDefault();
-            navigate(`/thread/${noteLink}`);
+            navigate(`/thread/${threadRef}`);
           }}
         >
           <Input
-            id="noteIDinput"
-            label="note ref"
+            id="threadRefInput"
+            label="thread ref"
             type="text"
-            value={noteLink}
-            onChange={(e) => setNoteLink(e.target.value)}
+            value={threadRef}
+            onChange={(e) => setThreadRef(e.target.value)}
           />
           <Button type="submit" variant="primary">
             open

--- a/src/features/thread/ThreadPage.tsx
+++ b/src/features/thread/ThreadPage.tsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useMemo } from "react";
-import { Event, nip19 } from "nostr-tools";
+import { Event } from "nostr-tools";
 import { getThreadDepth } from "@lib/getThreadDepth";
 import { Placeholder } from "../../shared/ui/Placeholder";
 import { Button } from "../../shared/ui/Button";
@@ -12,18 +12,9 @@ import { useThreadViewModel } from "../../hooks/useThreadViewModel";
 import { eventWork } from "../../nostr/processing/pow-score";
 import { readThreadSeedEvents } from "./threadSeedCache";
 import { useThreadNavigation } from "./useThreadNavigation";
+import { decodeThreadRef } from "@lib/threadRefs";
 
-function decodeNoteId(id: string | undefined): string | null {
-  if (!id) return null;
-  try {
-    const decodeResult = nip19.decode(id);
-    return decodeResult.type === "note" ? (decodeResult.data as string) : null;
-  } catch {
-    return null;
-  }
-}
-
-function ThreadView({ hexID }: { hexID: string }) {
+function ThreadView({ hexID, relayHints }: { hexID: string; relayHints: string[] }) {
   const visibleReplyEvents = useInfiniteScroll();
   const seedEvents = useMemo(() => readThreadSeedEvents(hexID), [hexID]);
   const openThread = useThreadNavigation();
@@ -35,7 +26,7 @@ function ThreadView({ hexID }: { hexID: string }) {
     showAllReplies,
     setShowAllReplies,
     uniqMentions,
-  } = useThreadViewModel(hexID, seedEvents);
+  } = useThreadViewModel(hexID, seedEvents, relayHints);
   const directReplyEvents = replyEvents.filter((event) =>
     event.postEvent.tags.some((tag) => tag[0] === "e" && tag[1] === hexID),
   );
@@ -114,9 +105,9 @@ function ThreadView({ hexID }: { hexID: string }) {
 export default function ThreadPage() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const hexID = decodeNoteId(id);
+  const threadRef = decodeThreadRef(id);
 
-  if (!hexID) {
+  if (!threadRef) {
     return (
       <PageShell className="bg-void min-h-screen flex flex-col items-center justify-center gap-4">
         <p className="text-secondary text-body">invalid signal ref</p>
@@ -127,5 +118,5 @@ export default function ThreadPage() {
     );
   }
 
-  return <ThreadView hexID={hexID} />;
+  return <ThreadView hexID={threadRef.id} relayHints={threadRef.relays} />;
 }

--- a/src/features/thread/useThreadNavigation.ts
+++ b/src/features/thread/useThreadNavigation.ts
@@ -1,7 +1,8 @@
 import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { nip19, type Event } from "nostr-tools";
+import { type Event } from "nostr-tools";
 import { writeThreadSeedEvents } from "./threadSeedCache";
+import { buildThreadPath } from "@lib/threadRefs";
 
 export function useThreadNavigation() {
   const navigate = useNavigate();
@@ -9,7 +10,7 @@ export function useThreadNavigation() {
   return useCallback(
     (event: Event, relatedEvents: Event[]) => {
       writeThreadSeedEvents(event.id, relatedEvents);
-      navigate(`/thread/${nip19.noteEncode(event.id)}`);
+      navigate(buildThreadPath(event.id));
     },
     [navigate],
   );

--- a/src/hooks/useThreadEvents.ts
+++ b/src/hooks/useThreadEvents.ts
@@ -1,14 +1,21 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
+import { ensureRelaysConnected } from "../nostr/client";
 import { subNote } from "../nostr/subscriptions";
 import { useFilteredNoteSubscription } from "../shared/hooks/useFilteredNoteSubscription";
+import { uniqueRelays } from "@lib/threadRefs";
 
-export function useThreadEvents(hexID: string) {
+export function useThreadEvents(hexID: string, relayHints: readonly string[] = []) {
+  const relayUrls = useMemo(() => uniqueRelays(relayHints), [relayHints]);
+  const relayDependency = relayUrls.join(",");
   const subscribe = useCallback(
-    (onEvent: Parameters<typeof subNote>[1]) => subNote(hexID, onEvent),
-    [hexID],
+    async (onEvent: Parameters<typeof subNote>[1]) => {
+      await ensureRelaysConnected(relayUrls);
+      return subNote(hexID, onEvent, relayUrls);
+    },
+    [hexID, relayUrls],
   );
 
-  const noteEvents = useFilteredNoteSubscription(subscribe, [hexID]);
+  const noteEvents = useFilteredNoteSubscription(subscribe, [hexID, relayDependency]);
 
   return { noteEvents };
 }

--- a/src/hooks/useThreadViewModel.ts
+++ b/src/hooks/useThreadViewModel.ts
@@ -8,10 +8,14 @@ import { useNostrSubscription } from "../shared/hooks/useNostrSubscription";
 import { useModerationManifest } from "../shared/hooks/useModerationManifest";
 import { filterModeratedEvents } from "../shared/lib/moderation";
 
-export function useThreadViewModel(hexID: string, seedEvents: Event[] = []) {
+export function useThreadViewModel(
+  hexID: string,
+  seedEvents: Event[] = [],
+  relayHints: readonly string[] = [],
+) {
   const [showAllReplies, setShowAllReplies] = useState(true);
   const moderationManifest = useModerationManifest();
-  const { noteEvents } = useThreadEvents(hexID);
+  const { noteEvents } = useThreadEvents(hexID, relayHints);
 
   const allEvents = useMemo(() => {
     return filterModeratedEvents([...noteEvents, ...seedEvents], moderationManifest);

--- a/src/nostr/subscriptions/thread.test.ts
+++ b/src/nostr/subscriptions/thread.test.ts
@@ -38,4 +38,15 @@ describe("subNote", () => {
     });
     expect(replyRequest.filter.since).toBeUndefined();
   });
+
+  it("adds relay hints to thread subscriptions", () => {
+    subNote("1".repeat(64), vi.fn(), ["wss://relay.example/", THREAD_RELAYS[0]]);
+
+    const opRequest = subscribeMock.mock.calls[0][0][0];
+    const replyRequest = subscribeMock.mock.calls[1][0][0];
+    const relays = [...expectedRelays, "wss://relay.example"];
+
+    expect(opRequest.relayUrls).toEqual(relays);
+    expect(replyRequest.relayUrls).toEqual(relays);
+  });
 });

--- a/src/nostr/subscriptions/thread.ts
+++ b/src/nostr/subscriptions/thread.ts
@@ -2,12 +2,18 @@ import { getRegistry, THREAD_RELAYS } from "../client";
 import type { SubCallback, SubHandle } from "../types";
 import { composeSubHandle } from "./utils";
 import { buildThreadReplyFilter } from "./query-limits";
+import { uniqueRelays } from "@lib/threadRefs";
 
-export const subNote = (eventId: string, onEvent: SubCallback): SubHandle => {
+export const subNote = (
+  eventId: string,
+  onEvent: SubCallback,
+  relayHints: readonly string[] = [],
+): SubHandle => {
   const registry = getRegistry();
   const children: SubHandle[] = [];
   let replyHandle: SubHandle | null = null;
   const replies = new Set<string>([eventId]);
+  const relayUrls = uniqueRelays([...THREAD_RELAYS, ...relayHints]);
 
   const refreshReplySubscription = () => {
     const filter = buildThreadReplyFilter(Array.from(replies));
@@ -17,7 +23,7 @@ export const subNote = (eventId: string, onEvent: SubCallback): SubHandle => {
     replyHandle = registry.subscribe([
       {
         filter,
-        relayUrls: THREAD_RELAYS,
+        relayUrls,
         cb: (evt, relay) => {
           const isNew = !replies.has(evt.id);
           if (isNew) {
@@ -40,7 +46,7 @@ export const subNote = (eventId: string, onEvent: SubCallback): SubHandle => {
           kinds: [1, 1068],
           limit: 1,
         },
-        relayUrls: THREAD_RELAYS,
+        relayUrls,
         cb: onEvent,
         closeOnEose: true,
       },

--- a/src/shared/hooks/useFilteredNoteSubscription.ts
+++ b/src/shared/hooks/useFilteredNoteSubscription.ts
@@ -5,7 +5,7 @@ import { filterNoteEvents } from "@lib/noteEvents";
 import { useNostrSubscription } from "./useNostrSubscription";
 
 export function useFilteredNoteSubscription(
-  createSubscription: (onEvent: SubCallback) => SubHandle,
+  createSubscription: (onEvent: SubCallback) => SubHandle | Promise<SubHandle>,
   deps: DependencyList,
   enabled = true,
 ): Event[] {

--- a/src/shared/hooks/useNostrSubscription.ts
+++ b/src/shared/hooks/useNostrSubscription.ts
@@ -3,8 +3,10 @@ import type { Event } from "nostr-tools";
 import { initNostr } from "../../nostr/client";
 import type { SubCallback, SubHandle } from "../../nostr/types";
 
+type SubscriptionFactory = (onEvent: SubCallback) => SubHandle | Promise<SubHandle>;
+
 export function useNostrSubscription(
-  createSubscription: (onEvent: SubCallback) => SubHandle,
+  createSubscription: SubscriptionFactory,
   deps: DependencyList,
   enabled = true,
 ): Event[] {
@@ -30,7 +32,14 @@ export function useNostrSubscription(
         );
       };
 
-      subscription = createSubscription(onEvent);
+      void Promise.resolve(createSubscription(onEvent)).then((nextSubscription) => {
+        if (cancelled) {
+          nextSubscription.close();
+          return;
+        }
+
+        subscription = nextSubscription;
+      });
     });
 
     return () => {

--- a/src/shared/lib/threadRefs.test.ts
+++ b/src/shared/lib/threadRefs.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { nip19 } from "nostr-tools";
+import {
+  buildThreadPath,
+  decodeThreadRef,
+  encodeThreadRef,
+  uniqueRelays,
+} from "./threadRefs";
+
+const EVENT_ID = "a".repeat(64);
+const RELAYS = ["wss://relay.example/", "wss://relay.example", "wss://backup.example"];
+
+describe("threadRefs", () => {
+  it("encodes thread routes as nevent refs with relay hints", () => {
+    const ref = encodeThreadRef(EVENT_ID, RELAYS);
+    const decoded = nip19.decode(ref);
+
+    expect(ref).toMatch(/^nevent1/);
+    expect(decoded.type).toBe("nevent");
+    if (decoded.type !== "nevent") {
+      throw new Error("expected nevent ref");
+    }
+    expect(decoded.data).toMatchObject({
+      id: EVENT_ID,
+      relays: ["wss://relay.example", "wss://backup.example"],
+    });
+    expect(buildThreadPath(EVENT_ID, RELAYS)).toBe(`/thread/${ref}`);
+  });
+
+  it("decodes nevent refs to event ids and relay hints", () => {
+    const ref = encodeThreadRef(EVENT_ID, RELAYS);
+
+    expect(decodeThreadRef(ref)).toEqual({
+      id: EVENT_ID,
+      relays: ["wss://relay.example", "wss://backup.example"],
+    });
+  });
+
+  it("preserves compatibility with legacy note refs", () => {
+    expect(decodeThreadRef(nip19.noteEncode(EVENT_ID))).toEqual({
+      id: EVENT_ID,
+      relays: [],
+    });
+  });
+
+  it("normalizes duplicate relay hints", () => {
+    expect(uniqueRelays(RELAYS)).toEqual([
+      "wss://relay.example",
+      "wss://backup.example",
+    ]);
+  });
+});

--- a/src/shared/lib/threadRefs.ts
+++ b/src/shared/lib/threadRefs.ts
@@ -1,0 +1,59 @@
+import { nip19 } from "nostr-tools";
+import { THREAD_RELAYS } from "../../config";
+
+export type ThreadRef = {
+  id: string;
+  relays: string[];
+};
+
+const HEX_EVENT_ID_PATTERN = /^[0-9a-f]{64}$/i;
+
+export function normalizeRelayUrl(relay: string): string {
+  return relay.replace(/\/+$/, "");
+}
+
+export function uniqueRelays(relays: readonly string[]): string[] {
+  return [...new Set(relays.map(normalizeRelayUrl).filter(Boolean))];
+}
+
+export function encodeThreadRef(
+  eventId: string,
+  relays: readonly string[] = THREAD_RELAYS,
+): string {
+  return nip19.neventEncode({
+    id: eventId,
+    relays: uniqueRelays(relays),
+  });
+}
+
+export function buildThreadPath(
+  eventId: string,
+  relays: readonly string[] = THREAD_RELAYS,
+): string {
+  return `/thread/${encodeThreadRef(eventId, relays)}`;
+}
+
+export function decodeThreadRef(ref: string | undefined): ThreadRef | null {
+  if (!ref) return null;
+
+  try {
+    const decoded = nip19.decode(ref);
+
+    if (decoded.type === "note") {
+      return { id: decoded.data as string, relays: [] };
+    }
+
+    if (decoded.type === "nevent") {
+      return {
+        id: decoded.data.id,
+        relays: uniqueRelays(decoded.data.relays ?? []),
+      };
+    }
+  } catch {
+    if (HEX_EVENT_ID_PATTERN.test(ref)) {
+      return { id: ref.toLowerCase(), relays: [] };
+    }
+  }
+
+  return null;
+}

--- a/src/shared/ui/PostCard.tsx
+++ b/src/shared/ui/PostCard.tsx
@@ -1,8 +1,9 @@
-import { Event, nip19 } from "nostr-tools";
+import { Event } from "nostr-tools";
 import { timeAgo } from "@lib/timeFormat";
 import { verifyPow } from "../../shared/pow/core";
 import { uniqBy } from "@lib/collections";
 import { getDisplayName } from "@lib/profile";
+import { buildThreadPath } from "@lib/threadRefs";
 import { TextContent } from "./TextContent";
 import { MetadataRow } from "./MetadataRow";
 import { ReplyContext } from "./ReplyContext";
@@ -71,7 +72,7 @@ export function PostCard({
       return;
     }
 
-    navigate(`/thread/${nip19.noteEncode(event.id)}`);
+    navigate(buildThreadPath(event.id));
   }, [event, onOpenThread, relatedEvents, navigate]);
 
   const roleClass = role === "threadContext" ? "opacity-70" : "";


### PR DESCRIPTION
## Summary
- encode generated thread routes as `nevent` refs with relay hints
- decode both `nevent` and legacy `note1` thread route refs
- include nevent relay hints when subscribing to thread events
- update posted/confess and settings thread ref UI plus focused tests

Closes #44

## Verification
- `npm test -- src/shared/lib/threadRefs.test.ts src/nostr/subscriptions/thread.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run lint` (passes with existing fast-refresh warnings in `src/app/providers.tsx` and `src/app/settings.tsx`)
