### PR TITLE
Fix quoted event resolution

### DIFF
--- a/src/nostr/subscriptions/index.ts
+++ b/src/nostr/subscriptions/index.ts
@@ -1,4 +1,4 @@
-import { ENRICHMENT_RELAYS, POW_RELAYS } from "../../config";
+import { POW_RELAYS, QUOTE_FALLBACK_RELAYS } from "../../config";
 import {
   ensureRelaysConnected,
   initNostr,
@@ -8,7 +8,7 @@ import {
 } from "../client";
 import type { SubCallback, SubHandle } from "../types";
 import type { QuotedRef } from "@lib/quotedEvents";
-import { emptySubHandle } from "./utils";
+import { createSubHandleOwner, emptySubHandle } from "./utils";
 import { profileQueryLimit } from "./query-limits";
 
 export type { SubCallback, SubHandle };
@@ -78,8 +78,41 @@ export async function subProfilesOnce(
   ]);
 }
 
-function relayUrlsForQuote(ref: QuotedRef): string[] {
-  return [...new Set([...POW_RELAYS, ...ref.relays, ...ENRICHMENT_RELAYS])];
+function uniqueRelayUrls(relays: readonly string[]): string[] {
+  return [...new Set(relays)];
+}
+
+function fallbackRelayUrlsForQuote(ref: QuotedRef): string[] {
+  return uniqueRelayUrls([...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS, ...ref.relays]);
+}
+
+function extraRelayHintsForQuote(ref: QuotedRef): string[] {
+  const fallbackRelays = new Set([...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS]);
+  return uniqueRelayUrls(ref.relays.filter((relay) => !fallbackRelays.has(relay)));
+}
+
+function hasExtraRelayHints(ref: QuotedRef): boolean {
+  return extraRelayHintsForQuote(ref).length > 0;
+}
+
+function quoteRequests(
+  refs: QuotedRef[],
+  onEvent: SubCallback,
+  onEose: ((refId: string) => void) | undefined,
+  relayUrlsForRef: (ref: QuotedRef) => string[],
+  shouldReportEose: (ref: QuotedRef) => boolean = () => true,
+) {
+  return refs.map((ref) => ({
+    filter: {
+      ids: [ref.id],
+      kinds: [1, 1068],
+      limit: 1,
+    },
+    cb: onEvent,
+    closeOnEose: true,
+    onEose: onEose && shouldReportEose(ref) ? () => onEose(ref.id) : undefined,
+    relayUrls: relayUrlsForRef(ref),
+  }));
 }
 
 export async function subQuotedEventsOnce(
@@ -91,20 +124,37 @@ export async function subQuotedEventsOnce(
     return emptySubHandle("quoted-events-once:empty");
   }
 
-  const relayUrls = [...new Set(refs.flatMap(relayUrlsForQuote))];
-  await ensureRelaysConnected(relayUrls);
+  await initNostr();
 
-  return getRegistry().subscribe(
-    refs.map((ref) => ({
-      filter: {
-        ids: [ref.id],
-        kinds: [1, 1068],
-        limit: 1,
-      },
-      cb: onEvent,
-      closeOnEose: true,
-      onEose: onEose ? () => onEose(ref.id) : undefined,
-      relayUrls: relayUrlsForQuote(ref),
-    })),
+  const owner = createSubHandleOwner("quoted-events-once");
+  const refsWithExtraHints = refs.filter(hasExtraRelayHints);
+
+  owner.add(
+    getRegistry().subscribe(
+      quoteRequests(
+        refs,
+        onEvent,
+        onEose,
+        fallbackRelayUrlsForQuote,
+        (ref) => !hasExtraRelayHints(ref),
+      ),
+    ),
   );
+
+  if (refsWithExtraHints.length > 0) {
+    const extraRelayHints = uniqueRelayUrls(
+      refsWithExtraHints.flatMap(extraRelayHintsForQuote),
+    );
+    void ensureRelaysConnected(extraRelayHints)
+      .then(() => {
+        owner.add(
+          getRegistry().subscribe(
+            quoteRequests(refsWithExtraHints, onEvent, onEose, extraRelayHintsForQuote),
+          ),
+        );
+      })
+      .catch(() => {});
+  }
+
+  return owner.handle();
 }

--- a/src/nostr/subscriptions/quoted-events.test.ts
+++ b/src/nostr/subscriptions/quoted-events.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POW_RELAYS, QUOTE_FALLBACK_RELAYS, THREAD_RELAYS } from "../../config";
+
+const mocks = vi.hoisted(() => ({
+  ensureRelaysConnected: vi.fn(),
+  initNostr: vi.fn(),
+  subscribe: vi.fn(),
+}));
+
+vi.mock("../client", () => ({
+  ensureRelaysConnected: mocks.ensureRelaysConnected,
+  getRegistry: () => ({
+    subscribe: mocks.subscribe,
+  }),
+  initNostr: mocks.initNostr,
+  PROFILE_RELAYS: THREAD_RELAYS,
+  THREAD_RELAYS,
+}));
+
+import { subQuotedEventsOnce } from "./index";
+
+const quoteId = "a38fb77ce8783c30bf64063fe78e8060f3b58e41476fb3a5cd94ddfb1b3837d1";
+
+describe("subQuotedEventsOnce", () => {
+  beforeEach(() => {
+    mocks.ensureRelaysConnected.mockReset();
+    mocks.initNostr.mockReset();
+    mocks.subscribe.mockReset();
+    mocks.initNostr.mockResolvedValue(undefined);
+    mocks.ensureRelaysConnected.mockResolvedValue(undefined);
+    mocks.subscribe.mockReturnValue({ id: "sub", close: vi.fn() });
+  });
+
+  it("subscribes to fallback quote relays before waiting for stale relay hints", async () => {
+    let resolveHintRelays: () => void = () => {};
+    mocks.ensureRelaysConnected.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveHintRelays = resolve;
+      }),
+    );
+
+    await subQuotedEventsOnce(
+      [{ id: quoteId, relays: ["wss://nostr.land"] }],
+      vi.fn(),
+      vi.fn(),
+    );
+
+    expect(mocks.initNostr).toHaveBeenCalledTimes(1);
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureRelaysConnected).toHaveBeenCalledWith(["wss://nostr.land"]);
+
+    const fallbackRequest = mocks.subscribe.mock.calls[0][0][0];
+    expect(fallbackRequest.filter).toEqual({
+      ids: [quoteId],
+      kinds: [1, 1068],
+      limit: 1,
+    });
+    expect(fallbackRequest.relayUrls).toEqual([
+      ...new Set([...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS, "wss://nostr.land"]),
+    ]);
+    expect(fallbackRequest.onEose).toBeUndefined();
+
+    resolveHintRelays();
+    await Promise.resolve();
+
+    expect(mocks.subscribe).toHaveBeenCalledTimes(2);
+    const hintedRequest = mocks.subscribe.mock.calls[1][0][0];
+    expect(hintedRequest.relayUrls).toEqual(["wss://nostr.land"]);
+    expect(hintedRequest.onEose).toEqual(expect.any(Function));
+  });
+
+  it("reports EOSE from the fallback subscription when no extra relay hints exist", async () => {
+    const onEose = vi.fn();
+
+    await subQuotedEventsOnce(
+      [{ id: quoteId, relays: ["wss://nos.lol"] }],
+      vi.fn(),
+      onEose,
+    );
+
+    expect(mocks.ensureRelaysConnected).not.toHaveBeenCalled();
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+
+    const fallbackRequest = mocks.subscribe.mock.calls[0][0][0];
+    expect(fallbackRequest.relayUrls).toEqual([
+      ...new Set([...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS, "wss://nos.lol"]),
+    ]);
+
+    fallbackRequest.onEose();
+    expect(onEose).toHaveBeenCalledWith(quoteId);
+  });
+});

