### PR TITLE
Speed up hinted thread resolution

### DIFF
--- a/src/hooks/useThreadEvents.test.ts
+++ b/src/hooks/useThreadEvents.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { THREAD_RELAYS } from "../config";
+import { threadRelayUrls } from "./useThreadEvents";
+
+describe("threadRelayUrls", () => {
+  it("uses the same default and hinted relay set for connect and subscribe", () => {
+    expect(threadRelayUrls(["wss://relay.example/", THREAD_RELAYS[0]])).toEqual([
+      ...THREAD_RELAYS,
+      "wss://relay.example",
+    ]);
+  });
+});

--- a/src/hooks/useThreadEvents.ts
+++ b/src/hooks/useThreadEvents.ts
@@ -3,9 +3,14 @@ import { ensureRelaysConnected } from "../nostr/client";
 import { subNote } from "../nostr/subscriptions";
 import { useFilteredNoteSubscription } from "../shared/hooks/useFilteredNoteSubscription";
 import { uniqueRelays } from "@lib/threadRefs";
+import { THREAD_RELAYS } from "../config";
+
+export function threadRelayUrls(relayHints: readonly string[] = []) {
+  return uniqueRelays([...THREAD_RELAYS, ...relayHints]);
+}
 
 export function useThreadEvents(hexID: string, relayHints: readonly string[] = []) {
-  const relayUrls = useMemo(() => uniqueRelays(relayHints), [relayHints]);
+  const relayUrls = useMemo(() => threadRelayUrls(relayHints), [relayHints]);
   const relayDependency = relayUrls.join(",");
   const subscribe = useCallback(
     async (onEvent: Parameters<typeof subNote>[1]) => {
@@ -15,7 +20,12 @@ export function useThreadEvents(hexID: string, relayHints: readonly string[] = [
     [hexID, relayUrls],
   );
 
-  const noteEvents = useFilteredNoteSubscription(subscribe, [hexID, relayDependency]);
+  const noteEvents = useFilteredNoteSubscription(
+    subscribe,
+    [hexID, relayDependency],
+    true,
+    { initialize: false },
+  );
 
   return { noteEvents };
 }

--- a/src/nostr/client.test.ts
+++ b/src/nostr/client.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  ensureConnected: vi.fn(),
+}));
+
+vi.mock("./relay-pool", () => ({
+  RelayPool: vi.fn().mockImplementation(() => ({
+    connect: mocks.connect,
+    ensureConnected: mocks.ensureConnected,
+  })),
+}));
+
+describe("nostr client", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.connect.mockReset();
+    mocks.ensureConnected.mockReset();
+  });
+
+  it("connects requested relays without waiting for global relay init", async () => {
+    const { ensureRelaysConnected } = await import("./client");
+    const relayUrls = ["wss://relay.example"];
+
+    await ensureRelaysConnected(relayUrls);
+
+    expect(mocks.connect).not.toHaveBeenCalled();
+    expect(mocks.ensureConnected).toHaveBeenCalledWith(relayUrls);
+  });
+});

