### PR TITLE
Recover truncated thread nevent routes

### DIFF
--- a/src/shared/lib/threadRefs.test.ts
+++ b/src/shared/lib/threadRefs.test.ts
@@ -11,6 +11,8 @@ const EVENT_ID = "a".repeat(64);
 const RELAYS = ["wss://relay.example/", "wss://relay.example", "wss://backup.example"];
 const ISSUE_64_THREAD_NEVENT =
   "nevent1qqsqqqzhl26q0wdwelm6thc8v02n6crrelwwlgl5mhezdvq7lu32j7spz3mhxue69uhhyetvv9ujuerpd46hxtnfduq3vamnwvaz7tmjv4kxz7fwwpexjmtpdshxuet5qy2hwumn8ghj7ur0wuh8yetvv9uhxtnvv9hxgqg7waehxw309aex2mrp0yh8w6tjv4j8x6t8deskctn0dekxjmn9qgsrla93hqmv0e37ujk08yf8pkrxpcdh4att49r5hy5r3wc8ne6jslgrqsqqqqqpspq99w";
+const ISSUE_68_TRUNCATED_NEVENT =
+  "nevent1qy08wumn8ghj7un9d3shjtnhd9ex2ernd9nkuctv9ehkumrfdejsz9rhwden5te0wfjkccte9ejxzmt4wvhxjmcpzfmhxue69uhk7enxvd5xz6tw9ec82cspp4mhxue69uhkummn9ekx7mqpzemhxue69uhhyetvv9ujuurjd9kkzmpwdejhgqgkwaehxw309aex2mrp0yhxummnw3ezucnpdejqzyrhwden5te0dehhxarj9emkjmn9qyv8wumn8ghj7un9d3shjtnndehhyapwwdhkx6tpdsqzqqqqp0j4rkuydfv66x8vxeq7v3jkvp5vs5437fugu4hupzr0vreu56p";
 
 describe("threadRefs", () => {
   it("does not add relay hints by default", () => {
@@ -75,6 +77,22 @@ describe("threadRefs", () => {
         "wss://relay.primal.net",
         "wss://pow.relays.land",
         "wss://relay.wiredsignal.online",
+      ],
+    });
+  });
+
+  it("recovers the issue 68 truncated nevent route", () => {
+    expect(decodeThreadRef(ISSUE_68_TRUNCATED_NEVENT)).toEqual({
+      id: "00000be551db846a59ad18ec3641e646566068c852b1f2788e56fc0886f60f3c",
+      relays: [
+        "wss://relay.wiredsignal.online",
+        "wss://relay.damus.io",
+        "wss://offchain.pub",
+        "wss://nos.lol",
+        "wss://relay.primal.net",
+        "wss://relay.nostr.band",
+        "wss://nostr.wine",
+        "wss://relay.snort.social",
       ],
     });
   });

--- a/src/shared/lib/threadRefs.ts
+++ b/src/shared/lib/threadRefs.ts
@@ -6,6 +6,11 @@ export type ThreadRef = {
 };
 
 const HEX_EVENT_ID_PATTERN = /^[0-9a-f]{64}$/i;
+const BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+const NEVENT_PREFIX = "nevent1";
+const EVENT_TLV_TYPE = 0;
+const RELAY_TLV_TYPE = 1;
+const EVENT_ID_LENGTH = 32;
 
 export function normalizeRelayUrl(relay: string): string {
   return relay.replace(/\/+$/, "");
@@ -32,6 +37,72 @@ export function buildThreadPath(
   return `/thread/${encodeThreadRef(eventId, relays)}`;
 }
 
+function bytesFromBech32Words(words: number[]): number[] {
+  const bytes: number[] = [];
+  let value = 0;
+  let bits = 0;
+
+  for (const word of words) {
+    value = (value << 5) | word;
+    bits += 5;
+
+    while (bits >= 8) {
+      bits -= 8;
+      bytes.push((value >> bits) & 0xff);
+    }
+  }
+
+  return bytes;
+}
+
+function parseNeventTlv(bytes: number[]): ThreadRef | null {
+  let index = 0;
+  let id: string | null = null;
+  const relays: string[] = [];
+
+  while (index < bytes.length) {
+    const type = bytes[index];
+    const length = bytes[index + 1];
+    const valueStart = index + 2;
+    const valueEnd = valueStart + length;
+
+    if (length === undefined || valueEnd > bytes.length) {
+      return null;
+    }
+
+    const value = bytes.slice(valueStart, valueEnd);
+
+    if (type === EVENT_TLV_TYPE && length === EVENT_ID_LENGTH) {
+      id = value.map((byte) => byte.toString(16).padStart(2, "0")).join("");
+    }
+
+    if (type === RELAY_TLV_TYPE) {
+      relays.push(String.fromCharCode(...value));
+    }
+
+    index = valueEnd;
+  }
+
+  return id ? { id, relays: uniqueRelays(relays) } : null;
+}
+
+function decodeTruncatedNevent(ref: string): ThreadRef | null {
+  if (!ref.startsWith(NEVENT_PREFIX)) return null;
+
+  const data = ref.slice(NEVENT_PREFIX.length).toLowerCase();
+  const words = [...data].map((char) => BECH32_CHARSET.indexOf(char));
+  if (words.some((word) => word < 0)) return null;
+
+  for (let checksumCharsPresent = 0; checksumCharsPresent < 6; checksumCharsPresent += 1) {
+    const dataWords =
+      checksumCharsPresent === 0 ? words : words.slice(0, -checksumCharsPresent);
+    const decoded = parseNeventTlv(bytesFromBech32Words(dataWords));
+    if (decoded) return decoded;
+  }
+
+  return null;
+}
+
 export function decodeThreadRef(ref: string | undefined): ThreadRef | null {
   if (!ref) return null;
 
@@ -49,6 +120,9 @@ export function decodeThreadRef(ref: string | undefined): ThreadRef | null {
       };
     }
   } catch {
+    const truncatedNevent = decodeTruncatedNevent(ref);
+    if (truncatedNevent) return truncatedNevent;
+
     if (HEX_EVENT_ID_PATTERN.test(ref)) {
       return { id: ref.toLowerCase(), relays: [] };
     }


### PR DESCRIPTION
Closes #68

## Root cause
The issue URL contains a legacy malformed `nevent` route param. Strict `nostr-tools` decoding rejects it as an invalid checksum, which makes `decodeThreadRef` return `null` and the thread page render `invalid signal ref`. The payload is recoverable: the ref is missing the final three bech32 characters, and the remaining data still contains the event id and relay hints.

## Changes
- Add a bounded fallback decoder for malformed/truncated `nevent` route refs after strict `nip19.decode` fails.
- Parse available bech32 data words directly as NIP-19 TLV data, recovering event id and relay hints without brute-force checksum search.
- Add a regression fixture for the exact issue #68 URL parameter.

## Verification
- npm test -- src/shared/lib/threadRefs.test.ts
- npm run typecheck
- npm run lint (passes with existing Fast Refresh warnings in providers/settings)
- npm test
- npm run build

Note: dependencies were installed in the isolated worktree; npm reported existing audit findings.