### PR TITLE
Keep durable quote fallback relays

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_RELAYS, configuredRelays } from "./config";
 
 describe("DEFAULT_RELAYS", () => {
@@ -25,6 +25,25 @@ describe("configuredRelays", () => {
   it("uses fallback relays when env contains no wss URLs", () => {
     expect(configuredRelays("https://bad.example", ["wss://fallback.example"])).toEqual([
       "wss://fallback.example",
+    ]);
+  });
+});
+
+describe("QUOTE_FALLBACK_RELAYS", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("keeps default quote fallback relays when enrichment relays are narrowed", async () => {
+    vi.stubEnv("VITE_ENRICHMENT_RELAYS", "wss://configured.example");
+    vi.resetModules();
+
+    const config = await import("./config");
+
+    expect(config.ENRICHMENT_RELAYS).toEqual(["wss://configured.example"]);
+    expect(config.QUOTE_FALLBACK_RELAYS).toEqual([
+      ...config.DEFAULT_ENRICHMENT_RELAYS,
+      "wss://configured.example",
     ]);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,9 @@ export const ENRICHMENT_RELAYS = configuredRelays(
   DEFAULT_ENRICHMENT_RELAYS,
 );
 
-export const QUOTE_FALLBACK_RELAYS = ENRICHMENT_RELAYS;
+export const QUOTE_FALLBACK_RELAYS = [
+  ...new Set([...DEFAULT_ENRICHMENT_RELAYS, ...ENRICHMENT_RELAYS]),
+] as const;
 
 export const THREAD_RELAYS = [
   ...new Set([...POW_RELAYS, ...ENRICHMENT_RELAYS]),

--- a/src/nostr/subscriptions/quoted-events.test.ts
+++ b/src/nostr/subscriptions/quoted-events.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { POW_RELAYS, QUOTE_FALLBACK_RELAYS, THREAD_RELAYS } from "../../config";
 
 const mocks = vi.hoisted(() => ({
@@ -22,6 +22,10 @@ import { subQuotedEventsOnce } from "./index";
 const quoteId = "a38fb77ce8783c30bf64063fe78e8060f3b58e41476fb3a5cd94ddfb1b3837d1";
 
 describe("subQuotedEventsOnce", () => {
+  afterEach(() => {
+    vi.doUnmock("../../config");
+  });
+
   beforeEach(() => {
     mocks.ensureRelaysConnected.mockReset();
     mocks.initNostr.mockReset();
@@ -88,5 +92,37 @@ describe("subQuotedEventsOnce", () => {
 
     fallbackRequest.onEose();
     expect(onEose).toHaveBeenCalledWith(quoteId);
+  });
+
+  it("keeps default quote fallback relays with configured relays and issue relay hints", async () => {
+    const powRelays = ["wss://relay.wiredsignal.online"];
+    const defaultQuoteRelays = ["wss://relay.damus.io", "wss://offchain.pub"];
+    const configuredQuoteRelays = ["wss://configured.example"];
+
+    vi.resetModules();
+    vi.doMock("../../config", () => ({
+      POW_RELAYS: powRelays,
+      QUOTE_FALLBACK_RELAYS: [...defaultQuoteRelays, ...configuredQuoteRelays],
+      THREAD_RELAYS: [],
+    }));
+
+    const { subQuotedEventsOnce: subQuotedEventsOnceWithNarrowedConfig } = await import(
+      "./index"
+    );
+
+    await subQuotedEventsOnceWithNarrowedConfig(
+      [{ id: quoteId, relays: ["wss://nostr.land"] }],
+      vi.fn(),
+      vi.fn(),
+    );
+
+    const fallbackRequest = mocks.subscribe.mock.calls[0][0][0];
+    expect(fallbackRequest.relayUrls).toEqual([
+      ...powRelays,
+      ...defaultQuoteRelays,
+      ...configuredQuoteRelays,
+      "wss://nostr.land",
+    ]);
+    expect(mocks.ensureRelaysConnected).toHaveBeenCalledWith(["wss://nostr.land"]);
   });
 });


### PR DESCRIPTION
Closes #63

## Root cause
Quote lookup fallback relays were tied directly to `ENRICHMENT_RELAYS`. A production `VITE_ENRICHMENT_RELAYS` override could narrow the quote search set and remove default enrichment relays that hold quoted events.

## Changes
- Make `QUOTE_FALLBACK_RELAYS` include default enrichment relays plus configured enrichment relays.
- Add config coverage for narrowed enrichment env values.
- Add quoted-event subscription coverage for default fallbacks, configured relays, and the issue quote relay hint.

## Verification
- npm test -- src/config.test.ts src/nostr/subscriptions/quoted-events.test.ts src/shared/lib/quotedEvents.test.ts
- npm run typecheck
- npm run lint (passes with existing Fast Refresh warnings in providers/settings)
- npm test
- npm run build