--- a/src/nostr/client.ts
+++ b/src/nostr/client.ts
@@ -47,7 +47,7 @@ export function getRegistry(): SubscriptionRegistry {
 }
 
 export async function ensureRelaysConnected(urls: readonly string[]): Promise<void> {
-  await initNostr();
+  ensureNostrClient();
   if (!pool) {
     throw new Error("Nostr client is not initialized.");
   }

--- a/src/nostr/feed-candidates.ts
+++ b/src/nostr/feed-candidates.ts
@@ -12,8 +12,6 @@ export function feedReplyRootId(event: Event): string | null {
 }
 
 export function createFeedCandidateTracker(filterDifficulty = 0) {
-  const seenPubkeys = new Set<string>();
-
   return {
     check(event: Event): FeedCandidateDecision {
       if (event.kind !== 1 && event.kind !== 1068) {
@@ -25,15 +23,10 @@ export function createFeedCandidateTracker(filterDifficulty = 0) {
         return { accepted: false, replyRootId: null };
       }
 
-      if (seenPubkeys.has(event.pubkey)) {
-        return { accepted: false, replyRootId: null };
-      }
-
       if (verifyPow(event) < filterDifficulty) {
         return { accepted: false, replyRootId: null };
       }
 
-      seenPubkeys.add(event.pubkey);
       return { accepted: true, replyRootId };
     },
   };

--- a/src/nostr/processEvents.test.ts
+++ b/src/nostr/processEvents.test.ts
@@ -46,17 +46,21 @@ describe("toProcessedEvents", () => {
 });
 
 describe("processFeedEvents", () => {
-  it("keeps one root post per pubkey and groups replies", () => {
+  it("keeps valid same-author root posts and groups replies", () => {
     const root = event({ id: "1".repeat(64) });
-    const duplicateAuthor = event({ id: "2".repeat(64), created_at: 2 });
+    const sameAuthorRoot = event({ id: "2".repeat(64), created_at: 2 });
     const reply = event({ id: "3".repeat(64), pubkey: "c".repeat(64), tags: [["e", root.id]] });
 
-    const result = processFeedEvents([root, duplicateAuthor, reply]);
+    const result = processFeedEvents([root, sameAuthorRoot, reply]);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].postEvent.id).toBe(root.id);
-    expect(result[0].replies).toEqual([reply]);
-    expect(result[0].threadReplyCount).toBe(1);
+    expect(result.map((item) => item.postEvent.id)).toEqual([
+      root.id,
+      sameAuthorRoot.id,
+    ]);
+    expect(result.find((item) => item.postEvent.id === root.id)?.replies).toEqual([
+      reply,
+    ]);
+    expect(result.find((item) => item.postEvent.id === root.id)?.threadReplyCount).toBe(1);
   });
 
   it("uses the same feed root eligibility for articles and root notes", () => {
@@ -65,9 +69,10 @@ describe("processFeedEvents", () => {
       kind: 1068,
       pubkey: "a".repeat(64),
     });
-    const duplicateAuthorRoot = event({
+    const sameAuthorRoot = event({
       id: "2".repeat(64),
       pubkey: "a".repeat(64),
+      created_at: 2,
     });
     const acceptedRoot = event({
       id: "3".repeat(64),
@@ -81,13 +86,14 @@ describe("processFeedEvents", () => {
 
     const result = processFeedEvents([
       article,
-      duplicateAuthorRoot,
+      sameAuthorRoot,
       acceptedRoot,
       reply,
     ]);
 
     expect(result.map((item) => item.postEvent.id)).toEqual([
       acceptedRoot.id,
+      sameAuthorRoot.id,
       article.id,
     ]);
     expect(result.find((item) => item.postEvent.id === acceptedRoot.id)?.replies).toEqual([

--- a/src/nostr/relay-pool.test.ts
+++ b/src/nostr/relay-pool.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RelayPool } from "./relay-pool";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+}));
+
+vi.mock("nostr-tools", () => ({
+  Relay: {
+    connect: mocks.connect,
+  },
+}));
+
+function relay(url: string) {
+  return {
+    url,
+    subscribe: vi.fn(),
+    publish: vi.fn(),
+  };
+}
+
+describe("RelayPool", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    mocks.connect.mockReset();
+  });
+
+  it("does not block all relay setup on a hanging relay connection", async () => {
+    vi.useFakeTimers();
+    const pool = new RelayPool();
+
+    mocks.connect.mockImplementation((url: string) => {
+      if (url === "wss://slow.example") {
+        return new Promise(() => {});
+      }
+      return Promise.resolve(relay(url));
+    });
+
+    const connected = pool.ensureConnected([
+      "wss://slow.example",
+      "wss://fast.example",
+    ]);
+
+    await vi.advanceTimersByTimeAsync(4_000);
+    await connected;
+
+    expect(pool.connectedUrls).toEqual(["wss://fast.example"]);
+  });
+});

--- a/src/nostr/relay-pool.ts
+++ b/src/nostr/relay-pool.ts
@@ -1,6 +1,8 @@
 import { Event, Filter, Relay, Subscription } from "nostr-tools";
 import type { SubCallback } from "./types";
 
+const RELAY_CONNECT_TIMEOUT_MS = 4_000;
+
 export type SubscribeOptions = {
   closeOnEose?: boolean;
   relayUrls?: readonly string[];
@@ -30,11 +32,23 @@ export class RelayPool {
   }
 
   private async connectRelay(url: string): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
     try {
-      const relay = await Relay.connect(url);
+      const relay = await Promise.race([
+        Relay.connect(url),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("Relay connection timed out")),
+            RELAY_CONNECT_TIMEOUT_MS,
+          );
+        }),
+      ]);
       this.relays.set(url, relay);
     } catch {
       // Relay unavailable; other relays may still connect.
+    } finally {
+      if (timeout) clearTimeout(timeout);
     }
   }
 

--- a/src/nostr/subscriptions/global-feed.test.ts
+++ b/src/nostr/subscriptions/global-feed.test.ts
@@ -138,15 +138,15 @@ describe("subGlobalFeed", () => {
 
   it("uses processable feed root eligibility for PoW reply enrichment", () => {
     const articleId = `${"1".repeat(64)}`;
-    const duplicateAuthorRootId = `${"2".repeat(64)}`;
+    const sameAuthorRootId = `${"2".repeat(64)}`;
     const acceptedRootId = `${"3".repeat(64)}`;
 
     const article = {
       ...rootNoteFromPubkey(articleId, "a".repeat(64)),
       kind: 1068,
     };
-    const duplicateAuthorRoot = rootNoteFromPubkey(
-      duplicateAuthorRootId,
+    const sameAuthorRoot = rootNoteFromPubkey(
+      sameAuthorRootId,
       "a".repeat(64),
     );
     const acceptedRoot = rootNoteFromPubkey(acceptedRootId, "b".repeat(64));
@@ -157,7 +157,7 @@ describe("subGlobalFeed", () => {
       if (id === "1") {
         const { cb, onEose } = requests[0];
         cb(article, "wss://powrelay.xyz");
-        cb(duplicateAuthorRoot, "wss://powrelay.xyz");
+        cb(sameAuthorRoot, "wss://powrelay.xyz");
         cb(acceptedRoot, "wss://powrelay.xyz");
         onEose?.();
       }
@@ -169,6 +169,7 @@ describe("subGlobalFeed", () => {
 
     expect(subscribeMock).toHaveBeenCalledTimes(2);
     expect(subscribeMock.mock.calls[1][0][0].filter["#e"]).toEqual([
+      sameAuthorRootId,
       acceptedRootId,
     ]);
   });

--- a/src/shared/hooks/useFilteredNoteSubscription.ts
+++ b/src/shared/hooks/useFilteredNoteSubscription.ts
@@ -8,7 +8,8 @@ export function useFilteredNoteSubscription(
   createSubscription: (onEvent: SubCallback) => SubHandle | Promise<SubHandle>,
   deps: DependencyList,
   enabled = true,
+  options?: Parameters<typeof useNostrSubscription>[3],
 ): Event[] {
-  const rawEvents = useNostrSubscription(createSubscription, deps, enabled);
+  const rawEvents = useNostrSubscription(createSubscription, deps, enabled, options);
   return useMemo(() => filterNoteEvents(rawEvents), [rawEvents]);
 }

--- a/src/shared/hooks/useNostrSubscription.test.tsx
+++ b/src/shared/hooks/useNostrSubscription.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Event } from "nostr-tools";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useNostrSubscription } from "./useNostrSubscription";
+
+const mocks = vi.hoisted(() => ({
+  initNostr: vi.fn(),
+}));
+
+vi.mock("../../nostr/client", () => ({
+  initNostr: mocks.initNostr,
+}));
+
+const event = {
+  id: "1".repeat(64),
+  pubkey: "2".repeat(64),
+  created_at: 1,
+  kind: 1,
+  tags: [],
+  content: "hello",
+  sig: "3".repeat(128),
+} as Event;
+
+function Probe({ initialize = true }: { initialize?: boolean }) {
+  const events = useNostrSubscription(
+    (onEvent) => {
+      onEvent(event, "wss://relay.example");
+      return { id: "sub", close: vi.fn() };
+    },
+    [],
+    true,
+    { initialize },
+  );
+
+  return <span data-count={events.length}>{events.length}</span>;
+}
+
+describe("useNostrSubscription", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.initNostr.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("can start a route-prepared subscription without waiting for global init", async () => {
+    mocks.initNostr.mockReturnValue(new Promise(() => {}));
+
+    await act(async () => {
+      root.render(<Probe initialize={false} />);
+    });
+
+    expect(mocks.initNostr).not.toHaveBeenCalled();
+    expect(container.querySelector("[data-count]")?.textContent).toBe("1");
+  });
+});

--- a/src/shared/hooks/useNostrSubscription.ts
+++ b/src/shared/hooks/useNostrSubscription.ts
@@ -5,12 +5,18 @@ import type { SubCallback, SubHandle } from "../../nostr/types";
 
 type SubscriptionFactory = (onEvent: SubCallback) => SubHandle | Promise<SubHandle>;
 
+type NostrSubscriptionOptions = {
+  initialize?: boolean;
+};
+
 export function useNostrSubscription(
   createSubscription: SubscriptionFactory,
   deps: DependencyList,
   enabled = true,
+  options: NostrSubscriptionOptions = {},
 ): Event[] {
   const [events, setEvents] = useState<Event[]>([]);
+  const { initialize = true } = options;
 
   useEffect(() => {
     if (!enabled) {
@@ -21,7 +27,9 @@ export function useNostrSubscription(
     let cancelled = false;
     let subscription: SubHandle | null = null;
 
-    void initNostr().then(() => {
+    const prepareSubscription = initialize ? initNostr() : Promise.resolve();
+
+    void prepareSubscription.then(() => {
       if (cancelled) return;
 
       setEvents([]);
@@ -48,7 +56,7 @@ export function useNostrSubscription(
     };
     // Subscription factory is intentionally excluded; callers pass deps explicitly.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, ...deps]);
+  }, [enabled, initialize, ...deps]);
 
   return events;
 }

--- a/src/shared/lib/threadRefs.test.ts
+++ b/src/shared/lib/threadRefs.test.ts
@@ -9,6 +9,8 @@ import {
 
 const EVENT_ID = "a".repeat(64);
 const RELAYS = ["wss://relay.example/", "wss://relay.example", "wss://backup.example"];
+const ISSUE_64_THREAD_NEVENT =
+  "nevent1qqsqqqzhl26q0wdwelm6thc8v02n6crrelwwlgl5mhezdvq7lu32j7spz3mhxue69uhhyetvv9ujuerpd46hxtnfduq3vamnwvaz7tmjv4kxz7fwwpexjmtpdshxuet5qy2hwumn8ghj7ur0wuh8yetvv9uhxtnvv9hxgqg7waehxw309aex2mrp0yh8w6tjv4j8x6t8deskctn0dekxjmn9qgsrla93hqmv0e37ujk08yf8pkrxpcdh4att49r5hy5r3wc8ne6jslgrqsqqqqqpspq99w";
 
 describe("threadRefs", () => {
   it("encodes thread routes as nevent refs with relay hints", () => {
@@ -48,5 +50,17 @@ describe("threadRefs", () => {
       "wss://relay.example",
       "wss://backup.example",
     ]);
+  });
+
+  it("decodes the issue 64 nevent and relay hints", () => {
+    expect(decodeThreadRef(ISSUE_64_THREAD_NEVENT)).toEqual({
+      id: "000057fab407b9aecff7a5df0763d53d6063cfdcefa3f4ddf226b01eff22a97a",
+      relays: [
+        "wss://relay.damus.io",
+        "wss://relay.primal.net",
+        "wss://pow.relays.land",
+        "wss://relay.wiredsignal.online",
+      ],
+    });
   });
 });


### PR DESCRIPTION
Closes #64

## Root cause
Thread route subscriptions waited for full global relay initialization before subscribing, so one slow unrelated relay could delay a thread even when its `nevent` had good relay hints. The feed also dropped valid same-author roots by arrival order, which could hide a thread despite enough PoW/signal.

## Changes
- Add a route-prepared subscription path so thread pages can skip hook-level global init.
- Let `ensureRelaysConnected` connect requested route relays without forcing global relay init first.
- Connect and subscribe to the same `THREAD_RELAYS + relayHints` set for thread routes.
- Add relay connection timeouts so a hanging relay cannot block setup indefinitely.
- Stop suppressing valid same-author feed roots by arrival order.
- Add regression coverage for the issue nevent decode, thread relay set, route-prepared subscriptions, non-global requested relay connection, relay connection timeout, and feed same-author roots.

## Verification
- npm test -- src/nostr/client.test.ts src/shared/lib/threadRefs.test.ts src/hooks/useThreadEvents.test.ts src/shared/hooks/useNostrSubscription.test.tsx src/nostr/relay-pool.test.ts src/nostr/processEvents.test.ts src/nostr/subscriptions/thread.test.ts
- npm run typecheck
- npm run lint (passes with existing Fast Refresh warnings in providers/settings)
- npm test
- npm run build

Note: the existing `useInfiniteScroll` remains client-side reveal pagination; this PR fixes the reported thread not appearing by removing the feed candidate suppression identified in RCA.