### PR TITLE
Fix Vercel API runtime errors

### DIFF
--- a/api/_shared/handlers.test.ts
+++ b/api/_shared/handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   handleFeedBootstrapApi,
   handleFeedRefreshApi,
@@ -29,6 +29,23 @@ const snapshot: FeedBootstrapSnapshot = {
 };
 
 describe("shared API handlers", () => {
+  const originalCronSecret = process.env.CRON_SECRET;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    if (originalCronSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalCronSecret;
+    }
+
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
   it("rejects unsupported methods consistently", async () => {
     await expect(handleUnfurlApi({ method: "POST" })).resolves.toMatchObject({
       status: 405,
@@ -49,6 +66,8 @@ describe("shared API handlers", () => {
   });
 
   it("returns a refresh summary from the shared cache service", async () => {
+    delete process.env.CRON_SECRET;
+    process.env.NODE_ENV = "test";
     const service = new FeedBootstrapCacheService({
       store: new MemoryFeedBootstrapStore(),
       fetchSnapshot: vi.fn().mockResolvedValue(snapshot),
@@ -63,5 +82,70 @@ describe("shared API handlers", () => {
         profileCount: 1,
       },
     });
+  });
+
+  it("accepts cron authorization headers case-insensitively", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.CRON_SECRET = "secret";
+    const service = new FeedBootstrapCacheService({
+      store: new MemoryFeedBootstrapStore(),
+      fetchSnapshot: vi.fn().mockResolvedValue(snapshot),
+    });
+
+    await expect(
+      handleFeedRefreshApi(
+        {
+          method: "GET",
+          headers: { Authorization: "Bearer secret" },
+        },
+        { service },
+      ),
+    ).resolves.toMatchObject({ status: 200 });
+  });
+
+  it("rejects cron refreshes without the configured production secret", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.CRON_SECRET = "secret";
+    const service = new FeedBootstrapCacheService({
+      store: new MemoryFeedBootstrapStore(),
+      fetchSnapshot: vi.fn().mockResolvedValue(snapshot),
+    });
+
+    await expect(
+      handleFeedRefreshApi(
+        {
+          method: "GET",
+          headers: { authorization: "Bearer wrong" },
+        },
+        { service },
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("can schedule cron refreshes in the background", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.CRON_SECRET = "secret";
+    const waitUntil = vi.fn();
+    const service = new FeedBootstrapCacheService({
+      store: new MemoryFeedBootstrapStore(),
+      fetchSnapshot: vi.fn().mockResolvedValue(snapshot),
+    });
+
+    await expect(
+      handleFeedRefreshApi(
+        {
+          method: "GET",
+          headers: { authorization: "Bearer secret" },
+        },
+        { service, waitUntil },
+      ),
+    ).resolves.toMatchObject({
+      status: 202,
+      body: { ok: true, refresh: "started" },
+    });
+
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await expect(waitUntil.mock.calls[0][0]).resolves.toEqual(snapshot);
+    await expect(service.read()).resolves.toEqual(snapshot);
   });
 });

--- a/api/_shared/handlers.ts
+++ b/api/_shared/handlers.ts
@@ -25,6 +25,7 @@ export type ApiResult = {
 
 export type FeedApiOptions = {
   service?: FeedBootstrapCacheService;
+  waitUntil?: (promise: Promise<unknown>) => void;
 };
 
 function json(status: number, body: unknown, headers: Record<string, string> = {}): ApiResult {
@@ -56,13 +57,26 @@ function getQueryValue(req: ApiRequest, key: string): string {
   return requestUrl.searchParams.get(key) ?? "";
 }
 
+function getHeaderValue(req: ApiRequest, key: string): string {
+  const headers = req.headers;
+  if (!headers) return "";
+
+  const lowerKey = key.toLowerCase();
+  for (const [headerKey, value] of Object.entries(headers)) {
+    if (headerKey.toLowerCase() !== lowerKey) continue;
+    return firstQueryValue(value);
+  }
+
+  return "";
+}
+
 function isAuthorized(req: ApiRequest): boolean {
   const cronSecret = process.env.CRON_SECRET;
   if (!cronSecret) {
     return process.env.NODE_ENV !== "production";
   }
 
-  const authorization = req.headers?.authorization;
+  const authorization = getHeaderValue(req, "authorization");
   return authorization === `Bearer ${cronSecret}`;
 }
 
@@ -114,7 +128,7 @@ export async function handleFeedBootstrapApi(
 
 export async function handleFeedRefreshApi(
   req: ApiRequest,
-  { service = getDefaultFeedBootstrapService() }: FeedApiOptions = {},
+  { service = getDefaultFeedBootstrapService(), waitUntil }: FeedApiOptions = {},
 ): Promise<ApiResult> {
   if (req.method !== "GET") {
     return methodNotAllowed();
@@ -122,6 +136,15 @@ export async function handleFeedRefreshApi(
 
   if (!isAuthorized(req)) {
     return json(401, { error: "unauthorized" });
+  }
+
+  if (waitUntil) {
+    const wasRefreshing = service.isRefreshing();
+    waitUntil(service.refresh().catch(() => undefined));
+    return json(202, {
+      ok: true,
+      refresh: wasRefreshing ? "already-running" : "started",
+    });
   }
 
   try {

--- a/api/cron/refresh-feed.ts
+++ b/api/cron/refresh-feed.ts
@@ -1,7 +1,8 @@
+import { waitUntil } from "@vercel/functions";
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { handleFeedRefreshApi } from "../_shared/handlers.js";
 import { sendJson } from "../_shared/vercel.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  return sendJson(res, await handleFeedRefreshApi(req));
+  return sendJson(res, await handleFeedRefreshApi(req, { waitUntil }));
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,13 +30,24 @@ export function configuredRelays(
   return relays.length > 0 ? relays : fallback;
 }
 
+function configuredEnv(key: string): string | undefined {
+  const viteEnv = import.meta.env as Record<string, string | undefined> | undefined;
+  if (viteEnv?.[key] !== undefined) return viteEnv[key];
+
+  if (typeof process !== "undefined") {
+    return process.env[key];
+  }
+
+  return undefined;
+}
+
 export const POW_RELAYS = configuredRelays(
-  import.meta.env.VITE_POW_RELAYS,
+  configuredEnv("VITE_POW_RELAYS"),
   DEFAULT_RELAYS,
 );
 
 export const ENRICHMENT_RELAYS = configuredRelays(
-  import.meta.env.VITE_ENRICHMENT_RELAYS,
+  configuredEnv("VITE_ENRICHMENT_RELAYS"),
   DEFAULT_ENRICHMENT_RELAYS,
 );
 
@@ -48,6 +59,6 @@ export const THREAD_RELAYS = [
   ...new Set([...POW_RELAYS, ...ENRICHMENT_RELAYS]),
 ] as const;
 
-export const CONFESS_API_BASE = (import.meta.env.VITE_CONFESS_API_BASE || "")
+export const CONFESS_API_BASE = (configuredEnv("VITE_CONFESS_API_BASE") || "")
   .trim()
   .replace(/\/+$/, "");


### PR DESCRIPTION
## Summary
- make shared config safe in Vercel Node runtimes instead of assuming `import.meta.env` exists
- make cron auth header lookup case-insensitive
- schedule feed refresh work with Vercel `waitUntil` so cron returns before function timeout
- add regression coverage for cron auth and background scheduling

## Verification
- `npm test -- --run src/config.test.ts api/_shared/handlers.test.ts lib/feedBootstrapCache.test.ts lib/unfurl.test.ts`
- `npm run build`
- production hotfix deployed and verified on `wiredsignal.online`: `/api/unfurl` returns 200, authenticated `/api/cron/refresh-feed` returns 202, unauthenticated cron returns 401
