### PR TITLE
Fix confess production admission signing

### DIFF
--- a/src/features/confess/ConfessPage.test.tsx
+++ b/src/features/confess/ConfessPage.test.tsx
@@ -2,10 +2,10 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import type { Event as NostrEvent } from "nostr-tools";
+import type { Event as NostrEvent, UnsignedEvent } from "nostr-tools";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import ConfessPage from "./ConfessPage";
-import type { ConfessAdmissionEvent, ConfessStatus, ConfessSubmitResponse } from "./api";
+import type { ConfessStatus, ConfessSubmitResponse } from "./api";
 
 type ReactActGlobal = typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
 
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   submitConfession: vi.fn(),
   startWork: vi.fn(),
   powState: {
-    messageFromWorker: undefined as ConfessAdmissionEvent | undefined,
+    messageFromWorker: undefined as (UnsignedEvent & Pick<NostrEvent, "id">) | undefined,
     hashrate: 0,
     bestPow: 0,
   },
@@ -22,8 +22,17 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("nostr-tools", async (importOriginal) => {
   const actual = await importOriginal<typeof import("nostr-tools")>();
+  const proofPubkey = "f".repeat(64);
   return {
     ...actual,
+    generateSecretKey: vi.fn(() => new Uint8Array(32).fill(1)),
+    getPublicKey: vi.fn(() => proofPubkey),
+    finalizeEvent: vi.fn((event: UnsignedEvent & Pick<NostrEvent, "id">) => ({
+      ...event,
+      pubkey: proofPubkey,
+      id: event.id,
+      sig: "2".repeat(128),
+    })),
   };
 });
 
