### PR TITLE
Expand feed snapshot scope

### DIFF
--- a/api/_shared/handlers.test.ts
+++ b/api/_shared/handlers.test.ts
@@ -23,6 +23,8 @@ const postEvent = {
 const snapshot: FeedBootstrapSnapshot = {
   fetchedAt: 123,
   processedEvents: [{ postEvent, replies: [], totalWork: 1 }],
+  events: [postEvent],
+  relayHintsByEventId: {},
   profiles: { pubkey: { name: "Ada" } },
 };
 

--- a/lib/feedBootstrapCache.test.ts
+++ b/lib/feedBootstrapCache.test.ts
@@ -20,6 +20,8 @@ vi.mock("./feedSnapshot.js", () => ({
 const snapshot = {
   fetchedAt: 123,
   processedEvents: [],
+  events: [],
+  relayHintsByEventId: {},
   profiles: {},
 };
 

--- a/lib/feedBootstrapCache.ts
+++ b/lib/feedBootstrapCache.ts
@@ -19,6 +19,9 @@ function isFeedBootstrapSnapshot(value: unknown): value is FeedBootstrapSnapshot
     typeof value === "object" &&
     typeof (value as FeedBootstrapSnapshot).fetchedAt === "number" &&
     Array.isArray((value as FeedBootstrapSnapshot).processedEvents) &&
+    Array.isArray((value as FeedBootstrapSnapshot).events) &&
+    !!(value as FeedBootstrapSnapshot).relayHintsByEventId &&
+    typeof (value as FeedBootstrapSnapshot).relayHintsByEventId === "object" &&
     !!(value as FeedBootstrapSnapshot).profiles &&
     typeof (value as FeedBootstrapSnapshot).profiles === "object"
   );

--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -15,8 +15,9 @@ import {
   sinceFromAgeHours,
 } from "../src/nostr/subscriptions/query-limits.js";
 import { processFeedEvents } from "../src/nostr/processEvents.js";
-import type { ProcessedEvent } from "../src/nostr/types.js";
+import type { ProcessedEvent, RelayHintsByEventId } from "../src/nostr/types.js";
 import { isRootNote } from "../src/shared/lib/noteEvents.js";
+import { extractMentionedEventRefs } from "../src/shared/lib/quotedEvents.js";
 import {
   parseProfileEvent,
   type ProfileMetadata,
@@ -29,11 +30,18 @@ const FEED_SNAPSHOT_RELAYS = [...THREAD_RELAYS];
 const REPLY_RELAYS = [...THREAD_RELAYS];
 
 const DEFAULT_TIMEOUT_MS = 12_000;
-const REPLY_FETCH_DEPTH = 3;
+const REPLY_FETCH_DEPTH = 2;
+
+type EventBatch = {
+  events: Event[];
+  relayHintsByEventId: Map<string, string[]>;
+};
 
 export type FeedBootstrapSnapshot = {
   fetchedAt: number;
   processedEvents: ProcessedEvent[];
+  events: Event[];
+  relayHintsByEventId: Record<string, string[]>;
   profiles: Record<string, ProfileMetadata>;
 };
 
@@ -51,6 +59,57 @@ const trackRootNote = (notes: Set<string>, evt: Event) => {
 
 function normalizeRelayUrl(url: string): string {
   return url.replace(/\/+$/, "");
+}
+
+function uniqueRelays(relays: readonly string[]): string[] {
+  return [...new Set(relays.map(normalizeRelayUrl).filter(Boolean))];
+}
+
+function addRelayHint(
+  relayHintsByEventId: Map<string, string[]>,
+  eventId: string,
+  relayUrl: string,
+): void {
+  const normalizedRelay = normalizeRelayUrl(relayUrl);
+  if (!normalizedRelay) return;
+
+  const existing = relayHintsByEventId.get(eventId) ?? [];
+  if (existing.includes(normalizedRelay)) return;
+
+  relayHintsByEventId.set(eventId, [...existing, normalizedRelay]);
+}
+
+function mergeRelayHints(
+  ...hintGroups: RelayHintsByEventId[]
+): Map<string, string[]> {
+  const merged = new Map<string, string[]>();
+
+  hintGroups.forEach((relayHintsByEventId) => {
+    relayHintsByEventId.forEach((relays, eventId) => {
+      relays.forEach((relay) => addRelayHint(merged, eventId, relay));
+    });
+  });
+
+  return merged;
+}
+
+function mergeEvents(...eventGroups: Event[][]): Event[] {
+  const merged = new Map<string, Event>();
+  eventGroups.forEach((events) => {
+    events.forEach((event) => merged.set(event.id, event));
+  });
+  return [...merged.values()];
+}
+
+function serializeRelayHints(
+  relayHintsByEventId: RelayHintsByEventId,
+): Record<string, string[]> {
+  return Object.fromEntries(
+    [...relayHintsByEventId.entries()].map(([eventId, relays]) => [
+      eventId,
+      uniqueRelays(relays),
+    ]),
+  );
 }
 
 async function connectRelays(urls: readonly string[], timeoutMs: number): Promise<Relay[]> {
@@ -82,9 +141,9 @@ async function subscribeOnce(
   filter: Filter,
   timeoutMs: number,
   relayUrls?: string[],
-): Promise<Event[]> {
+): Promise<EventBatch> {
   if (relays.length === 0) {
-    return [];
+    return { events: [], relayHintsByEventId: new Map() };
   }
 
   const targetRelays = relayUrls
@@ -96,11 +155,12 @@ async function subscribeOnce(
     : relays;
 
   if (targetRelays.length === 0) {
-    return [];
+    return { events: [], relayHintsByEventId: new Map() };
   }
 
   const events: Event[] = [];
   const seenIds = new Set<string>();
+  const relayHintsByEventId = new Map<string, string[]>();
 
   await new Promise<void>((resolve) => {
     const subscriptions: { close: () => void }[] = [];
@@ -120,6 +180,7 @@ async function subscribeOnce(
     for (const relay of targetRelays) {
       const sub = relay.subscribe([filter], {
         onevent(event) {
+          addRelayHint(relayHintsByEventId, event.id, relay.url);
           if (seenIds.has(event.id)) return;
           seenIds.add(event.id);
           events.push(event);
@@ -135,34 +196,36 @@ async function subscribeOnce(
     }
   });
 
-  return events;
+  return { events, relayHintsByEventId };
 }
 
 async function fetchGlobalFeedEvents(
   ageHours: number,
   timeoutMs: number,
-): Promise<Event[]> {
+): Promise<EventBatch> {
   const relays = await connectRelays(FEED_SNAPSHOT_RELAYS, timeoutMs);
 
   try {
     const notes = new Set<string>();
     const since = sinceFromAgeHours(ageHours);
 
-    const rootEvents = await subscribeOnce(
+    const rootBatch = await subscribeOnce(
       relays,
       { kinds: [1, 1068], since, limit: 500 },
       timeoutMs,
       [...POW_RELAYS],
     );
+    const rootEvents = rootBatch.events;
 
     rootEvents.forEach((event) => trackRootNote(notes, event));
 
     if (notes.size === 0) {
-      return rootEvents;
+      return rootBatch;
     }
 
     const replyEvents: Event[] = [];
     const seenReplyIds = new Set<string>();
+    const replyRelayHintsByEventId = new Map<string, string[]>();
     let parentIds = [...notes];
 
     const replyDepth = clampReplyDepth(REPLY_FETCH_DEPTH);
@@ -170,13 +233,18 @@ async function fetchGlobalFeedEvents(
       const replyFilter = buildReplyFilter(parentIds, since);
       if (!replyFilter) break;
 
-      const nextReplies = await subscribeOnce(
+      const replyBatch = await subscribeOnce(
         relays,
         replyFilter,
         timeoutMs,
         REPLY_RELAYS,
       );
+      const nextReplies = replyBatch.events;
       const nextParentIds: string[] = [];
+
+      replyBatch.relayHintsByEventId.forEach((relays, eventId) => {
+        relays.forEach((relay) => addRelayHint(replyRelayHintsByEventId, eventId, relay));
+      });
 
       nextReplies.forEach((event) => {
         if (seenReplyIds.has(event.id)) return;
@@ -189,12 +257,105 @@ async function fetchGlobalFeedEvents(
       parentIds = nextParentIds;
     }
 
-    const merged = new Map<string, Event>();
-    [...rootEvents, ...replyEvents].forEach((event) => {
-      merged.set(event.id, event);
-    });
+    return {
+      events: mergeEvents(rootEvents, replyEvents),
+      relayHintsByEventId: mergeRelayHints(
+        rootBatch.relayHintsByEventId,
+        replyRelayHintsByEventId,
+      ),
+    };
+  } finally {
+    closeRelays(relays);
+  }
+}
 
-    return [...merged.values()];
+function snapshotReferenceRefs(processedEvents: ProcessedEvent[]) {
+  const byId = new Map<string, { id: string; relays: string[] }>();
+
+  processedEvents.forEach((processed) => {
+    extractMentionedEventRefs(processed.postEvent).forEach((ref) => {
+      const existing = byId.get(ref.id);
+      if (existing) {
+        existing.relays = uniqueRelays([...existing.relays, ...ref.relays]);
+        return;
+      }
+      byId.set(ref.id, { id: ref.id, relays: uniqueRelays(ref.relays) });
+    });
+  });
+
+  return [...byId.values()];
+}
+
+async function fetchReferencedEvents(
+  refs: ReturnType<typeof snapshotReferenceRefs>,
+  knownEventIds: Set<string>,
+  ageHours: number,
+  timeoutMs: number,
+): Promise<EventBatch> {
+  const missingRefs = refs.filter((ref) => !knownEventIds.has(ref.id));
+  if (missingRefs.length === 0) {
+    return { events: [], relayHintsByEventId: new Map() };
+  }
+
+  const relayUrls = uniqueRelays([
+    ...FEED_SNAPSHOT_RELAYS,
+    ...missingRefs.flatMap((ref) => ref.relays),
+  ]);
+  const relays = await connectRelays(relayUrls, timeoutMs);
+
+  try {
+    const referencedBatch = await subscribeOnce(
+      relays,
+      {
+        ids: missingRefs.map((ref) => ref.id),
+        kinds: [1, 1068],
+        limit: missingRefs.length,
+      },
+      timeoutMs,
+      relayUrls,
+    );
+
+    const replyEvents: Event[] = [];
+    const seenReplyIds = new Set<string>();
+    const replyRelayHintsByEventId = new Map<string, string[]>();
+    const since = sinceFromAgeHours(ageHours);
+    let parentIds = referencedBatch.events.map((event) => event.id);
+
+    const replyDepth = clampReplyDepth(REPLY_FETCH_DEPTH);
+    for (let depth = 0; depth < replyDepth && parentIds.length > 0; depth += 1) {
+      const replyFilter = buildReplyFilter(parentIds, since);
+      if (!replyFilter) break;
+
+      const replyBatch = await subscribeOnce(
+        relays,
+        replyFilter,
+        timeoutMs,
+        relayUrls,
+      );
+      const nextParentIds: string[] = [];
+
+      replyBatch.relayHintsByEventId.forEach((relays, eventId) => {
+        relays.forEach((relay) => addRelayHint(replyRelayHintsByEventId, eventId, relay));
+      });
+
+      replyBatch.events.forEach((event) => {
+        if (knownEventIds.has(event.id) || seenReplyIds.has(event.id)) return;
+
+        seenReplyIds.add(event.id);
+        replyEvents.push(event);
+        nextParentIds.push(event.id);
+      });
+
+      parentIds = nextParentIds;
+    }
+
+    return {
+      events: mergeEvents(referencedBatch.events, replyEvents),
+      relayHintsByEventId: mergeRelayHints(
+        referencedBatch.relayHintsByEventId,
+        replyRelayHintsByEventId,
+      ),
+    };
   } finally {
     closeRelays(relays);
   }
@@ -211,7 +372,7 @@ async function fetchProfileMetadata(
   const relays = await connectRelays(PROFILE_RELAYS, timeoutMs);
 
   try {
-    const events = await subscribeOnce(
+    const { events } = await subscribeOnce(
       relays,
       {
         authors: pubkeys,
@@ -251,9 +412,14 @@ function pubkeysFromProcessedEvents(processedEvents: ProcessedEvent[]): string[]
 
   processedEvents.forEach((processed) => {
     pubkeys.add(processed.postEvent.pubkey);
+    processed.replies.forEach((reply) => pubkeys.add(reply.pubkey));
   });
 
   return [...pubkeys];
+}
+
+function pubkeysFromEvents(events: Event[]): string[] {
+  return [...new Set(events.map((event) => event.pubkey))];
 }
 
 export async function fetchFeedSnapshot(
@@ -263,16 +429,37 @@ export async function fetchFeedSnapshot(
   const filterDifficulty = options.filterDifficulty ?? BOOTSTRAP_FILTER_DIFFICULTY;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-  const events = await fetchGlobalFeedEvents(ageHours, timeoutMs);
-  const processedEvents = processFeedEvents(events, filterDifficulty);
+  const feedBatch = await fetchGlobalFeedEvents(ageHours, timeoutMs);
+  const processedEvents = processFeedEvents(
+    feedBatch.events,
+    filterDifficulty,
+    feedBatch.relayHintsByEventId,
+  );
+  const knownEventIds = new Set(feedBatch.events.map((event) => event.id));
+  const referencedBatch = await fetchReferencedEvents(
+    snapshotReferenceRefs(processedEvents),
+    knownEventIds,
+    ageHours,
+    timeoutMs,
+  );
+  const events = mergeEvents(feedBatch.events, referencedBatch.events);
+  const relayHintsByEventId = mergeRelayHints(
+    feedBatch.relayHintsByEventId,
+    referencedBatch.relayHintsByEventId,
+  );
   const profiles = await fetchProfileMetadata(
-    pubkeysFromProcessedEvents(processedEvents),
+    [...new Set([
+      ...pubkeysFromProcessedEvents(processedEvents),
+      ...pubkeysFromEvents(referencedBatch.events),
+    ])],
     timeoutMs,
   );
 
   return {
     fetchedAt: Date.now(),
     processedEvents,
+    events,
+    relayHintsByEventId: serializeRelayHints(relayHintsByEventId),
     profiles,
   };
 }

--- a/src/features/thread/ThreadPage.tsx
+++ b/src/features/thread/ThreadPage.tsx
@@ -10,13 +10,22 @@ import { ThreadComposer } from "../compose/ThreadComposer";
 import { useInfiniteScroll } from "../../shared/hooks/useInfiniteScroll";
 import { useThreadViewModel } from "../../hooks/useThreadViewModel";
 import { eventWork } from "../../nostr/processing/pow-score";
-import { readThreadSeedEvents } from "./threadSeedCache";
+import {
+  readThreadSeedEvents,
+  useSnapshotThreadSeedEvents,
+} from "./threadSeedCache";
 import { useThreadNavigation } from "./useThreadNavigation";
 import { decodeThreadRef } from "@lib/threadRefs";
+import { uniqBy } from "@lib/collections";
 
 function ThreadView({ hexID, relayHints }: { hexID: string; relayHints: string[] }) {
   const visibleReplyEvents = useInfiniteScroll();
-  const seedEvents = useMemo(() => readThreadSeedEvents(hexID), [hexID]);
+  const sessionSeedEvents = useMemo(() => readThreadSeedEvents(hexID), [hexID]);
+  const snapshotSeedEvents = useSnapshotThreadSeedEvents(hexID);
+  const seedEvents = useMemo(
+    () => uniqBy([...sessionSeedEvents, ...snapshotSeedEvents], "id"),
+    [sessionSeedEvents, snapshotSeedEvents],
+  );
   const openThread = useThreadNavigation();
   const {
     opEvent,

--- a/src/features/thread/threadSeedCache.ts
+++ b/src/features/thread/threadSeedCache.ts
@@ -1,4 +1,10 @@
 import type { Event } from "nostr-tools";
+import { useEffect, useState } from "react";
+import {
+  loadFeedBootstrapSnapshot,
+  threadEventsFromSnapshot,
+} from "../../shared/lib/feedBootstrapClient";
+import { seedProfiles } from "../../shared/hooks/useProfiles";
 
 const THREAD_SEED_PREFIX = "threadSeed:";
 
@@ -63,4 +69,30 @@ export function writeThreadSeedEvents(threadId: string, events: Event[]): void {
   } catch {
     // Seed persistence is an optimization; navigation should still work.
   }
+}
+
+export function useSnapshotThreadSeedEvents(threadId: string): Event[] {
+  const [events, setEvents] = useState<Event[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setEvents([]);
+
+    void loadFeedBootstrapSnapshot()
+      .then((snapshot) => {
+        if (cancelled || !snapshot) return;
+        seedProfiles(snapshot.profiles);
+        setEvents(threadEventsFromSnapshot(snapshot, threadId));
+      })
+      .catch(() => {
+        if (!cancelled) setEvents([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [threadId]);
+
+  return events;
 }

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -14,8 +14,8 @@ import { filterModeratedEvents } from "../shared/lib/moderation";
 import {
   canUseFeedBootstrap,
   eventsFromProcessed,
-  fetchFeedBootstrapSnapshot,
-  relayHintsFromProcessed,
+  loadFeedBootstrapSnapshot,
+  relayHintsFromSnapshot,
 } from "../shared/lib/feedBootstrapClient";
 
 const FEED_REPLY_DEPTH = 3;
@@ -66,7 +66,7 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
 
     let cancelled = false;
 
-    void fetchFeedBootstrapSnapshot()
+    void loadFeedBootstrapSnapshot()
       .then((snapshot) => {
         if (cancelled) return;
         if (!snapshot) {
@@ -77,7 +77,7 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
         }
         setBootstrapEvents(eventsFromProcessed(snapshot.processedEvents));
         setBootstrapRelayHintsByEventId(
-          relayHintsFromProcessed(snapshot.processedEvents),
+          relayHintsFromSnapshot(snapshot),
         );
         setBootstrapRootIds(
           snapshot.processedEvents.map((event) => event.postEvent.id),

--- a/src/hooks/useThreadViewModel.ts
+++ b/src/hooks/useThreadViewModel.ts
@@ -58,9 +58,9 @@ export function useThreadViewModel(
 
     return toProcessedEvents(
       posts,
-      filterModeratedEvents(noteEvents, moderationManifest),
+      allEvents,
     );
-  }, [opEvent, prevMentions, allEvents, noteEvents, moderationManifest]);
+  }, [opEvent, prevMentions, allEvents, moderationManifest]);
 
   const earlierEvents = useMemo(() => {
     if (!opEvent) return [];

--- a/src/shared/hooks/useQuotedEvents.ts
+++ b/src/shared/hooks/useQuotedEvents.ts
@@ -2,6 +2,11 @@ import { useEffect, useMemo, useState } from "react";
 import type { Event } from "nostr-tools";
 import { subQuotedEventsOnce } from "../../nostr/subscriptions";
 import { extractQuotedRefs, type QuotedRef } from "@lib/quotedEvents";
+import {
+  loadFeedBootstrapSnapshot,
+  snapshotEventById,
+} from "../lib/feedBootstrapClient";
+import { seedProfiles } from "./useProfiles";
 
 type QuotedEventsState = {
   quotedEvents: Event[];
@@ -37,7 +42,8 @@ export function useQuotedEvents(event: Event): QuotedEventsState {
       if (cancelled) return;
       setQuotedById((current) => {
         if (current.has(quoted.id)) return current;
-        return new Map(current).set(quoted.id, quoted);
+        const next = new Map(current).set(quoted.id, quoted);
+        return next;
       });
     };
 
@@ -49,12 +55,47 @@ export function useQuotedEvents(event: Event): QuotedEventsState {
       });
     };
 
-    void subQuotedEventsOnce(quotedRefs, onEvent, onEose).then((subscription) => {
-      if (cancelled) {
-        subscription.close();
+    void loadFeedBootstrapSnapshot().then((snapshot) => {
+      if (cancelled) return;
+
+      const snapshotEvents = snapshot ? snapshotEventById(snapshot) : new Map<string, Event>();
+      if (snapshot) seedProfiles(snapshot.profiles);
+      const refsMissingFromSnapshot: QuotedRef[] = [];
+      const nextQuotedById = new Map<string, Event>();
+
+      quotedRefs.forEach((ref) => {
+        const quoted = snapshotEvents.get(ref.id);
+        if (quoted) {
+          nextQuotedById.set(quoted.id, quoted);
+          return;
+        }
+        refsMissingFromSnapshot.push(ref);
+      });
+
+      setQuotedById(nextQuotedById);
+
+      if (refsMissingFromSnapshot.length === 0) {
         return;
       }
-      handle = subscription;
+
+      void subQuotedEventsOnce(refsMissingFromSnapshot, onEvent, onEose).then(
+        (subscription) => {
+          if (cancelled) {
+            subscription.close();
+            return;
+          }
+          handle = subscription;
+        },
+      );
+    }).catch(() => {
+      if (cancelled) return;
+      void subQuotedEventsOnce(quotedRefs, onEvent, onEose).then((subscription) => {
+        if (cancelled) {
+          subscription.close();
+          return;
+        }
+        handle = subscription;
+      });
     });
 
     return () => {

--- a/src/shared/lib/feedBootstrapClient.test.ts
+++ b/src/shared/lib/feedBootstrapClient.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 import { Event } from "nostr-tools";
 import {
   eventsFromProcessed,
+  eventsFromSnapshot,
   feedBootstrapUrls,
   fetchFeedBootstrapSnapshot,
-  relayHintsFromProcessed,
+  relayHintsFromSnapshot,
+  resetFeedBootstrapSnapshotCache,
+  threadEventsFromSnapshot,
   VERCEL_FEED_BOOTSTRAP_URL,
 } from "./feedBootstrapClient";
 import type { FeedBootstrapResponse } from "./feedBootstrapClient";
@@ -34,21 +37,80 @@ describe("eventsFromProcessed", () => {
   });
 });
 
-describe("relayHintsFromProcessed", () => {
+describe("eventsFromSnapshot", () => {
+  it("deduplicates raw and processed events", () => {
+    const root = event({ id: "1".repeat(64) });
+    const reply = event({ id: "2".repeat(64), pubkey: "c".repeat(64) });
+
+    expect(
+      eventsFromSnapshot({
+        fetchedAt: 1,
+        events: [root],
+        relayHintsByEventId: {},
+        processedEvents: [{ postEvent: root, replies: [reply], totalWork: 0 }],
+        profiles: {},
+      }).map((item) => item.id),
+    ).toEqual([root.id, reply.id]);
+  });
+});
+
+describe("relayHintsFromSnapshot", () => {
   it("returns relay hints for processed root events", () => {
     const root = event({ id: "1".repeat(64) });
     const reply = event({ id: "2".repeat(64), pubkey: "c".repeat(64) });
 
     expect(
-      relayHintsFromProcessed([
-        {
-          postEvent: root,
-          replies: [reply],
-          relayHints: ["wss://relay.example"],
-          totalWork: 0,
+      relayHintsFromSnapshot({
+        fetchedAt: 1,
+        events: [root, reply],
+        relayHintsByEventId: {
+          [reply.id]: ["wss://reply.example"],
         },
+        processedEvents: [
+          {
+            postEvent: root,
+            replies: [reply],
+            relayHints: ["wss://relay.example"],
+            totalWork: 0,
+          },
+        ],
+        profiles: {},
+      }),
+    ).toEqual(
+      new Map([
+        [reply.id, ["wss://reply.example"]],
+        [root.id, ["wss://relay.example"]],
       ]),
-    ).toEqual(new Map([[root.id, ["wss://relay.example"]]]));
+    );
+  });
+});
+
+describe("threadEventsFromSnapshot", () => {
+  it("returns an op with nested replies from the snapshot", () => {
+    const root = event({ id: "1".repeat(64) });
+    const directReply = event({
+      id: "2".repeat(64),
+      pubkey: "c".repeat(64),
+      tags: [["e", root.id]],
+    });
+    const nestedReply = event({
+      id: "3".repeat(64),
+      pubkey: "d".repeat(64),
+      tags: [["e", directReply.id]],
+    });
+
+    expect(
+      threadEventsFromSnapshot(
+        {
+          fetchedAt: 1,
+          events: [root, directReply, nestedReply],
+          relayHintsByEventId: {},
+          processedEvents: [],
+          profiles: {},
+        },
+        root.id,
+      ).map((item) => item.id),
+    ).toEqual([root.id, directReply.id, nestedReply.id]);
   });
 });
 
@@ -69,6 +131,8 @@ describe("fetchFeedBootstrapSnapshot", () => {
   const snapshot = (): FeedBootstrapResponse => ({
     fetchedAt: 1,
     processedEvents: [],
+    events: [],
+    relayHintsByEventId: {},
     profiles: {},
   });
 
@@ -79,6 +143,7 @@ describe("fetchFeedBootstrapSnapshot", () => {
     });
 
   it("returns the Cloudflare snapshot when it succeeds", async () => {
+    resetFeedBootstrapSnapshotCache();
     const calls: string[] = [];
     const fetcher = async (input: RequestInfo | URL) => {
       calls.push(String(input));
@@ -95,6 +160,7 @@ describe("fetchFeedBootstrapSnapshot", () => {
   });
 
   it("falls back to Vercel bootstrap when the Cloudflare snapshot fails", async () => {
+    resetFeedBootstrapSnapshotCache();
     const calls: string[] = [];
     const fetcher = async (input: RequestInfo | URL) => {
       calls.push(String(input));
@@ -117,6 +183,7 @@ describe("fetchFeedBootstrapSnapshot", () => {
   });
 
   it("falls back to Vercel bootstrap when the Cloudflare payload is invalid", async () => {
+    resetFeedBootstrapSnapshotCache();
     const calls: string[] = [];
     const fetcher = async (input: RequestInfo | URL) => {
       calls.push(String(input));
@@ -139,6 +206,7 @@ describe("fetchFeedBootstrapSnapshot", () => {
   });
 
   it("returns null when all bootstrap sources fail so live relays can take over", async () => {
+    resetFeedBootstrapSnapshotCache();
     const fetcher = async () => new Response("unavailable", { status: 503 });
 
     await expect(

--- a/src/shared/lib/feedBootstrapClient.ts
+++ b/src/shared/lib/feedBootstrapClient.ts
@@ -5,6 +5,8 @@ import type { ProfileMetadata } from "./profile";
 export type FeedBootstrapResponse = {
   fetchedAt: number;
   processedEvents: ProcessedEvent[];
+  events: Event[];
+  relayHintsByEventId: Record<string, string[]>;
   profiles: Record<string, ProfileMetadata>;
 };
 
@@ -15,6 +17,9 @@ type FetchLike = (
   input: RequestInfo | URL,
   init?: RequestInit,
 ) => Promise<Response>;
+
+let cachedSnapshot: FeedBootstrapResponse | null = null;
+let snapshotPromise: Promise<FeedBootstrapResponse | null> | null = null;
 
 function configuredFeedSnapshotUrl(): string | null {
   const url = import.meta.env[FEED_SNAPSHOT_URL_ENV]?.trim();
@@ -37,6 +42,9 @@ function isFeedBootstrapResponse(value: unknown): value is FeedBootstrapResponse
   return (
     typeof candidate.fetchedAt === "number" &&
     Array.isArray(candidate.processedEvents) &&
+    Array.isArray(candidate.events) &&
+    !!candidate.relayHintsByEventId &&
+    typeof candidate.relayHintsByEventId === "object" &&
     !!candidate.profiles &&
     typeof candidate.profiles === "object"
   );
@@ -63,6 +71,34 @@ export async function fetchFeedBootstrapSnapshot(
   return null;
 }
 
+export function loadFeedBootstrapSnapshot(
+  fetcher: FetchLike = fetch,
+  externalSnapshotUrl: string | null = configuredFeedSnapshotUrl(),
+): Promise<FeedBootstrapResponse | null> {
+  if (cachedSnapshot) return Promise.resolve(cachedSnapshot);
+  if (snapshotPromise) return snapshotPromise;
+
+  snapshotPromise = fetchFeedBootstrapSnapshot(fetcher, externalSnapshotUrl)
+    .then((snapshot) => {
+      cachedSnapshot = snapshot;
+      return snapshot;
+    })
+    .finally(() => {
+      snapshotPromise = null;
+    });
+
+  return snapshotPromise;
+}
+
+export function cachedFeedBootstrapSnapshot(): FeedBootstrapResponse | null {
+  return cachedSnapshot;
+}
+
+export function resetFeedBootstrapSnapshotCache(): void {
+  cachedSnapshot = null;
+  snapshotPromise = null;
+}
+
 export function eventsFromProcessed(processedEvents: ProcessedEvent[]): Event[] {
   const events: Event[] = [];
   const seen = new Set<string>();
@@ -78,17 +114,95 @@ export function eventsFromProcessed(processedEvents: ProcessedEvent[]): Event[] 
   return events;
 }
 
-export function relayHintsFromProcessed(
-  processedEvents: ProcessedEvent[],
+export function eventsFromSnapshot(snapshot: FeedBootstrapResponse): Event[] {
+  const events: Event[] = [];
+  const seen = new Set<string>();
+
+  [...snapshot.events, ...eventsFromProcessed(snapshot.processedEvents)].forEach((event) => {
+    if (seen.has(event.id)) return;
+    seen.add(event.id);
+    events.push(event);
+  });
+
+  return events;
+}
+
+export function relayHintsFromSnapshot(
+  snapshot: FeedBootstrapResponse,
 ): RelayHintsByEventId {
   const relayHintsByEventId = new Map<string, string[]>();
 
-  processedEvents.forEach((processed) => {
+  Object.entries(snapshot.relayHintsByEventId).forEach(([eventId, relays]) => {
+    relayHintsByEventId.set(eventId, [...new Set(relays)]);
+  });
+
+  snapshot.processedEvents.forEach((processed) => {
     if (!processed.relayHints || processed.relayHints.length === 0) return;
-    relayHintsByEventId.set(processed.postEvent.id, processed.relayHints);
+    const existing = relayHintsByEventId.get(processed.postEvent.id) ?? [];
+    relayHintsByEventId.set(
+      processed.postEvent.id,
+      [...new Set([...existing, ...processed.relayHints])],
+    );
   });
 
   return relayHintsByEventId;
+}
+
+export function snapshotEventById(snapshot: FeedBootstrapResponse): Map<string, Event> {
+  return new Map(eventsFromSnapshot(snapshot).map((event) => [event.id, event]));
+}
+
+function buildRepliesByParent(events: Event[]): Map<string, Event[]> {
+  const repliesByParent = new Map<string, Event[]>();
+
+  events.forEach((event) => {
+    if (event.kind !== 1) return;
+
+    event.tags.forEach((tag) => {
+      if (tag[0] !== "e" || !tag[1]) return;
+
+      const replies = repliesByParent.get(tag[1]) ?? [];
+      replies.push(event);
+      repliesByParent.set(tag[1], replies);
+    });
+  });
+
+  return repliesByParent;
+}
+
+export function threadEventsFromSnapshot(
+  snapshot: FeedBootstrapResponse,
+  threadId: string,
+): Event[] {
+  const eventsById = snapshotEventById(snapshot);
+  const opEvent = eventsById.get(threadId);
+  if (!opEvent) return [];
+
+  const repliesByParent = buildRepliesByParent(eventsFromSnapshot(snapshot));
+  const threadEvents: Event[] = [opEvent];
+  const seen = new Set<string>([opEvent.id]);
+  const pending = [...(repliesByParent.get(threadId) ?? [])];
+
+  while (pending.length > 0) {
+    const event = pending.shift();
+    if (!event || seen.has(event.id)) continue;
+
+    seen.add(event.id);
+    threadEvents.push(event);
+    pending.push(...(repliesByParent.get(event.id) ?? []));
+  }
+
+  opEvent.tags.forEach((tag) => {
+    if (tag[0] !== "e" || !tag[1] || seen.has(tag[1])) return;
+
+    const mentioned = eventsById.get(tag[1]);
+    if (!mentioned) return;
+
+    seen.add(mentioned.id);
+    threadEvents.push(mentioned);
+  });
+
+  return threadEvents;
 }
 
 export {

--- a/src/shared/lib/quotedEvents.test.ts
+++ b/src/shared/lib/quotedEvents.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { Event } from "nostr-tools";
-import { decodeNostrRef, extractQuotedRefs } from "./quotedEvents";
+import {
+  decodeNostrRef,
+  extractMentionedEventRefs,
+  extractQuotedRefs,
+} from "./quotedEvents";
 
 const QUOTED_POLL_ID = "48942b7f9e4501af2d9f8e668256c0652dcbe41fa0104acce6aca81ab9ff2de2";
 const QUOTED_POLL_NEVENT =
@@ -108,6 +112,27 @@ describe("extractQuotedRefs", () => {
         id: NOTE_TAG_ID,
         relays: [],
       },
+    ]);
+  });
+});
+
+describe("extractMentionedEventRefs", () => {
+  it("includes q tags, inline references, and e tags", () => {
+    const event = {
+      content: `see nostr:${QUOTED_POLL_NEVENT}`,
+      tags: [
+        ["q", "b".repeat(64), "wss://relay.example/"],
+        ["e", "d".repeat(64), "wss://relay.damus.io/"],
+      ],
+    } as Event;
+
+    expect(extractMentionedEventRefs(event)).toEqual([
+      { id: "b".repeat(64), relays: ["wss://relay.example"] },
+      {
+        id: QUOTED_POLL_ID,
+        relays: ["wss://relay.damus.io", "wss://offchain.pub"],
+      },
+      { id: "d".repeat(64), relays: ["wss://relay.damus.io"] },
     ]);
   });
 });

--- a/src/shared/lib/quotedEvents.ts
+++ b/src/shared/lib/quotedEvents.ts
@@ -80,6 +80,30 @@ export function extractQuotedRefs(event: Event): QuotedRef[] {
   return [...byId.values()];
 }
 
+export function extractMentionedEventRefs(event: Event): QuotedRef[] {
+  const byId = new Map<string, QuotedRef>();
+
+  const addRef = (id: string, relays: string[] = []) => {
+    const existing = byId.get(id);
+    if (existing) {
+      existing.relays = [...new Set([...existing.relays, ...relays])];
+      return;
+    }
+    byId.set(id, { id, relays: [...new Set(relays)] });
+  };
+
+  extractQuotedRefs(event).forEach((ref) => addRef(ref.id, ref.relays));
+
+  for (const tag of event.tags ?? []) {
+    if (tag[0] !== "e" || !tag[1] || !EVENT_ID_PATTERN.test(tag[1])) continue;
+
+    const relayHint = tag[2] ? normalizeRelayUrl(tag[2]) : undefined;
+    addRef(tag[1].toLowerCase(), relayHint ? [relayHint] : []);
+  }
+
+  return [...byId.values()];
+}
+
 /** @deprecated Use extractQuotedRefs instead. */
 export function extractQuotedEventIds(event: Event): string[] {
   return extractQuotedRefs(event).map((ref) => ref.id);


### PR DESCRIPTION
## Summary
- expand the feed snapshot payload with a raw event pool and relay hints
- capture quoted/mentioned root-post references plus depth-2 replies
- use the snapshot to seed quote previews and direct /thread routes before live relay updates

Closes #70.

## Testing
- npm run typecheck
- npm test
- npm run lint (passes with existing react-refresh warnings in src/app/providers.tsx and src/app/settings.tsx)
- npm run build
- git diff --check