### PR TITLE
Use observed relay hints for thread nevents

### DIFF
--- a/src/features/compose/PostForm.tsx
+++ b/src/features/compose/PostForm.tsx
@@ -146,7 +146,12 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
           </p>
         )}
         {signedPoWEvent && (
-          <PostCard event={signedPoWEvent} replies={[]} onOpenThread={openThread} />
+          <PostCard
+            event={signedPoWEvent}
+            replies={[]}
+            relayHints={acceptedRelays}
+            onOpenThread={openThread}
+          />
         )}
       </div>
     </form>

--- a/src/features/feed/FeedPage.tsx
+++ b/src/features/feed/FeedPage.tsx
@@ -70,6 +70,7 @@ export default function FeedPage({ mode = "default" }: FeedPageProps) {
               replies={event.replies}
               totalWork={event.totalWork}
               replyCount={event.threadReplyCount}
+              relayHints={event.relayHints}
               animate={shouldResolve}
               animationIndex={index - SKIP_RESOLVE_COUNT}
               fadeIn={shouldFadeIn}

--- a/src/features/thread/useThreadNavigation.ts
+++ b/src/features/thread/useThreadNavigation.ts
@@ -8,9 +8,13 @@ export function useThreadNavigation() {
   const navigate = useNavigate();
 
   return useCallback(
-    (event: Event, relatedEvents: Event[]) => {
+    (
+      event: Event,
+      relatedEvents: Event[],
+      relayHints: readonly string[] = [],
+    ) => {
       writeThreadSeedEvents(event.id, relatedEvents);
-      navigate(buildThreadPath(event.id));
+      navigate(buildThreadPath(event.id, relayHints));
     },
     [navigate],
   );

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -2,9 +2,12 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Event } from "nostr-tools";
 import { subGlobalFeed, subRepliesForRootIds } from "../nostr/subscriptions";
 import { processFeedEvents } from "../nostr/processEvents";
+import type { RelayHintsByEventId } from "../nostr/types";
 import { useSettings } from "../app/settings";
 import { POW_RELAYS, THREAD_RELAYS } from "../config";
-import { useFilteredNoteSubscription } from "../shared/hooks/useFilteredNoteSubscription";
+import {
+  useFilteredNoteSubscriptionWithRelays,
+} from "../shared/hooks/useFilteredNoteSubscription";
 import { useModerationManifest } from "../shared/hooks/useModerationManifest";
 import { seedProfiles } from "../shared/hooks/useProfiles";
 import { filterModeratedEvents } from "../shared/lib/moderation";
@@ -12,6 +15,7 @@ import {
   canUseFeedBootstrap,
   eventsFromProcessed,
   fetchFeedBootstrapSnapshot,
+  relayHintsFromProcessed,
 } from "../shared/lib/feedBootstrapClient";
 
 const FEED_REPLY_DEPTH = 3;
@@ -26,6 +30,21 @@ function mergeNoteEvents(...eventGroups: Event[][]): Event[] {
   return [...merged.values()];
 }
 
+function mergeRelayHints(
+  ...hintGroups: RelayHintsByEventId[]
+): RelayHintsByEventId {
+  const merged = new Map<string, string[]>();
+
+  hintGroups.forEach((relayHintsByEventId) => {
+    relayHintsByEventId.forEach((relays, eventId) => {
+      const existing = merged.get(eventId) ?? [];
+      merged.set(eventId, [...new Set([...existing, ...relays])]);
+    });
+  });
+
+  return merged;
+}
+
 export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
   const { settings } = useSettings();
   const moderationManifest = useModerationManifest();
@@ -34,11 +53,14 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
   const bootstrapEligible = !isRawMode && canUseFeedBootstrap(settings);
   const [bootstrapEvents, setBootstrapEvents] = useState<Event[]>([]);
   const [bootstrapRootIds, setBootstrapRootIds] = useState<string[]>([]);
+  const [bootstrapRelayHintsByEventId, setBootstrapRelayHintsByEventId] =
+    useState<RelayHintsByEventId>(() => new Map());
 
   useEffect(() => {
     if (!bootstrapEligible) {
       setBootstrapEvents([]);
       setBootstrapRootIds([]);
+      setBootstrapRelayHintsByEventId(new Map());
       return;
     }
 
@@ -50,9 +72,13 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
         if (!snapshot) {
           setBootstrapEvents([]);
           setBootstrapRootIds([]);
+          setBootstrapRelayHintsByEventId(new Map());
           return;
         }
         setBootstrapEvents(eventsFromProcessed(snapshot.processedEvents));
+        setBootstrapRelayHintsByEventId(
+          relayHintsFromProcessed(snapshot.processedEvents),
+        );
         setBootstrapRootIds(
           snapshot.processedEvents.map((event) => event.postEvent.id),
         );
@@ -62,6 +88,7 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
         // Fall back to live relay subscription only.
         setBootstrapEvents([]);
         setBootstrapRootIds([]);
+        setBootstrapRelayHintsByEventId(new Map());
       });
 
     return () => {
@@ -84,7 +111,10 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
     [rawFilterDifficulty, settings.ageHours],
   );
 
-  const liveEvents = useFilteredNoteSubscription(subscribe, [
+  const {
+    noteEvents: liveEvents,
+    relayHintsByEventId: liveRelayHintsByEventId,
+  } = useFilteredNoteSubscriptionWithRelays(subscribe, [
     mode,
     settings.ageHours,
     rawFilterDifficulty,
@@ -101,7 +131,10 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [bootstrapRootKey],
   );
-  const bootstrapReplyEvents = useFilteredNoteSubscription(
+  const {
+    noteEvents: bootstrapReplyEvents,
+    relayHintsByEventId: bootstrapReplyRelayHintsByEventId,
+  } = useFilteredNoteSubscriptionWithRelays(
     subscribeBootstrapReplies,
     [bootstrapRootKey],
     !isRawMode && bootstrapRootIds.length > 0,
@@ -111,13 +144,31 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
     () => mergeNoteEvents(bootstrapEvents, liveEvents, bootstrapReplyEvents),
     [bootstrapEvents, liveEvents, bootstrapReplyEvents],
   );
+  const relayHintsByEventId = useMemo(
+    () =>
+      mergeRelayHints(
+        bootstrapRelayHintsByEventId,
+        liveRelayHintsByEventId,
+        bootstrapReplyRelayHintsByEventId,
+      ),
+    [
+      bootstrapRelayHintsByEventId,
+      liveRelayHintsByEventId,
+      bootstrapReplyRelayHintsByEventId,
+    ],
+  );
   const visibleNoteEvents = useMemo(
     () => filterModeratedEvents(noteEvents, moderationManifest),
     [noteEvents, moderationManifest],
   );
   const processedEvents = useMemo(
-    () => processFeedEvents(visibleNoteEvents, settings.filterDifficulty),
-    [visibleNoteEvents, settings.filterDifficulty],
+    () =>
+      processFeedEvents(
+        visibleNoteEvents,
+        settings.filterDifficulty,
+        relayHintsByEventId,
+      ),
+    [visibleNoteEvents, settings.filterDifficulty, relayHintsByEventId],
   );
 
   return { processedEvents, noteEvents: visibleNoteEvents };

--- a/src/nostr/processEvents.test.ts
+++ b/src/nostr/processEvents.test.ts
@@ -43,6 +43,30 @@ describe("toProcessedEvents", () => {
 
     expect(result.map((item) => item.postEvent.id)).toEqual([olderReply.id, newerReply.id]);
   });
+
+  it("adds relay hints for processed root posts", () => {
+    const op = event({ id: "1".repeat(64), created_at: 100 });
+    const reply = event({
+      id: "2".repeat(64),
+      pubkey: "b".repeat(64),
+      created_at: 101,
+      tags: [["e", op.id]],
+    });
+
+    const result = toProcessedEvents(
+      [op],
+      [reply],
+      new Map([
+        [op.id, ["wss://relay.example/", "wss://relay.example"]],
+        [reply.id, ["wss://reply.example"]],
+      ]),
+    );
+
+    expect(result[0]).toMatchObject({
+      postEvent: op,
+      relayHints: ["wss://relay.example"],
+    });
+  });
 });
 
 describe("processFeedEvents", () => {
@@ -61,6 +85,27 @@ describe("processFeedEvents", () => {
       reply,
     ]);
     expect(result.find((item) => item.postEvent.id === root.id)?.threadReplyCount).toBe(1);
+  });
+
+  it("carries observed relay hints for feed roots", () => {
+    const root = event({ id: "1".repeat(64) });
+    const reply = event({
+      id: "2".repeat(64),
+      pubkey: "b".repeat(64),
+      tags: [["e", root.id]],
+    });
+
+    const result = processFeedEvents(
+      [root, reply],
+      0,
+      new Map([
+        [root.id, ["wss://relay.wiredsignal.online"]],
+        [reply.id, ["wss://reply.example"]],
+      ]),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].relayHints).toEqual(["wss://relay.wiredsignal.online"]);
   });
 
   it("uses the same feed root eligibility for articles and root notes", () => {

--- a/src/nostr/processEvents.ts
+++ b/src/nostr/processEvents.ts
@@ -1,7 +1,7 @@
 import type { Event } from "nostr-tools";
 import { createFeedCandidateTracker } from "./feed-candidates.js";
 import { workScoreBreakdown } from "./processing/pow-score.js";
-import type { ProcessedEvent } from "./types.js";
+import type { ProcessedEvent, RelayHintsByEventId } from "./types.js";
 
 export type { ProcessedEvent } from "./types.js";
 
@@ -10,6 +10,24 @@ export function compareProcessedEventsByWork(
   b: ProcessedEvent,
 ): number {
   return b.totalWork - a.totalWork || b.postEvent.created_at - a.postEvent.created_at;
+}
+
+function normalizeRelayUrl(relay: string): string {
+  return relay.replace(/\/+$/, "");
+}
+
+function relayHintsForEvent(
+  eventId: string,
+  relayHintsByEventId?: RelayHintsByEventId,
+): string[] | undefined {
+  const relayHints = relayHintsByEventId?.get(eventId);
+  if (!relayHints) return undefined;
+
+  const normalized = [
+    ...new Set(relayHints.map(normalizeRelayUrl).filter(Boolean)),
+  ];
+
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 export function buildRepliesByParent(events: Event[]): Map<string, Event[]> {
@@ -51,6 +69,7 @@ export function collectThreadReplies(
 export function toProcessedEvents(
   posts: Event[],
   replySource: Event[],
+  relayHintsByEventId?: RelayHintsByEventId,
 ): ProcessedEvent[] {
   const repliesByParent = buildRepliesByParent(replySource);
 
@@ -60,6 +79,7 @@ export function toProcessedEvents(
       return {
         postEvent,
         replies,
+        relayHints: relayHintsForEvent(postEvent.id, relayHintsByEventId),
         threadReplyCount: replies.length,
         ...workScoreBreakdown(postEvent, replies),
       };
@@ -67,7 +87,11 @@ export function toProcessedEvents(
     .sort((a, b) => a.postEvent.created_at - b.postEvent.created_at);
 }
 
-export const processFeedEvents = (events: Event[], filterDifficulty = 0): ProcessedEvent[] => {
+export const processFeedEvents = (
+  events: Event[],
+  filterDifficulty = 0,
+  relayHintsByEventId?: RelayHintsByEventId,
+): ProcessedEvent[] => {
   const repliesByParent = buildRepliesByParent(events);
   const candidates = createFeedCandidateTracker(filterDifficulty);
   const posts: Event[] = [];
@@ -83,6 +107,7 @@ export const processFeedEvents = (events: Event[], filterDifficulty = 0): Proces
       return {
         postEvent,
         replies,
+        relayHints: relayHintsForEvent(postEvent.id, relayHintsByEventId),
         threadReplyCount: replies.length,
         ...workScoreBreakdown(postEvent, replies, {
           minReplyDifficulty: filterDifficulty,

--- a/src/nostr/types.ts
+++ b/src/nostr/types.ts
@@ -3,12 +3,15 @@ import type { Event } from "nostr-tools";
 export type ProcessedEvent = {
   postEvent: Event;
   replies: Event[];
+  relayHints?: string[];
   totalWork: number;
   rootWork?: number;
   replyWork?: number;
   rankingReplyCount?: number;
   threadReplyCount?: number;
 };
+
+export type RelayHintsByEventId = ReadonlyMap<string, readonly string[]>;
 
 export type SubCallback = (event: Event, relay: string) => void;
 

--- a/src/shared/hooks/useFilteredNoteSubscription.ts
+++ b/src/shared/hooks/useFilteredNoteSubscription.ts
@@ -1,8 +1,16 @@
 import { useMemo, type DependencyList } from "react";
 import type { Event } from "nostr-tools";
-import type { SubCallback, SubHandle } from "../../nostr/types";
+import type { RelayHintsByEventId, SubCallback, SubHandle } from "../../nostr/types";
 import { filterNoteEvents } from "@lib/noteEvents";
-import { useNostrSubscription } from "./useNostrSubscription";
+import {
+  useNostrSubscription,
+  useNostrSubscriptionWithRelays,
+} from "./useNostrSubscription";
+
+type FilteredNoteSubscriptionState = {
+  noteEvents: Event[];
+  relayHintsByEventId: RelayHintsByEventId;
+};
 
 export function useFilteredNoteSubscription(
   createSubscription: (onEvent: SubCallback) => SubHandle | Promise<SubHandle>,
@@ -12,4 +20,19 @@ export function useFilteredNoteSubscription(
 ): Event[] {
   const rawEvents = useNostrSubscription(createSubscription, deps, enabled, options);
   return useMemo(() => filterNoteEvents(rawEvents), [rawEvents]);
+}
+
+export function useFilteredNoteSubscriptionWithRelays(
+  createSubscription: (onEvent: SubCallback) => SubHandle | Promise<SubHandle>,
+  deps: DependencyList,
+  enabled = true,
+): FilteredNoteSubscriptionState {
+  const { events, relayHintsByEventId } = useNostrSubscriptionWithRelays(
+    createSubscription,
+    deps,
+    enabled,
+  );
+  const noteEvents = useMemo(() => filterNoteEvents(events), [events]);
+
+  return { noteEvents, relayHintsByEventId };
 }

--- a/src/shared/hooks/useNostrSubscription.ts
+++ b/src/shared/hooks/useNostrSubscription.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState, type DependencyList } from "react";
 import type { Event } from "nostr-tools";
 import { initNostr } from "../../nostr/client";
-import type { SubCallback, SubHandle } from "../../nostr/types";
+import type { RelayHintsByEventId, SubCallback, SubHandle } from "../../nostr/types";
 
 type SubscriptionFactory = (onEvent: SubCallback) => SubHandle | Promise<SubHandle>;
 
@@ -9,18 +9,31 @@ type NostrSubscriptionOptions = {
   initialize?: boolean;
 };
 
-export function useNostrSubscription(
+export type NostrSubscriptionState = {
+  events: Event[];
+  relayHintsByEventId: RelayHintsByEventId;
+};
+
+function normalizeRelayUrl(relay: string): string {
+  return relay.replace(/\/+$/, "");
+}
+
+export function useNostrSubscriptionWithRelays(
   createSubscription: SubscriptionFactory,
   deps: DependencyList,
   enabled = true,
   options: NostrSubscriptionOptions = {},
-): Event[] {
+): NostrSubscriptionState {
   const [events, setEvents] = useState<Event[]>([]);
+  const [relayHintsByEventId, setRelayHintsByEventId] = useState<Map<string, string[]>>(
+    () => new Map(),
+  );
   const { initialize = true } = options;
 
   useEffect(() => {
     if (!enabled) {
       setEvents([]);
+      setRelayHintsByEventId(new Map());
       return;
     }
 
@@ -33,11 +46,25 @@ export function useNostrSubscription(
       if (cancelled) return;
 
       setEvents([]);
+      setRelayHintsByEventId(new Map());
 
-      const onEvent = (event: Event) => {
+      const onEvent = (event: Event, relay: string) => {
         setEvents((current) =>
           current.some((e) => e.id === event.id) ? current : [...current, event],
         );
+
+        if (!relay) return;
+        const normalizedRelay = normalizeRelayUrl(relay);
+        if (!normalizedRelay) return;
+
+        setRelayHintsByEventId((current) => {
+          const existing = current.get(event.id) ?? [];
+          if (existing.includes(normalizedRelay)) return current;
+
+          const next = new Map(current);
+          next.set(event.id, [...existing, normalizedRelay]);
+          return next;
+        });
       };
 
       void Promise.resolve(createSubscription(onEvent)).then((nextSubscription) => {
@@ -58,5 +85,19 @@ export function useNostrSubscription(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, initialize, ...deps]);
 
-  return events;
+  return { events, relayHintsByEventId };
+}
+
+export function useNostrSubscription(
+  createSubscription: SubscriptionFactory,
+  deps: DependencyList,
+  enabled = true,
+  options: NostrSubscriptionOptions = {},
+): Event[] {
+  return useNostrSubscriptionWithRelays(
+    createSubscription,
+    deps,
+    enabled,
+    options,
+  ).events;
 }

--- a/src/shared/lib/feedBootstrapClient.test.ts
+++ b/src/shared/lib/feedBootstrapClient.test.ts
@@ -4,6 +4,7 @@ import {
   eventsFromProcessed,
   feedBootstrapUrls,
   fetchFeedBootstrapSnapshot,
+  relayHintsFromProcessed,
   VERCEL_FEED_BOOTSTRAP_URL,
 } from "./feedBootstrapClient";
 import type { FeedBootstrapResponse } from "./feedBootstrapClient";
@@ -30,6 +31,24 @@ describe("eventsFromProcessed", () => {
 
     expect(events).toHaveLength(2);
     expect(events.map((item) => item.id)).toEqual([root.id, reply.id]);
+  });
+});
+
+describe("relayHintsFromProcessed", () => {
+  it("returns relay hints for processed root events", () => {
+    const root = event({ id: "1".repeat(64) });
+    const reply = event({ id: "2".repeat(64), pubkey: "c".repeat(64) });
+
+    expect(
+      relayHintsFromProcessed([
+        {
+          postEvent: root,
+          replies: [reply],
+          relayHints: ["wss://relay.example"],
+          totalWork: 0,
+        },
+      ]),
+    ).toEqual(new Map([[root.id, ["wss://relay.example"]]]));
   });
 });
 

--- a/src/shared/lib/feedBootstrapClient.ts
+++ b/src/shared/lib/feedBootstrapClient.ts
@@ -1,5 +1,5 @@
 import type { Event } from "nostr-tools";
-import type { ProcessedEvent } from "../../nostr/types";
+import type { ProcessedEvent, RelayHintsByEventId } from "../../nostr/types";
 import type { ProfileMetadata } from "./profile";
 
 export type FeedBootstrapResponse = {
@@ -76,6 +76,19 @@ export function eventsFromProcessed(processedEvents: ProcessedEvent[]): Event[] 
   });
 
   return events;
+}
+
+export function relayHintsFromProcessed(
+  processedEvents: ProcessedEvent[],
+): RelayHintsByEventId {
+  const relayHintsByEventId = new Map<string, string[]>();
+
+  processedEvents.forEach((processed) => {
+    if (!processed.relayHints || processed.relayHints.length === 0) return;
+    relayHintsByEventId.set(processed.postEvent.id, processed.relayHints);
+  });
+
+  return relayHintsByEventId;
 }
 
 export {

--- a/src/shared/lib/threadRefs.test.ts
+++ b/src/shared/lib/threadRefs.test.ts
@@ -13,6 +13,21 @@ const ISSUE_64_THREAD_NEVENT =
   "nevent1qqsqqqzhl26q0wdwelm6thc8v02n6crrelwwlgl5mhezdvq7lu32j7spz3mhxue69uhhyetvv9ujuerpd46hxtnfduq3vamnwvaz7tmjv4kxz7fwwpexjmtpdshxuet5qy2hwumn8ghj7ur0wuh8yetvv9uhxtnvv9hxgqg7waehxw309aex2mrp0yh8w6tjv4j8x6t8deskctn0dekxjmn9qgsrla93hqmv0e37ujk08yf8pkrxpcdh4att49r5hy5r3wc8ne6jslgrqsqqqqqpspq99w";
 
 describe("threadRefs", () => {
+  it("does not add relay hints by default", () => {
+    const ref = encodeThreadRef(EVENT_ID);
+    const decoded = nip19.decode(ref);
+
+    expect(decoded.type).toBe("nevent");
+    if (decoded.type !== "nevent") {
+      throw new Error("expected nevent ref");
+    }
+    expect(decoded.data).toMatchObject({
+      id: EVENT_ID,
+      relays: [],
+    });
+    expect(buildThreadPath(EVENT_ID)).toBe(`/thread/${ref}`);
+  });
+
   it("encodes thread routes as nevent refs with relay hints", () => {
     const ref = encodeThreadRef(EVENT_ID, RELAYS);
     const decoded = nip19.decode(ref);

--- a/src/shared/lib/threadRefs.ts
+++ b/src/shared/lib/threadRefs.ts
@@ -1,5 +1,4 @@
 import { nip19 } from "nostr-tools";
-import { THREAD_RELAYS } from "../../config";
 
 export type ThreadRef = {
   id: string;
@@ -18,7 +17,7 @@ export function uniqueRelays(relays: readonly string[]): string[] {
 
 export function encodeThreadRef(
   eventId: string,
-  relays: readonly string[] = THREAD_RELAYS,
+  relays: readonly string[] = [],
 ): string {
   return nip19.neventEncode({
     id: eventId,
@@ -28,7 +27,7 @@ export function encodeThreadRef(
 
 export function buildThreadPath(
   eventId: string,
-  relays: readonly string[] = THREAD_RELAYS,
+  relays: readonly string[] = [],
 ): string {
   return `/thread/${encodeThreadRef(eventId, relays)}`;
 }

--- a/src/shared/ui/PostCard.tsx
+++ b/src/shared/ui/PostCard.tsx
@@ -25,7 +25,12 @@ interface PostCardProps {
   avatarPriority?: boolean;
   totalWork?: number;
   replyCount?: number;
-  onOpenThread?: (event: Event, relatedEvents: Event[]) => void;
+  relayHints?: readonly string[];
+  onOpenThread?: (
+    event: Event,
+    relatedEvents: Event[],
+    relayHints?: readonly string[],
+  ) => void;
 }
 
 const depthClasses: Record<number, string> = {
@@ -34,6 +39,7 @@ const depthClasses: Record<number, string> = {
   2: "pl-8 opacity-[0.84]",
   3: "pl-12 opacity-[0.76]",
 };
+const EMPTY_RELAY_HINTS: readonly string[] = [];
 
 function getDepthClass(depth?: number): string {
   if (depth === undefined) return "";
@@ -53,6 +59,7 @@ export function PostCard({
   avatarPriority = false,
   totalWork,
   replyCount,
+  relayHints = EMPTY_RELAY_HINTS,
   onOpenThread,
 }: PostCardProps) {
   const navigate = useNavigate();
@@ -68,12 +75,12 @@ export function PostCard({
 
   const handleNavigate = useCallback(() => {
     if (onOpenThread) {
-      onOpenThread(event, relatedEvents);
+      onOpenThread(event, relatedEvents, relayHints);
       return;
     }
 
-    navigate(buildThreadPath(event.id));
-  }, [event, onOpenThread, relatedEvents, navigate]);
+    navigate(buildThreadPath(event.id, relayHints));
+  }, [event, onOpenThread, relatedEvents, relayHints, navigate]);
 
   const roleClass = role === "threadContext" ? "opacity-70" : "";
 


### PR DESCRIPTION
## Summary
- stop defaulting thread nevent routes to all configured client relays
- carry observed relay hints through live/bootstrap feed processing
- pass observed or accepted relays into thread navigation

## Tests
- npm test -- src/shared/lib/threadRefs.test.ts src/nostr/processEvents.test.ts src/shared/lib/feedBootstrapClient.test.ts src/shared/hooks/useNostrSubscription.test.ts
- npm run typecheck