@@ -47,7 +56,6 @@ vi.mock("./api", () => ({
 
 const openStatus: ConfessStatus = {
   configured: true,
-  pubkey: "f".repeat(64),
   day: "2026-06-30",
   count: 0,
   limit: 6,
@@ -176,12 +184,12 @@ describe("ConfessPage", () => {
     expect(mocks.submitConfession).toHaveBeenCalledWith({
       id: postedEvent.id,
       kind: postedEvent.kind,
-      pubkey: openStatus.pubkey,
+      pubkey: postedEvent.pubkey,
       created_at: postedEvent.created_at,
       tags: [...postedEvent.tags, ["nonce", "1", "1"]],
       content: postedEvent.content,
+      sig: postedEvent.sig,
     });
-    expect(mocks.submitConfession.mock.calls[0][0]).not.toHaveProperty("sig");
     expect(container.textContent).toContain("submitting to wired backend...");
     expect(container.textContent).not.toContain("publishing to relays");
 

--- a/src/features/confess/ConfessPage.tsx
+++ b/src/features/confess/ConfessPage.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  finalizeEvent,
+  generateSecretKey,
+  getPublicKey,
+  type Event,
   type UnsignedEvent,
 } from "nostr-tools";
 import { ContentColumn, PageShell } from "../../shared/ui/PageShell";
@@ -12,14 +16,12 @@ import { encodeThreadRef } from "@lib/threadRefs";
 import {
   fetchConfessStatus,
   submitConfession,
-  type ConfessAdmissionEvent,
   type ConfessStatus,
   type ConfessSubmitResponse,
 } from "./api";
 
 const EMPTY_STATUS: ConfessStatus = {
   configured: false,
-  pubkey: "",
   day: "",
   count: 0,
   limit: 6,
@@ -59,19 +61,21 @@ function buildAdmissionEvent(content: string, pubkey: string): UnsignedEvent {
 
 export default function ConfessPage() {
   const [comment, setComment] = useState("");
+  const [secretKey, setSecretKey] = useState(() => generateSecretKey());
   const [status, setStatus] = useState<ConfessStatus>(EMPTY_STATUS);
   const [submitStatus, setSubmitStatus] = useState<ConfessSubmitStatus>("loading");
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [posted, setPosted] = useState<ConfessSubmitResponse | null>(null);
-  const [minedEvent, setMinedEvent] = useState<ConfessAdmissionEvent>();
+  const [minedEvent, setMinedEvent] = useState<UnsignedEvent & Pick<Event, "id">>();
 
   const difficulty = String(status.minimumPow);
   const contentError = hasDisallowedContent(comment)
     ? "links and media are not allowed"
     : null;
+  const pubkey = useMemo(() => getPublicKey(secretKey), [secretKey]);
   const unsigned = useMemo(
-    () => buildAdmissionEvent(comment.trim(), status.pubkey),
-    [comment, status.pubkey],
+    () => buildAdmissionEvent(comment.trim(), pubkey),
+    [comment, pubkey],
   );
   const {
     startWork,
@@ -111,14 +115,15 @@ export default function ConfessPage() {
       setSubmitError(null);
 
       try {
-        const result = await submitConfession(minedEvent);
+        const admissionEvent = finalizeEvent(minedEvent, secretKey) as Event;
+        const result = await submitConfession(admissionEvent);
         if (cancelled) return;
 
         setPosted(result);
         setComment("");
+        setSecretKey(generateSecretKey());
         setStatus((current) => ({
           ...current,
-          pubkey: result.event.pubkey,
           count: result.count,
           remaining: result.remaining,
           minimumPow: result.minimumPow,
@@ -143,21 +148,21 @@ export default function ConfessPage() {
     return () => {
       cancelled = true;
     };
-  }, [loadStatus, minedEvent]);
+  }, [loadStatus, minedEvent, secretKey]);
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     setPosted(null);
     setSubmitError(null);
 
-    if (!comment.trim() || contentError || status.closed || !status.configured || !status.pubkey) return;
+    if (!comment.trim() || contentError || status.closed || !status.configured) return;
 
     setSubmitStatus("mining");
     startWork();
   };
 
   const doingWork = submitStatus === "mining" || submitStatus === "submitting";
-  const isUnavailable = !status.configured || !status.pubkey || status.closed || submitStatus === "loading";
+  const isUnavailable = !status.configured || status.closed || submitStatus === "loading";
   const threadRef = posted ? encodeThreadRef(posted.event.id, posted.acceptedRelays) : "";
 
   return (
@@ -202,7 +207,7 @@ export default function ConfessPage() {
             <p className="text-meta text-secondary">
               {status.closed
                 ? "daily cap reached"
-                : status.configured && status.pubkey
+                : status.configured
                   ? `server will accept signal ${status.minimumPow}+`
                   : "confess account is not configured"}
             </p>

--- a/src/features/confess/api.ts
+++ b/src/features/confess/api.ts
@@ -1,11 +1,8 @@
-import type { Event, UnsignedEvent } from "nostr-tools";
+import type { Event } from "nostr-tools";
 import { CONFESS_API_BASE } from "../../config";
-
-export type ConfessAdmissionEvent = UnsignedEvent & Pick<Event, "id">;
 
 export type ConfessStatus = {
   configured: boolean;
-  pubkey: string;
   day: string;
   count: number;
   limit: number;
@@ -46,7 +43,7 @@ export async function fetchConfessStatus(): Promise<ConfessStatus> {
   return readJson<ConfessStatus>(response);
 }
 
-export async function submitConfession(event: ConfessAdmissionEvent): Promise<ConfessSubmitResponse> {
+export async function submitConfession(event: Event): Promise<ConfessSubmitResponse> {
   const response = await fetch(confessUrl("/api/confess"), {
     method: "POST",
     headers: {


### PR DESCRIPTION
## Summary
- remove the stale requirement for /api/confess/status to return a pubkey
- sign the mined Confess admission event client-side before submitting it to the current backend
- update the Confess page test to assert the signed backend contract

## Verification
- npm test -- src/features/confess/ConfessPage.test.tsx --run
- npm test -- --run
- npm run build
- deployed hotfix to https://wiredsignal.online/confess
