### PR TITLE
Document staging preview client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Optional moderation filtering:
 - The web client only consumes the manifest for client-side filtering. Moderation management and admin actions stay in the local Umbrel relay app and are not part of this Vercel deployment.
 - If the manifest URL is unset or unavailable, moderation filtering fails open and the feed continues to use snapshots/live relays.
 
+Staging previews:
+
+- Use `docs/staging.env.example` to point a local or Vercel preview branch at
+  the Wired Admin staging relay and snapshot origin.
+- See `docs/staging-preview.md` for the staging workflow.
+
 Run a durable local snapshot origin:
 
 ```sh

--- a/docs/staging-preview.md
+++ b/docs/staging-preview.md
@@ -1,0 +1,26 @@
+# Wired staging preview
+
+Wired client branches can use the shared Wired Admin staging relay and snapshot
+origin without changing source code.
+
+Copy the values from `docs/staging.env.example` into a local `.env.local` or a
+Vercel preview environment.
+
+```sh
+npm run dev
+```
+
+The staging admin origin is:
+
+```text
+https://staging.wiredsignal.online
+```
+
+The client uses it for:
+
+- feed bootstrap snapshots
+- moderation manifests
+- PoW relay writes and reads
+- Confess API calls
+
+Do not commit local `.env*` files.

--- a/docs/staging.env.example
+++ b/docs/staging.env.example
@@ -1,0 +1,5 @@
+VITE_FEED_SNAPSHOT_URL=https://staging.wiredsignal.online/api/feed/bootstrap
+VITE_MODERATION_MANIFEST_URL=https://staging.wiredsignal.online/api/moderation/manifest
+VITE_POW_RELAYS=wss://staging.wiredsignal.online,wss://powrelay.xyz,wss://pow.relays.land
+VITE_ENRICHMENT_RELAYS=wss://staging.wiredsignal.online,wss://relay.damus.io,wss://offchain.pub,wss://nos.lol,wss://relay.primal.net,wss://relay.nostr.band,wss://nostr.wine,wss://relay.snort.social
+VITE_CONFESS_API_BASE=https://staging.wiredsignal.online


### PR DESCRIPTION
## Summary
- document how Wired dev branches can use the wired-admin staging origin
- add a staging env example for snapshot, moderation, relay, and Confess endpoints
- link the staging guide from the README

## Validation
- npm run typecheck
- npm run test
- npm run build

Note: validation was run in the existing Wired worktree after applying the same docs-only change. The PR branch is clean off origin/main and contains only the staging docs.