--- a/src/shared/lib/quotedEvents.test.ts
+++ b/src/shared/lib/quotedEvents.test.ts
@@ -5,6 +5,11 @@ import { decodeNostrRef, extractQuotedRefs } from "./quotedEvents";
 const QUOTED_POLL_ID = "48942b7f9e4501af2d9f8e668256c0652dcbe41fa0104acce6aca81ab9ff2de2";
 const QUOTED_POLL_NEVENT =
   "nevent1qvzqqqqy9spzpmnw5yatnljuff5w47d35d87q99xddqpzlzsac4xzn6vm22ekmn5qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qgnwaehxw309ahkvenrdpskjm3wwp6kytcqypyfg2mlnezsrtedn78xdqjkcpjjmjlyr7spqjkvu6k2sx4eluk7yarpf4w";
+const NOTE_TAG_ID = "c".repeat(64);
+const NOTE_TAG_NOTE = "note1enxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxqzqztj2";
+const ISSUE_54_QUOTED_ID = "a38fb77ce8783c30bf64063fe78e8060f3b58e41476fb3a5cd94ddfb1b3837d1";
+const ISSUE_54_QUOTED_NEVENT =
+  "nevent1qqs28rah0n58s0pshajqv0l836qxpua43eq5wman5hxefh0mrvur05gpzpmhxue69uhkummnw3ezumrpdejqygr2q2mat4wpemkr6zkj3ht3cn87awmrj7u4lm6u65pjey3r5y7s9gcs8lc6";
 
 describe("decodeNostrRef", () => {
   it("decodes nevent references to event ids and relay hints", () => {
@@ -63,6 +68,45 @@ describe("extractQuotedRefs", () => {
       {
         id: QUOTED_POLL_ID,
         relays: ["wss://relay.damus.io", "wss://offchain.pub"],
+      },
+    ]);
+  });
+
+  it("extracts the reported issue 54 quote and its relay hint", () => {
+    const event = {
+      content: `No one should ever make a dumb "dry heat" joke.\nnostr:${ISSUE_54_QUOTED_NEVENT}`,
+      tags: [["q", ISSUE_54_QUOTED_ID, "wss://nostr.land"]],
+    } as Event;
+
+    expect(extractQuotedRefs(event)).toEqual([
+      {
+        id: ISSUE_54_QUOTED_ID,
+        relays: ["wss://nostr.land"],
+      },
+    ]);
+  });
+
+  it("decodes note and nevent values from q tags", () => {
+    const event = {
+      content: "",
+      tags: [
+        ["q", `nostr:${QUOTED_POLL_NEVENT}`, "wss://relay.example/"],
+        ["q", NOTE_TAG_NOTE],
+      ],
+    } as Event;
+
+    expect(extractQuotedRefs(event)).toEqual([
+      {
+        id: QUOTED_POLL_ID,
+        relays: [
+          "wss://relay.damus.io",
+          "wss://offchain.pub",
+          "wss://relay.example",
+        ],
+      },
+      {
+        id: NOTE_TAG_ID,
+        relays: [],
       },
     ]);
   });

--- a/src/shared/lib/quotedEvents.ts
+++ b/src/shared/lib/quotedEvents.ts
@@ -8,12 +8,14 @@ export type QuotedRef = {
   relays: string[];
 };
 
+const EVENT_ID_PATTERN = /^[0-9a-f]{64}$/i;
+
 export function normalizeRelayUrl(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
 export function decodeNostrRef(ref: string): QuotedRef | null {
-  const bech32 = ref.startsWith("nostr:") ? ref.slice(6) : ref;
+  const bech32 = ref.replace(/^nostr:/i, "");
   try {
     const decoded = nip19.decode(bech32);
     if (decoded.type === "note") {
@@ -52,10 +54,22 @@ export function extractQuotedRefs(event: Event): QuotedRef[] {
     byId.set(id, { id, relays: [...new Set(relays)] });
   };
 
+  const addTaggedRef = (value: string, relayHints: string[] = []) => {
+    if (EVENT_ID_PATTERN.test(value)) {
+      addRef(value.toLowerCase(), relayHints);
+      return;
+    }
+
+    const decoded = decodeNostrRef(value);
+    if (decoded) {
+      addRef(decoded.id, [...decoded.relays, ...relayHints]);
+    }
+  };
+
   for (const tag of event.tags ?? []) {
     if (tag[0] === "q" && tag[1]) {
       const relayHint = tag[2] ? normalizeRelayUrl(tag[2]) : undefined;
-      addRef(tag[1], relayHint ? [relayHint] : []);
+      addTaggedRef(tag[1], relayHint ? [relayHint] : []);
     }
   }
 


### PR DESCRIPTION
## Summary
- decode quoted refs from hex, note, and nevent q tags while preserving relay hints
- query configured quote fallback relays immediately so stale or slow relay hints do not block resolution
- add regression coverage for the reported issue #54 event and quote subscription behavior

Closes #54

## Verification
- npx vitest run src/shared/lib/quotedEvents.test.ts src/nostr/subscriptions/quoted-events.test.ts
- npm test
- npm run typecheck
- npm run lint (passes with existing Fast Refresh warnings in src/app/providers.tsx and src/app/settings.tsx)
- npm run build