### PR TITLE
Add first-frame video previews

### DIFF
--- a/src/shared/ui/NoteMedia.test.tsx
+++ b/src/shared/ui/NoteMedia.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { NoteMedia } from "./NoteMedia";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("NoteMedia video previews", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("requests a first frame for bare video URLs", () => {
+    act(() => {
+      root.render(
+        <NoteMedia
+          items={[
+            {
+              url: "https://example.com/bare.mp4",
+              type: "video",
+              width: 640,
+              height: 360,
+            },
+          ]}
+        />,
+      );
+    });
+
+    const video = container.querySelector("video");
+    expect(video).not.toBeNull();
+    expect(video?.getAttribute("src")).toBe("https://example.com/bare.mp4");
+    expect(video?.getAttribute("preload")).toBe("auto");
+    expect(video?.hasAttribute("controls")).toBe(true);
+    expect(video?.getAttribute("poster")).toBeNull();
+    expect(video?.parentElement?.style.aspectRatio).toBe("640 / 360");
+    expect(container.textContent).toContain("video preview");
+
+    Object.defineProperty(video, "duration", {
+      configurable: true,
+      value: 12,
+    });
+
+    act(() => {
+      video?.dispatchEvent(new Event("loadedmetadata", { bubbles: true }));
+    });
+
+    expect(video?.currentTime).toBe(0.001);
+
+    act(() => {
+      video?.dispatchEvent(new Event("loadeddata", { bubbles: true }));
+    });
+
+    expect(container.textContent).not.toContain("video preview");
+  });
+
+  it("preserves imeta posters without seeking for a preview frame", () => {
+    act(() => {
+      root.render(
+        <NoteMedia
+          items={[
+            {
+              url: "https://example.com/clip.mp4",
+              type: "video",
+              posterUrl: "https://example.com/poster.jpg",
+            },
+          ]}
+        />,
+      );
+    });
+
+    const video = container.querySelector("video");
+    expect(video).not.toBeNull();
+    expect(video?.getAttribute("poster")).toBe("https://example.com/poster.jpg");
+    expect(video?.getAttribute("preload")).toBe("metadata");
+    expect(container.textContent).not.toContain("video preview");
+
+    Object.defineProperty(video, "duration", {
+      configurable: true,
+      value: 12,
+    });
+
+    act(() => {
+      video?.dispatchEvent(new Event("loadedmetadata", { bubbles: true }));
+    });
+
+    expect(video?.currentTime).toBe(0);
+  });
+
+  it("keeps the media fallback on video errors", () => {
+    act(() => {
+      root.render(
+        <NoteMedia
+          items={[
+            {
+              url: "https://example.com/broken.webm",
+              type: "video",
+            },
+          ]}
+        />,
+      );
+    });
+
+    const video = container.querySelector("video");
+
+    act(() => {
+      video?.dispatchEvent(new Event("error", { bubbles: true }));
+    });
+
+    expect(container.querySelector("video")).toBeNull();
+    expect(container.textContent).toContain("signal lost");
+  });
+});

--- a/src/shared/ui/NoteMedia.tsx
+++ b/src/shared/ui/NoteMedia.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { MediaItem } from "@lib/mediaUtils";
 import {
   optimizedImageSrcSet,
@@ -142,13 +142,35 @@ function MediaVideo({
   item: MediaItem;
   compact?: boolean;
 }) {
+  const videoRef = useRef<HTMLVideoElement>(null);
   const [failed, setFailed] = useState(false);
   const [started, setStarted] = useState(false);
+  const [previewReady, setPreviewReady] = useState(false);
 
   if (failed) return <MediaFallback />;
 
   const hasDimensions = Boolean(item.width && item.height);
   const aspectRatio = hasDimensions ? `${item.width} / ${item.height}` : "16 / 9";
+  const hasPoster = Boolean(item.posterUrl);
+  const requestFirstFrame = () => {
+    if (hasPoster) return;
+
+    const video = videoRef.current;
+    if (!video) return;
+
+    if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+      setPreviewReady(true);
+      return;
+    }
+
+    try {
+      if (Number.isFinite(video.duration) && video.duration > 0) {
+        video.currentTime = Math.min(0.001, video.duration);
+      }
+    } catch {
+      // Cross-origin or streaming media may reject seeking; native controls remain usable.
+    }
+  };
 
   return (
     <div
@@ -159,17 +181,21 @@ function MediaVideo({
       style={{ aspectRatio }}
     >
       <video
+        ref={videoRef}
         src={item.url}
         poster={item.posterUrl}
         controls
-        preload="metadata"
+        preload={hasPoster ? "metadata" : "auto"}
         playsInline
         onPlay={() => setStarted(true)}
-        onLoadedData={() => setStarted(true)}
+        onLoadedMetadata={requestFirstFrame}
+        onLoadedData={() => setPreviewReady(true)}
+        onCanPlay={() => setPreviewReady(true)}
+        onSeeked={() => setPreviewReady(true)}
         onError={() => setFailed(true)}
         className="h-full w-full object-contain"
       />
-      {!item.posterUrl && !started && (
+      {!hasPoster && !started && !previewReady && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-surface text-meta text-muted">
           <span
             aria-hidden="true"


### PR DESCRIPTION
Closes #62

## Root cause
Video media only used poster frames when `imeta` supplied `image` or `thumb`. Bare video URLs had no poster and could remain on the generic placeholder instead of showing a decoded first frame.

## Changes
- Keep existing `imeta` poster behavior.
- For posterless videos, request enough video data to surface the first frame.
- Preserve controls, stable aspect ratio, compact sizing, and fallback behavior.
- Add focused video media tests for first-frame request, supplied posters, and error fallback.

## Verification
- npm test -- src/shared/ui/NoteMedia.test.tsx
- npm run typecheck
- npm run lint (passes with existing Fast Refresh warnings in providers/settings)
- npm test
- npm run build

Note: dependencies were installed in the isolated worktree; npm reported existing audit findings.