### PR TITLE
Surface feed roots from fresh PoW activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Optional feed snapshot bootstrap:
 
 - Set `VITE_FEED_SNAPSHOT_URL` to a public JSON snapshot URL, such as an Umbrel service exposed through Cloudflare Tunnel.
 - The client tries that snapshot first, falls back to `/api/feed/bootstrap`, then falls back to live Nostr relay subscriptions if both bootstrap sources fail.
-- The snapshot response should match `/api/feed/bootstrap`: `{ "fetchedAt": number, "processedEvents": [], "profiles": {} }`.
+- The snapshot response should match `/api/feed/bootstrap`: `fetchedAt`, `processedEvents`, `eventsById`, `relayHintsByEventId`, `profiles`, and `scoring`. `processedEvents` is the authoritative main-feed list; `eventsById` may include extra hydration events for quoted notes and threads.
 
 Optional relay configuration:
 

--- a/api/_shared/handlers.test.ts
+++ b/api/_shared/handlers.test.ts
@@ -21,11 +21,18 @@ const postEvent = {
 };
 
 const snapshot: FeedBootstrapSnapshot = {
+  version: 2,
   fetchedAt: 123,
-  processedEvents: [{ postEvent, replies: [], totalWork: 1 }],
-  events: [postEvent],
+  processedEvents: [{ postEventId: postEvent.id, replyIds: [], totalWork: 1 }],
+  eventsById: { [postEvent.id]: postEvent },
   relayHintsByEventId: {},
   profiles: { pubkey: { name: "Ada" } },
+  scoring: {
+    ageHours: 24,
+    minPow: 16,
+    replyDepth: 2,
+    sort: "totalWork",
+  },
 };
 
 describe("shared API handlers", () => {

--- a/api/_shared/handlers.test.ts
+++ b/api/_shared/handlers.test.ts
@@ -21,9 +21,16 @@ const postEvent = {
 };
 
 const snapshot: FeedBootstrapSnapshot = {
-  version: 2,
   fetchedAt: 123,
-  processedEvents: [{ postEventId: postEvent.id, replyIds: [], totalWork: 1 }],
+  processedEvents: [{
+    postEventId: postEvent.id,
+    replyIds: [],
+    threadReplyCount: 0,
+    rootWork: 1,
+    replyWork: 0,
+    totalWork: 1,
+    rankingReplyCount: 0,
+  }],
   eventsById: { [postEvent.id]: postEvent },
   relayHintsByEventId: {},
   profiles: { pubkey: { name: "Ada" } },

--- a/lib/feedBootstrapCache.test.ts
+++ b/lib/feedBootstrapCache.test.ts
@@ -18,11 +18,18 @@ vi.mock("./feedSnapshot.js", () => ({
 }));
 
 const snapshot = {
+  version: 2,
   fetchedAt: 123,
   processedEvents: [],
-  events: [],
+  eventsById: {},
   relayHintsByEventId: {},
   profiles: {},
+  scoring: {
+    ageHours: 24,
+    minPow: 16,
+    replyDepth: 2,
+    sort: "totalWork",
+  },
 };
 
 async function loadCacheModule() {

--- a/lib/feedBootstrapCache.test.ts
+++ b/lib/feedBootstrapCache.test.ts
@@ -18,7 +18,6 @@ vi.mock("./feedSnapshot.js", () => ({
 }));
 
 const snapshot = {
-  version: 2,
   fetchedAt: 123,
   processedEvents: [],
   eventsById: {},

--- a/lib/feedBootstrapCache.ts
+++ b/lib/feedBootstrapCache.ts
@@ -7,29 +7,12 @@ import {
   BOOTSTRAP_CACHE_TTL_SECONDS,
 } from "./feedBootstrap.js";
 import { fetchFeedSnapshot, type FeedBootstrapSnapshot } from "./feedSnapshot.js";
+import { isFeedBootstrapSnapshot } from "../src/shared/lib/feedBootstrapTypes.js";
 
 export type FeedBootstrapStore = {
   read(): Promise<FeedBootstrapSnapshot | null>;
   write(snapshot: FeedBootstrapSnapshot): Promise<void>;
 };
-
-function isFeedBootstrapSnapshot(value: unknown): value is FeedBootstrapSnapshot {
-  return (
-    !!value &&
-    typeof value === "object" &&
-    (value as FeedBootstrapSnapshot).version === 2 &&
-    typeof (value as FeedBootstrapSnapshot).fetchedAt === "number" &&
-    Array.isArray((value as FeedBootstrapSnapshot).processedEvents) &&
-    !!(value as FeedBootstrapSnapshot).eventsById &&
-    typeof (value as FeedBootstrapSnapshot).eventsById === "object" &&
-    !!(value as FeedBootstrapSnapshot).relayHintsByEventId &&
-    typeof (value as FeedBootstrapSnapshot).relayHintsByEventId === "object" &&
-    !!(value as FeedBootstrapSnapshot).profiles &&
-    typeof (value as FeedBootstrapSnapshot).profiles === "object" &&
-    !!(value as FeedBootstrapSnapshot).scoring &&
-    typeof (value as FeedBootstrapSnapshot).scoring === "object"
-  );
-}
 
 export class MemoryFeedBootstrapStore implements FeedBootstrapStore {
   private snapshot: FeedBootstrapSnapshot | null;

--- a/lib/feedBootstrapCache.ts
+++ b/lib/feedBootstrapCache.ts
@@ -17,13 +17,17 @@ function isFeedBootstrapSnapshot(value: unknown): value is FeedBootstrapSnapshot
   return (
     !!value &&
     typeof value === "object" &&
+    (value as FeedBootstrapSnapshot).version === 2 &&
     typeof (value as FeedBootstrapSnapshot).fetchedAt === "number" &&
     Array.isArray((value as FeedBootstrapSnapshot).processedEvents) &&
-    Array.isArray((value as FeedBootstrapSnapshot).events) &&
+    !!(value as FeedBootstrapSnapshot).eventsById &&
+    typeof (value as FeedBootstrapSnapshot).eventsById === "object" &&
     !!(value as FeedBootstrapSnapshot).relayHintsByEventId &&
     typeof (value as FeedBootstrapSnapshot).relayHintsByEventId === "object" &&
     !!(value as FeedBootstrapSnapshot).profiles &&
-    typeof (value as FeedBootstrapSnapshot).profiles === "object"
+    typeof (value as FeedBootstrapSnapshot).profiles === "object" &&
+    !!(value as FeedBootstrapSnapshot).scoring &&
+    typeof (value as FeedBootstrapSnapshot).scoring === "object"
   );
 }
 

--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -49,11 +49,29 @@ type FeedEventBatch = EventBatch & {
 };
 
 export type FeedBootstrapSnapshot = {
+  version: 2;
   fetchedAt: number;
-  processedEvents: ProcessedEvent[];
-  events: Event[];
+  processedEvents: FeedBootstrapProcessedEvent[];
+  eventsById: Record<string, Event>;
   relayHintsByEventId: Record<string, string[]>;
   profiles: Record<string, ProfileMetadata>;
+  scoring: {
+    ageHours: number;
+    minPow: number;
+    replyDepth: number;
+    sort: "totalWork";
+  };
+};
+
+export type FeedBootstrapProcessedEvent = {
+  postEventId: string;
+  replyIds: string[];
+  relayHints?: string[];
+  threadReplyCount?: number;
+  rootWork?: number;
+  replyWork?: number;
+  totalWork: number;
+  rankingReplyCount?: number;
 };
 
 export type FeedSnapshotOptions = {
@@ -545,6 +563,36 @@ function pubkeysFromEvents(events: Event[]): string[] {
   return [...new Set(events.map((event) => event.pubkey))];
 }
 
+function eventsById(events: Event[]): Record<string, Event> {
+  return Object.fromEntries(
+    mergeEvents(events).map((event) => [event.id.toLowerCase(), event]),
+  );
+}
+
+function serializeProcessedEvents(
+  processedEvents: ProcessedEvent[],
+): FeedBootstrapProcessedEvent[] {
+  return processedEvents.map((processed) => {
+    const serialized: FeedBootstrapProcessedEvent = {
+      postEventId: processed.postEvent.id.toLowerCase(),
+      replyIds: processed.replies.map((reply) => reply.id.toLowerCase()),
+      totalWork: processed.totalWork,
+    };
+    if (processed.relayHints && processed.relayHints.length > 0) {
+      serialized.relayHints = processed.relayHints;
+    }
+    if (processed.threadReplyCount !== undefined) {
+      serialized.threadReplyCount = processed.threadReplyCount;
+    }
+    if (processed.rootWork !== undefined) serialized.rootWork = processed.rootWork;
+    if (processed.replyWork !== undefined) serialized.replyWork = processed.replyWork;
+    if (processed.rankingReplyCount !== undefined) {
+      serialized.rankingReplyCount = processed.rankingReplyCount;
+    }
+    return serialized;
+  });
+}
+
 export async function fetchFeedSnapshot(
   options: FeedSnapshotOptions = {},
 ): Promise<FeedBootstrapSnapshot> {
@@ -584,10 +632,17 @@ export async function fetchFeedSnapshot(
   );
 
   return {
+    version: 2,
     fetchedAt: Date.now(),
-    processedEvents,
-    events,
+    processedEvents: serializeProcessedEvents(processedEvents),
+    eventsById: eventsById(events),
     relayHintsByEventId: serializeRelayHints(relayHintsByEventId),
     profiles,
+    scoring: {
+      ageHours,
+      minPow: filterDifficulty,
+      replyDepth: REPLY_FETCH_DEPTH,
+      sort: "totalWork",
+    },
   };
 }

--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -18,10 +18,12 @@ import { processFeedEvents } from "../src/nostr/processEvents.js";
 import type { ProcessedEvent, RelayHintsByEventId } from "../src/nostr/types.js";
 import {
   buildFeedEventMap,
-  feedActivityRootRef,
-  feedRootRefsFromActivity,
+  ROOT_RESOLUTION_DEPTH,
+  feedRootRefsFromQualifyingActivity,
   isFeedThreadRootEvent,
   mergeFeedRootRefs,
+  planFeedRootResolution,
+  resolveFeedRootRef,
   type FeedRootRef,
 } from "../src/nostr/feed-candidates.js";
 import { extractMentionedEventRefs } from "../src/shared/lib/quotedEvents.js";
@@ -29,6 +31,10 @@ import {
   parseProfileEvent,
   type ProfileMetadata,
 } from "../src/shared/lib/profile.js";
+import type {
+  FeedBootstrapProcessedEvent,
+  FeedBootstrapSnapshot,
+} from "../src/shared/lib/feedBootstrapTypes.js";
 
 useWebSocketImplementation(WebSocket);
 
@@ -48,40 +54,13 @@ type FeedEventBatch = EventBatch & {
   activityRootIds: string[];
 };
 
-export type FeedBootstrapSnapshot = {
-  version: 2;
-  fetchedAt: number;
-  processedEvents: FeedBootstrapProcessedEvent[];
-  eventsById: Record<string, Event>;
-  relayHintsByEventId: Record<string, string[]>;
-  profiles: Record<string, ProfileMetadata>;
-  scoring: {
-    ageHours: number;
-    minPow: number;
-    replyDepth: number;
-    sort: "totalWork";
-  };
-};
-
-export type FeedBootstrapProcessedEvent = {
-  postEventId: string;
-  replyIds: string[];
-  relayHints?: string[];
-  threadReplyCount?: number;
-  rootWork?: number;
-  replyWork?: number;
-  totalWork: number;
-  rankingReplyCount?: number;
-};
+export type { FeedBootstrapSnapshot };
 
 export type FeedSnapshotOptions = {
   ageHours?: number;
   filterDifficulty?: number;
   timeoutMs?: number;
 };
-
-const ROOT_FETCH_DEPTH = 4;
-const ROOT_QUERY_LIMIT = 500;
 
 function normalizeRelayUrl(url: string): string {
   return url.replace(/\/+$/, "");
@@ -242,30 +221,14 @@ async function fetchRootEvents(
 
   for (
     let depth = 0;
-    depth < ROOT_FETCH_DEPTH && refsToResolve.length > 0;
+    depth < ROOT_RESOLUTION_DEPTH && refsToResolve.length > 0;
     depth += 1
   ) {
-    const fetchRefs: FeedRootRef[] = [];
-
-    refsToResolve.forEach((ref) => {
-      const knownEvent = eventsById.get(ref.id);
-      if (!knownEvent) {
-        fetchRefs.push(ref);
-        return;
-      }
-
-      const nextRef = feedActivityRootRef(knownEvent, eventsById);
-      if (nextRef && nextRef.id !== ref.id) {
-        fetchRefs.push({
-          id: nextRef.id,
-          relays: uniqueRelays([...ref.relays, ...nextRef.relays]),
-        });
-      }
-    });
-
-    const pendingRefs = mergeFeedRootRefs(fetchRefs)
-      .filter((ref) => !requestedIds.has(ref.id) && !eventsById.has(ref.id))
-      .slice(0, ROOT_QUERY_LIMIT);
+    const { refsToFetch: pendingRefs } = planFeedRootResolution(
+      refsToResolve,
+      eventsById,
+      requestedIds,
+    );
     if (pendingRefs.length === 0) break;
 
     pendingRefs.forEach((ref) => requestedIds.add(ref.id));
@@ -278,38 +241,31 @@ async function fetchRootEvents(
 
     try {
       const nextRefs: FeedRootRef[] = [];
+      const ids = pendingRefs.map((ref) => ref.id);
+      const batch = await subscribeOnce(
+        relays,
+        {
+          ids,
+          kinds: [1],
+          limit: ids.length,
+        },
+        timeoutMs,
+        relayUrls,
+      );
 
-      for (let index = 0; index < pendingRefs.length; index += ROOT_QUERY_LIMIT) {
-        const ids = pendingRefs
-          .slice(index, index + ROOT_QUERY_LIMIT)
-          .map((ref) => ref.id);
-        if (ids.length === 0) continue;
-
-        const batch = await subscribeOnce(
-          relays,
-          {
-            ids,
-            kinds: [1, 1068],
-            limit: ids.length,
-          },
-          timeoutMs,
-          relayUrls,
+      events.push(...batch.events);
+      batch.events.forEach((event) => {
+        eventsById.set(event.id.toLowerCase(), event);
+        const nextRef = resolveFeedRootRef(event, eventsById);
+        if (nextRef && nextRef.id !== event.id.toLowerCase()) {
+          nextRefs.push(nextRef);
+        }
+      });
+      batch.relayHintsByEventId.forEach((relaysForEvent, eventId) => {
+        relaysForEvent.forEach((relay) =>
+          addRelayHint(relayHintsByEventId, eventId, relay),
         );
-
-        events.push(...batch.events);
-        batch.events.forEach((event) => {
-          eventsById.set(event.id.toLowerCase(), event);
-          const nextRef = feedActivityRootRef(event, eventsById);
-          if (nextRef && nextRef.id !== event.id.toLowerCase()) {
-            nextRefs.push(nextRef);
-          }
-        });
-        batch.relayHintsByEventId.forEach((relaysForEvent, eventId) => {
-          relaysForEvent.forEach((relay) =>
-            addRelayHint(relayHintsByEventId, eventId, relay),
-          );
-        });
-      }
+      });
 
       refsToResolve = mergeFeedRootRefs(nextRefs);
     } finally {
@@ -332,12 +288,12 @@ async function fetchGlobalFeedEvents(
 
     const activityBatch = await subscribeOnce(
       relays,
-      { kinds: [1, 1068], since, limit: 500 },
+      { kinds: [1], since, limit: 500 },
       timeoutMs,
       [...POW_RELAYS],
     );
     const activityEvents = activityBatch.events;
-    const activityRootRefs = feedRootRefsFromActivity(
+    const activityRootRefs = feedRootRefsFromQualifyingActivity(
       activityEvents,
       filterDifficulty,
     );
@@ -353,7 +309,7 @@ async function fetchGlobalFeedEvents(
     );
     const seedEvents = mergeEvents(activityEvents, resolvedRootBatch.events);
     const seedEventsById = buildFeedEventMap(seedEvents);
-    const rootRefs = feedRootRefsFromActivity(
+    const rootRefs = feedRootRefsFromQualifyingActivity(
       activityEvents,
       filterDifficulty,
       seedEventsById,
@@ -576,18 +532,14 @@ function serializeProcessedEvents(
     const serialized: FeedBootstrapProcessedEvent = {
       postEventId: processed.postEvent.id.toLowerCase(),
       replyIds: processed.replies.map((reply) => reply.id.toLowerCase()),
+      threadReplyCount: processed.threadReplyCount ?? processed.replies.length,
+      rootWork: processed.rootWork ?? 0,
+      replyWork: processed.replyWork ?? 0,
       totalWork: processed.totalWork,
+      rankingReplyCount: processed.rankingReplyCount ?? 0,
     };
     if (processed.relayHints && processed.relayHints.length > 0) {
       serialized.relayHints = processed.relayHints;
-    }
-    if (processed.threadReplyCount !== undefined) {
-      serialized.threadReplyCount = processed.threadReplyCount;
-    }
-    if (processed.rootWork !== undefined) serialized.rootWork = processed.rootWork;
-    if (processed.replyWork !== undefined) serialized.replyWork = processed.replyWork;
-    if (processed.rankingReplyCount !== undefined) {
-      serialized.rankingReplyCount = processed.rankingReplyCount;
     }
     return serialized;
   });
@@ -632,7 +584,6 @@ export async function fetchFeedSnapshot(
   );
 
   return {
-    version: 2,
     fetchedAt: Date.now(),
     processedEvents: serializeProcessedEvents(processedEvents),
     eventsById: eventsById(events),

--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -17,8 +17,11 @@ import {
 import { processFeedEvents } from "../src/nostr/processEvents.js";
 import type { ProcessedEvent, RelayHintsByEventId } from "../src/nostr/types.js";
 import {
-  feedActivityRootRefs,
-  isQualifyingFeedActivity,
+  buildFeedEventMap,
+  feedActivityRootRef,
+  feedRootRefsFromActivity,
+  isFeedThreadRootEvent,
+  mergeFeedRootRefs,
   type FeedRootRef,
 } from "../src/nostr/feed-candidates.js";
 import { extractMentionedEventRefs } from "../src/shared/lib/quotedEvents.js";
@@ -59,7 +62,8 @@ export type FeedSnapshotOptions = {
   timeoutMs?: number;
 };
 
-const ROOT_QUERY_LIMIT = 50;
+const ROOT_FETCH_DEPTH = 4;
+const ROOT_QUERY_LIMIT = 500;
 
 function normalizeRelayUrl(url: string): string {
   return url.replace(/\/+$/, "");
@@ -114,16 +118,6 @@ function serializeRelayHints(
       uniqueRelays(relays),
     ]),
   );
-}
-
-function mergeRootRef(roots: Map<string, FeedRootRef>, ref: FeedRootRef): void {
-  const existing = roots.get(ref.id);
-  if (!existing) {
-    roots.set(ref.id, { id: ref.id, relays: uniqueRelays(ref.relays) });
-    return;
-  }
-
-  existing.relays = uniqueRelays([...existing.relays, ...ref.relays]);
 }
 
 async function connectRelays(urls: readonly string[], timeoutMs: number): Promise<Relay[]> {
@@ -215,45 +209,97 @@ async function subscribeOnce(
 
 async function fetchRootEvents(
   rootRefs: FeedRootRef[],
+  knownEvents: Event[],
   timeoutMs: number,
 ): Promise<EventBatch> {
   if (rootRefs.length === 0) {
     return { events: [], relayHintsByEventId: new Map() };
   }
 
-  const relayUrls = uniqueRelays([
-    ...FEED_SNAPSHOT_RELAYS,
-    ...rootRefs.flatMap((ref) => ref.relays),
-  ]);
-  const relays = await connectRelays(relayUrls, timeoutMs);
+  const events: Event[] = [];
+  const eventsById = buildFeedEventMap(knownEvents);
+  const relayHintsByEventId = new Map<string, string[]>();
+  const requestedIds = new Set<string>();
+  let refsToResolve = mergeFeedRootRefs(rootRefs);
 
-  try {
-    const events: Event[] = [];
-    const relayHintsByEventId = new Map<string, string[]>();
+  for (
+    let depth = 0;
+    depth < ROOT_FETCH_DEPTH && refsToResolve.length > 0;
+    depth += 1
+  ) {
+    const fetchRefs: FeedRootRef[] = [];
 
-    for (let index = 0; index < rootRefs.length; index += ROOT_QUERY_LIMIT) {
-      const ids = rootRefs.slice(index, index + ROOT_QUERY_LIMIT).map((ref) => ref.id);
-      const batch = await subscribeOnce(
-        relays,
-        {
-          ids,
-          kinds: [1, 1068],
-          limit: ids.length,
-        },
-        timeoutMs,
-        relayUrls,
-      );
+    refsToResolve.forEach((ref) => {
+      const knownEvent = eventsById.get(ref.id);
+      if (!knownEvent) {
+        fetchRefs.push(ref);
+        return;
+      }
 
-      events.push(...batch.events);
-      batch.relayHintsByEventId.forEach((relaysForEvent, eventId) => {
-        relaysForEvent.forEach((relay) => addRelayHint(relayHintsByEventId, eventId, relay));
-      });
+      const nextRef = feedActivityRootRef(knownEvent, eventsById);
+      if (nextRef && nextRef.id !== ref.id) {
+        fetchRefs.push({
+          id: nextRef.id,
+          relays: uniqueRelays([...ref.relays, ...nextRef.relays]),
+        });
+      }
+    });
+
+    const pendingRefs = mergeFeedRootRefs(fetchRefs)
+      .filter((ref) => !requestedIds.has(ref.id) && !eventsById.has(ref.id))
+      .slice(0, ROOT_QUERY_LIMIT);
+    if (pendingRefs.length === 0) break;
+
+    pendingRefs.forEach((ref) => requestedIds.add(ref.id));
+
+    const relayUrls = uniqueRelays([
+      ...FEED_SNAPSHOT_RELAYS,
+      ...pendingRefs.flatMap((ref) => ref.relays),
+    ]);
+    const relays = await connectRelays(relayUrls, timeoutMs);
+
+    try {
+      const nextRefs: FeedRootRef[] = [];
+
+      for (let index = 0; index < pendingRefs.length; index += ROOT_QUERY_LIMIT) {
+        const ids = pendingRefs
+          .slice(index, index + ROOT_QUERY_LIMIT)
+          .map((ref) => ref.id);
+        if (ids.length === 0) continue;
+
+        const batch = await subscribeOnce(
+          relays,
+          {
+            ids,
+            kinds: [1, 1068],
+            limit: ids.length,
+          },
+          timeoutMs,
+          relayUrls,
+        );
+
+        events.push(...batch.events);
+        batch.events.forEach((event) => {
+          eventsById.set(event.id.toLowerCase(), event);
+          const nextRef = feedActivityRootRef(event, eventsById);
+          if (nextRef && nextRef.id !== event.id.toLowerCase()) {
+            nextRefs.push(nextRef);
+          }
+        });
+        batch.relayHintsByEventId.forEach((relaysForEvent, eventId) => {
+          relaysForEvent.forEach((relay) =>
+            addRelayHint(relayHintsByEventId, eventId, relay),
+          );
+        });
+      }
+
+      refsToResolve = mergeFeedRootRefs(nextRefs);
+    } finally {
+      closeRelays(relays);
     }
-
-    return { events, relayHintsByEventId };
-  } finally {
-    closeRelays(relays);
   }
+
+  return { events, relayHintsByEventId };
 }
 
 async function fetchGlobalFeedEvents(
@@ -264,32 +310,44 @@ async function fetchGlobalFeedEvents(
   const relays = await connectRelays(FEED_SNAPSHOT_RELAYS, timeoutMs);
 
   try {
-    const roots = new Map<string, FeedRootRef>();
     const since = sinceFromAgeHours(ageHours);
 
-    const rootBatch = await subscribeOnce(
+    const activityBatch = await subscribeOnce(
       relays,
       { kinds: [1, 1068], since, limit: 500 },
       timeoutMs,
       [...POW_RELAYS],
     );
-    const rootEvents = rootBatch.events;
+    const activityEvents = activityBatch.events;
+    const activityRootRefs = feedRootRefsFromActivity(
+      activityEvents,
+      filterDifficulty,
+    );
 
-    rootEvents.forEach((event) => {
-      if (!isQualifyingFeedActivity(event, filterDifficulty)) return;
-      feedActivityRootRefs(event).forEach((ref) => mergeRootRef(roots, ref));
-    });
-
-    if (roots.size === 0) {
-      return { ...rootBatch, activityRootIds: [] };
+    if (activityRootRefs.length === 0) {
+      return { ...activityBatch, activityRootIds: [] };
     }
 
-    const rootRefs = Array.from(roots.values());
-    const resolvedRootBatch = await fetchRootEvents(rootRefs, timeoutMs);
+    const resolvedRootBatch = await fetchRootEvents(
+      activityRootRefs,
+      activityEvents,
+      timeoutMs,
+    );
+    const seedEvents = mergeEvents(activityEvents, resolvedRootBatch.events);
+    const seedEventsById = buildFeedEventMap(seedEvents);
+    const rootRefs = feedRootRefsFromActivity(
+      activityEvents,
+      filterDifficulty,
+      seedEventsById,
+    );
+    const rootIds = rootRefs
+      .map((ref) => seedEventsById.get(ref.id))
+      .filter((event): event is Event => !!event && isFeedThreadRootEvent(event))
+      .map((event) => event.id.toLowerCase());
     const replyEvents: Event[] = [];
     const seenReplyIds = new Set<string>();
     const replyRelayHintsByEventId = new Map<string, string[]>();
-    let parentIds = rootRefs.map((ref) => ref.id);
+    let parentIds = [...new Set(rootIds)];
 
     const replyDepth = clampReplyDepth(REPLY_FETCH_DEPTH);
     for (let depth = 0; depth < replyDepth && parentIds.length > 0; depth += 1) {
@@ -321,9 +379,9 @@ async function fetchGlobalFeedEvents(
     }
 
     return {
-      events: mergeEvents(rootEvents, resolvedRootBatch.events, replyEvents),
+      events: mergeEvents(activityEvents, resolvedRootBatch.events, replyEvents),
       relayHintsByEventId: mergeRelayHints(
-        rootBatch.relayHintsByEventId,
+        activityBatch.relayHintsByEventId,
         resolvedRootBatch.relayHintsByEventId,
         replyRelayHintsByEventId,
       ),

--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -16,7 +16,11 @@ import {
 } from "../src/nostr/subscriptions/query-limits.js";
 import { processFeedEvents } from "../src/nostr/processEvents.js";
 import type { ProcessedEvent, RelayHintsByEventId } from "../src/nostr/types.js";
-import { isRootNote } from "../src/shared/lib/noteEvents.js";
+import {
+  feedActivityRootRefs,
+  isQualifyingFeedActivity,
+  type FeedRootRef,
+} from "../src/nostr/feed-candidates.js";
 import { extractMentionedEventRefs } from "../src/shared/lib/quotedEvents.js";
 import {
   parseProfileEvent,
@@ -37,6 +41,10 @@ type EventBatch = {
   relayHintsByEventId: Map<string, string[]>;
 };
 
+type FeedEventBatch = EventBatch & {
+  activityRootIds: string[];
+};
+
 export type FeedBootstrapSnapshot = {
   fetchedAt: number;
   processedEvents: ProcessedEvent[];
@@ -51,11 +59,7 @@ export type FeedSnapshotOptions = {
   timeoutMs?: number;
 };
 
-const trackRootNote = (notes: Set<string>, evt: Event) => {
-  if (isRootNote(evt)) {
-    notes.add(evt.id);
-  }
-};
+const ROOT_QUERY_LIMIT = 50;
 
 function normalizeRelayUrl(url: string): string {
   return url.replace(/\/+$/, "");
@@ -110,6 +114,16 @@ function serializeRelayHints(
       uniqueRelays(relays),
     ]),
   );
+}
+
+function mergeRootRef(roots: Map<string, FeedRootRef>, ref: FeedRootRef): void {
+  const existing = roots.get(ref.id);
+  if (!existing) {
+    roots.set(ref.id, { id: ref.id, relays: uniqueRelays(ref.relays) });
+    return;
+  }
+
+  existing.relays = uniqueRelays([...existing.relays, ...ref.relays]);
 }
 
 async function connectRelays(urls: readonly string[], timeoutMs: number): Promise<Relay[]> {
@@ -199,14 +213,58 @@ async function subscribeOnce(
   return { events, relayHintsByEventId };
 }
 
-async function fetchGlobalFeedEvents(
-  ageHours: number,
+async function fetchRootEvents(
+  rootRefs: FeedRootRef[],
   timeoutMs: number,
 ): Promise<EventBatch> {
+  if (rootRefs.length === 0) {
+    return { events: [], relayHintsByEventId: new Map() };
+  }
+
+  const relayUrls = uniqueRelays([
+    ...FEED_SNAPSHOT_RELAYS,
+    ...rootRefs.flatMap((ref) => ref.relays),
+  ]);
+  const relays = await connectRelays(relayUrls, timeoutMs);
+
+  try {
+    const events: Event[] = [];
+    const relayHintsByEventId = new Map<string, string[]>();
+
+    for (let index = 0; index < rootRefs.length; index += ROOT_QUERY_LIMIT) {
+      const ids = rootRefs.slice(index, index + ROOT_QUERY_LIMIT).map((ref) => ref.id);
+      const batch = await subscribeOnce(
+        relays,
+        {
+          ids,
+          kinds: [1, 1068],
+          limit: ids.length,
+        },
+        timeoutMs,
+        relayUrls,
+      );
+
+      events.push(...batch.events);
+      batch.relayHintsByEventId.forEach((relaysForEvent, eventId) => {
+        relaysForEvent.forEach((relay) => addRelayHint(relayHintsByEventId, eventId, relay));
+      });
+    }
+
+    return { events, relayHintsByEventId };
+  } finally {
+    closeRelays(relays);
+  }
+}
+
+async function fetchGlobalFeedEvents(
+  ageHours: number,
+  filterDifficulty: number,
+  timeoutMs: number,
+): Promise<FeedEventBatch> {
   const relays = await connectRelays(FEED_SNAPSHOT_RELAYS, timeoutMs);
 
   try {
-    const notes = new Set<string>();
+    const roots = new Map<string, FeedRootRef>();
     const since = sinceFromAgeHours(ageHours);
 
     const rootBatch = await subscribeOnce(
@@ -217,16 +275,21 @@ async function fetchGlobalFeedEvents(
     );
     const rootEvents = rootBatch.events;
 
-    rootEvents.forEach((event) => trackRootNote(notes, event));
+    rootEvents.forEach((event) => {
+      if (!isQualifyingFeedActivity(event, filterDifficulty)) return;
+      feedActivityRootRefs(event).forEach((ref) => mergeRootRef(roots, ref));
+    });
 
-    if (notes.size === 0) {
-      return rootBatch;
+    if (roots.size === 0) {
+      return { ...rootBatch, activityRootIds: [] };
     }
 
+    const rootRefs = Array.from(roots.values());
+    const resolvedRootBatch = await fetchRootEvents(rootRefs, timeoutMs);
     const replyEvents: Event[] = [];
     const seenReplyIds = new Set<string>();
     const replyRelayHintsByEventId = new Map<string, string[]>();
-    let parentIds = [...notes];
+    let parentIds = rootRefs.map((ref) => ref.id);
 
     const replyDepth = clampReplyDepth(REPLY_FETCH_DEPTH);
     for (let depth = 0; depth < replyDepth && parentIds.length > 0; depth += 1) {
@@ -258,11 +321,13 @@ async function fetchGlobalFeedEvents(
     }
 
     return {
-      events: mergeEvents(rootEvents, replyEvents),
+      events: mergeEvents(rootEvents, resolvedRootBatch.events, replyEvents),
       relayHintsByEventId: mergeRelayHints(
         rootBatch.relayHintsByEventId,
+        resolvedRootBatch.relayHintsByEventId,
         replyRelayHintsByEventId,
       ),
+      activityRootIds: rootRefs.map((ref) => ref.id),
     };
   } finally {
     closeRelays(relays);
@@ -429,11 +494,16 @@ export async function fetchFeedSnapshot(
   const filterDifficulty = options.filterDifficulty ?? BOOTSTRAP_FILTER_DIFFICULTY;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-  const feedBatch = await fetchGlobalFeedEvents(ageHours, timeoutMs);
+  const feedBatch = await fetchGlobalFeedEvents(
+    ageHours,
+    filterDifficulty,
+    timeoutMs,
+  );
   const processedEvents = processFeedEvents(
     feedBatch.events,
     filterDifficulty,
     feedBatch.relayHintsByEventId,
+    { activityRootIds: feedBatch.activityRootIds },
   );
   const knownEventIds = new Set(feedBatch.events.map((event) => event.id));
   const referencedBatch = await fetchReferencedEvents(

--- a/src/hooks/useFeed.test.ts
+++ b/src/hooks/useFeed.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import type { Event } from "nostr-tools";
+import type { ProcessedEvent } from "../nostr/types";
+import { mergeProcessedFeedEvents } from "./useFeed";
+
+const event = (overrides: Partial<Event> = {}): Event => ({
+  id: "f".repeat(64),
+  pubkey: "a".repeat(64),
+  created_at: 1,
+  kind: 1,
+  tags: [],
+  content: "plain text",
+  sig: "b".repeat(128),
+  ...overrides,
+});
+
+const processed = (
+  postEvent: Event,
+  overrides: Partial<ProcessedEvent> = {},
+): ProcessedEvent => ({
+  postEvent,
+  replies: [],
+  totalWork: 1,
+  threadReplyCount: 0,
+  ...overrides,
+});
+
+describe("mergeProcessedFeedEvents", () => {
+  it("uses pre-ranked bootstrap rows as first-class feed items", () => {
+    const replyPoweredRoot = event({
+      id: "1".repeat(64),
+      created_at: 1,
+    });
+    const highRootWork = event({
+      id: "2".repeat(64),
+      created_at: 2,
+    });
+
+    const result = mergeProcessedFeedEvents(
+      [
+        processed(replyPoweredRoot, {
+          rootWork: 4,
+          replyWork: Math.pow(2, 24),
+          totalWork: Math.pow(2, 24) + 4,
+        }),
+        processed(highRootWork, {
+          rootWork: Math.pow(2, 20),
+          replyWork: 0,
+          totalWork: Math.pow(2, 20),
+        }),
+      ],
+      [],
+    );
+
+    expect(result.map((item) => item.postEvent.id)).toEqual([
+      replyPoweredRoot.id,
+      highRootWork.id,
+    ]);
+  });
+
+  it("does not let an incomplete live row downgrade a bootstrap row", () => {
+    const root = event({ id: "1".repeat(64) });
+    const bootstrapRow = processed(root, {
+      replies: [event({ id: "2".repeat(64), tags: [["e", root.id]] })],
+      totalWork: Math.pow(2, 20),
+    });
+    const incompleteLiveRow = processed(root, {
+      replies: [],
+      totalWork: Math.pow(2, 16),
+    });
+
+    expect(mergeProcessedFeedEvents([bootstrapRow], [incompleteLiveRow])).toEqual([
+      bootstrapRow,
+    ]);
+  });
+
+  it("lets live rows upgrade or add feed items", () => {
+    const existingRoot = event({ id: "1".repeat(64), created_at: 1 });
+    const newRoot = event({ id: "2".repeat(64), created_at: 2 });
+    const bootstrapRow = processed(existingRoot, {
+      totalWork: Math.pow(2, 16),
+    });
+    const upgradedLiveRow = processed(existingRoot, {
+      replies: [event({ id: "3".repeat(64), tags: [["e", existingRoot.id]] })],
+      totalWork: Math.pow(2, 20),
+    });
+    const newLiveRow = processed(newRoot, {
+      totalWork: Math.pow(2, 18),
+    });
+
+    const result = mergeProcessedFeedEvents(
+      [bootstrapRow],
+      [newLiveRow, upgradedLiveRow],
+    );
+
+    expect(result).toEqual([upgradedLiveRow, newLiveRow]);
+  });
+});

--- a/src/hooks/useFeed.test.ts
+++ b/src/hooks/useFeed.test.ts
@@ -74,6 +74,48 @@ describe("mergeProcessedFeedEvents", () => {
     ]);
   });
 
+  it("does not treat more low-work live replies as a feed-score upgrade", () => {
+    const root = event({ id: "1".repeat(64) });
+    const bootstrapRow = processed(root, {
+      replies: [event({ id: "2".repeat(64), tags: [["e", root.id]] })],
+      totalWork: Math.pow(2, 24),
+      threadReplyCount: 1,
+    });
+    const lowerWorkLiveRow = processed(root, {
+      replies: [
+        event({ id: "3".repeat(64), tags: [["e", root.id]] }),
+        event({ id: "4".repeat(64), tags: [["e", root.id]] }),
+      ],
+      totalWork: Math.pow(2, 16),
+      threadReplyCount: 2,
+    });
+
+    expect(mergeProcessedFeedEvents([bootstrapRow], [lowerWorkLiveRow])).toEqual([
+      bootstrapRow,
+    ]);
+  });
+
+  it("uses reply count as a tie-breaker when live work matches the snapshot", () => {
+    const root = event({ id: "1".repeat(64) });
+    const bootstrapRow = processed(root, {
+      replies: [event({ id: "2".repeat(64), tags: [["e", root.id]] })],
+      totalWork: Math.pow(2, 20),
+      threadReplyCount: 1,
+    });
+    const fullerLiveRow = processed(root, {
+      replies: [
+        event({ id: "3".repeat(64), tags: [["e", root.id]] }),
+        event({ id: "4".repeat(64), tags: [["e", root.id]] }),
+      ],
+      totalWork: Math.pow(2, 20),
+      threadReplyCount: 2,
+    });
+
+    expect(mergeProcessedFeedEvents([bootstrapRow], [fullerLiveRow])).toEqual([
+      fullerLiveRow,
+    ]);
+  });
+
   it("lets live rows upgrade or add feed items", () => {
     const existingRoot = event({ id: "1".repeat(64), created_at: 1 });
     const newRoot = event({ id: "2".repeat(64), created_at: 2 });

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -20,8 +20,9 @@ import {
 } from "../shared/lib/moderation";
 import {
   canUseFeedBootstrap,
-  eventsFromProcessed,
+  eventsFromSnapshot,
   loadFeedBootstrapSnapshot,
+  processedEventsFromSnapshot,
   relayHintsFromSnapshot,
 } from "../shared/lib/feedBootstrapClient";
 
@@ -121,13 +122,14 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
           setBootstrapRelayHintsByEventId(new Map());
           return;
         }
-        setBootstrapProcessedEvents(snapshot.processedEvents);
-        setBootstrapEvents(eventsFromProcessed(snapshot.processedEvents));
+        const processedEvents = processedEventsFromSnapshot(snapshot);
+        setBootstrapProcessedEvents(processedEvents);
+        setBootstrapEvents(eventsFromSnapshot(snapshot));
         setBootstrapRelayHintsByEventId(
           relayHintsFromSnapshot(snapshot),
         );
         setBootstrapRootIds(
-          snapshot.processedEvents.map((event) => event.postEvent.id),
+          processedEvents.map((event) => event.postEvent.id),
         );
         seedProfiles(snapshot.profiles);
       })

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -49,7 +49,6 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
   const { settings } = useSettings();
   const moderationManifest = useModerationManifest();
   const isRawMode = mode === "raw";
-  const rawFilterDifficulty = isRawMode ? settings.filterDifficulty : undefined;
   const bootstrapEligible = !isRawMode && canUseFeedBootstrap(settings);
   const [bootstrapEvents, setBootstrapEvents] = useState<Event[]>([]);
   const [bootstrapRootIds, setBootstrapRootIds] = useState<string[]>([]);
@@ -104,11 +103,11 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
         {
           rootRelayUrls: POW_RELAYS,
           replyRelayUrls: THREAD_RELAYS,
-          rootFilterDifficulty: rawFilterDifficulty,
+          rootFilterDifficulty: settings.filterDifficulty,
           replyDepth: FEED_REPLY_DEPTH,
         },
       ),
-    [rawFilterDifficulty, settings.ageHours],
+    [settings.ageHours, settings.filterDifficulty],
   );
 
   const {
@@ -117,7 +116,7 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
   } = useFilteredNoteSubscriptionWithRelays(subscribe, [
     mode,
     settings.ageHours,
-    rawFilterDifficulty,
+    settings.filterDifficulty,
   ]);
 
   const bootstrapRootKey = bootstrapRootIds.join(",");

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -53,6 +53,21 @@ function mergeRelayHints(
   return merged;
 }
 
+function eventsFromProcessedFeedEvents(processedEvents: ProcessedEvent[]): Event[] {
+  const events: Event[] = [];
+  const seen = new Set<string>();
+
+  processedEvents.forEach((processed) => {
+    [processed.postEvent, ...processed.replies].forEach((event) => {
+      if (seen.has(event.id)) return;
+      seen.add(event.id);
+      events.push(event);
+    });
+  });
+
+  return events;
+}
+
 function isProcessedEventModerated(
   event: ProcessedEvent,
   moderationManifest: ModerationManifest,
@@ -221,13 +236,30 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
     [bootstrapProcessedEvents, moderationManifest],
   );
   const liveProcessedEvents = useMemo(
-    () =>
-      processFeedEvents(
-        visibleNoteEvents,
+    () => {
+      const bootstrapFeedEvents = bootstrapEligible
+        ? eventsFromProcessedFeedEvents(visibleBootstrapProcessedEvents)
+        : [];
+      const visibleLiveEvents = filterModeratedEvents(
+        mergeNoteEvents(liveEvents, bootstrapReplyEvents),
+        moderationManifest,
+      );
+
+      return processFeedEvents(
+        mergeNoteEvents(bootstrapFeedEvents, visibleLiveEvents),
         settings.filterDifficulty,
         relayHintsByEventId,
-      ),
-    [visibleNoteEvents, settings.filterDifficulty, relayHintsByEventId],
+      );
+    },
+    [
+      bootstrapEligible,
+      visibleBootstrapProcessedEvents,
+      liveEvents,
+      bootstrapReplyEvents,
+      moderationManifest,
+      settings.filterDifficulty,
+      relayHintsByEventId,
+    ],
   );
   const processedEvents = useMemo(
     () =>

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -79,7 +79,8 @@ export function mergeProcessedFeedEvents(
     if (
       !existing ||
       event.totalWork > existing.totalWork ||
-      event.replies.length > existing.replies.length
+      (event.totalWork === existing.totalWork &&
+        event.replies.length > existing.replies.length)
     ) {
       mergedByRootId.set(event.postEvent.id, event);
     }

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Event } from "nostr-tools";
 import { subGlobalFeed, subRepliesForRootIds } from "../nostr/subscriptions";
-import { processFeedEvents } from "../nostr/processEvents";
-import type { RelayHintsByEventId } from "../nostr/types";
+import {
+  compareProcessedEventsByWork,
+  processFeedEvents,
+} from "../nostr/processEvents";
+import type { ProcessedEvent, RelayHintsByEventId } from "../nostr/types";
 import { useSettings } from "../app/settings";
 import { POW_RELAYS, THREAD_RELAYS } from "../config";
 import {
@@ -10,7 +13,11 @@ import {
 } from "../shared/hooks/useFilteredNoteSubscription";
 import { useModerationManifest } from "../shared/hooks/useModerationManifest";
 import { seedProfiles } from "../shared/hooks/useProfiles";
-import { filterModeratedEvents } from "../shared/lib/moderation";
+import {
+  filterModeratedEvents,
+  isEventModerated,
+  type ModerationManifest,
+} from "../shared/lib/moderation";
 import {
   canUseFeedBootstrap,
   eventsFromProcessed,
@@ -45,11 +52,48 @@ function mergeRelayHints(
   return merged;
 }
 
+function isProcessedEventModerated(
+  event: ProcessedEvent,
+  moderationManifest: ModerationManifest,
+): boolean {
+  return (
+    isEventModerated(event.postEvent, moderationManifest) ||
+    event.replies.some((reply) => isEventModerated(reply, moderationManifest))
+  );
+}
+
+export function mergeProcessedFeedEvents(
+  bootstrapEvents: ProcessedEvent[],
+  liveEvents: ProcessedEvent[],
+): ProcessedEvent[] {
+  if (liveEvents.length === 0) return bootstrapEvents;
+
+  const mergedByRootId = new Map<string, ProcessedEvent>();
+
+  bootstrapEvents.forEach((event) => {
+    mergedByRootId.set(event.postEvent.id, event);
+  });
+
+  liveEvents.forEach((event) => {
+    const existing = mergedByRootId.get(event.postEvent.id);
+    if (
+      !existing ||
+      event.totalWork > existing.totalWork ||
+      event.replies.length > existing.replies.length
+    ) {
+      mergedByRootId.set(event.postEvent.id, event);
+    }
+  });
+
+  return [...mergedByRootId.values()].sort(compareProcessedEventsByWork);
+}
+
 export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
   const { settings } = useSettings();
   const moderationManifest = useModerationManifest();
   const isRawMode = mode === "raw";
   const bootstrapEligible = !isRawMode && canUseFeedBootstrap(settings);
+  const [bootstrapProcessedEvents, setBootstrapProcessedEvents] = useState<ProcessedEvent[]>([]);
   const [bootstrapEvents, setBootstrapEvents] = useState<Event[]>([]);
   const [bootstrapRootIds, setBootstrapRootIds] = useState<string[]>([]);
   const [bootstrapRelayHintsByEventId, setBootstrapRelayHintsByEventId] =
@@ -57,6 +101,7 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
 
   useEffect(() => {
     if (!bootstrapEligible) {
+      setBootstrapProcessedEvents([]);
       setBootstrapEvents([]);
       setBootstrapRootIds([]);
       setBootstrapRelayHintsByEventId(new Map());
@@ -69,11 +114,13 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
       .then((snapshot) => {
         if (cancelled) return;
         if (!snapshot) {
+          setBootstrapProcessedEvents([]);
           setBootstrapEvents([]);
           setBootstrapRootIds([]);
           setBootstrapRelayHintsByEventId(new Map());
           return;
         }
+        setBootstrapProcessedEvents(snapshot.processedEvents);
         setBootstrapEvents(eventsFromProcessed(snapshot.processedEvents));
         setBootstrapRelayHintsByEventId(
           relayHintsFromSnapshot(snapshot),
@@ -85,6 +132,7 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
       })
       .catch(() => {
         // Fall back to live relay subscription only.
+        setBootstrapProcessedEvents([]);
         setBootstrapEvents([]);
         setBootstrapRootIds([]);
         setBootstrapRelayHintsByEventId(new Map());
@@ -160,7 +208,16 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
     () => filterModeratedEvents(noteEvents, moderationManifest),
     [noteEvents, moderationManifest],
   );
-  const processedEvents = useMemo(
+  const visibleBootstrapProcessedEvents = useMemo(
+    () =>
+      moderationManifest.updatedAt === 0
+        ? bootstrapProcessedEvents
+        : bootstrapProcessedEvents.filter(
+            (event) => !isProcessedEventModerated(event, moderationManifest),
+          ),
+    [bootstrapProcessedEvents, moderationManifest],
+  );
+  const liveProcessedEvents = useMemo(
     () =>
       processFeedEvents(
         visibleNoteEvents,
@@ -168,6 +225,14 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
         relayHintsByEventId,
       ),
     [visibleNoteEvents, settings.filterDifficulty, relayHintsByEventId],
+  );
+  const processedEvents = useMemo(
+    () =>
+      mergeProcessedFeedEvents(
+        bootstrapEligible ? visibleBootstrapProcessedEvents : [],
+        liveProcessedEvents,
+      ),
+    [bootstrapEligible, visibleBootstrapProcessedEvents, liveProcessedEvents],
   );
 
   return { processedEvents, noteEvents: visibleNoteEvents };

--- a/src/nostr/feed-candidates.test.ts
+++ b/src/nostr/feed-candidates.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import type { Event } from "nostr-tools";
 import {
   buildFeedEventMap,
-  createFeedCandidateTracker,
-  feedActivityRootRef,
+  feedRootRefsFromQualifyingActivity,
+  isFeedPostEvent,
+  resolveFeedRootRef,
 } from "./feed-candidates";
 
 vi.mock("../shared/pow/core", () => ({
@@ -22,7 +23,7 @@ const event = (overrides: Partial<Event> = {}): Event => ({
   ...overrides,
 });
 
-describe("feedActivityRootRef", () => {
+describe("resolveFeedRootRef", () => {
   it("uses the NIP-10 root marker before fallback e tags", () => {
     const rootId = "1".repeat(64);
     const parentId = "2".repeat(64);
@@ -34,7 +35,7 @@ describe("feedActivityRootRef", () => {
       ],
     });
 
-    expect(feedActivityRootRef(reply)).toEqual({
+    expect(resolveFeedRootRef(reply)).toEqual({
       id: rootId,
       relays: ["wss://root.example"],
     });
@@ -50,7 +51,7 @@ describe("feedActivityRootRef", () => {
       ],
     });
 
-    expect(feedActivityRootRef(reply)).toEqual({
+    expect(resolveFeedRootRef(reply)).toEqual({
       id: rootId,
       relays: ["wss://root.example"],
     });
@@ -67,14 +68,14 @@ describe("feedActivityRootRef", () => {
       tags: [["e", parent.id, "wss://parent.example"]],
     });
 
-    expect(feedActivityRootRef(nested, buildFeedEventMap([root, parent, nested]))).toEqual({
+    expect(resolveFeedRootRef(nested, buildFeedEventMap([root, parent, nested]))).toEqual({
       id: root.id,
       relays: ["wss://parent.example", "wss://root.example"],
     });
   });
 });
 
-describe("createFeedCandidateTracker", () => {
+describe("feedRootRefsFromQualifyingActivity", () => {
   it("accepts a reply activity only when its work qualifies", () => {
     const rootId = "1".repeat(64);
     const lowerWorkReply = event({
@@ -85,12 +86,16 @@ describe("createFeedCandidateTracker", () => {
       id: "3".repeat(64),
       tags: [["e", rootId, "", "root"], ["nonce", "higher", "16"]],
     });
-    const tracker = createFeedCandidateTracker(16);
+    expect(feedRootRefsFromQualifyingActivity([lowerWorkReply], 16)).toEqual([]);
+    expect(feedRootRefsFromQualifyingActivity([qualifyingReply], 16)).toEqual([
+      { id: rootId, relays: [] },
+    ]);
+  });
 
-    expect(tracker.check(lowerWorkReply).accepted).toBe(false);
-    expect(tracker.check(qualifyingReply)).toMatchObject({
-      accepted: true,
-      rootId,
-    });
+  it("does not treat kind-1068 articles as main-feed posts", () => {
+    expect(isFeedPostEvent(event({ kind: 1068 }))).toBe(false);
+    expect(feedRootRefsFromQualifyingActivity([
+      event({ kind: 1068, tags: [["nonce", "article", "24"]] }),
+    ], 16)).toEqual([]);
   });
 });

--- a/src/nostr/feed-candidates.test.ts
+++ b/src/nostr/feed-candidates.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Event } from "nostr-tools";
+import {
+  buildFeedEventMap,
+  createFeedCandidateTracker,
+  feedActivityRootRef,
+} from "./feed-candidates";
+
+vi.mock("../shared/pow/core", () => ({
+  verifyPow: (event: Event) =>
+    Number(event.tags.find((tag) => tag[0] === "nonce")?.[2] ?? 0),
+}));
+
+const event = (overrides: Partial<Event> = {}): Event => ({
+  id: "f".repeat(64),
+  pubkey: "a".repeat(64),
+  created_at: 1,
+  kind: 1,
+  tags: [],
+  content: "hello",
+  sig: "b".repeat(128),
+  ...overrides,
+});
+
+describe("feedActivityRootRef", () => {
+  it("uses the NIP-10 root marker before fallback e tags", () => {
+    const rootId = "1".repeat(64);
+    const parentId = "2".repeat(64);
+    const reply = event({
+      id: "3".repeat(64),
+      tags: [
+        ["e", parentId, "wss://parent.example"],
+        ["e", rootId, "wss://root.example/", "root"],
+      ],
+    });
+
+    expect(feedActivityRootRef(reply)).toEqual({
+      id: rootId,
+      relays: ["wss://root.example"],
+    });
+  });
+
+  it("falls back to the first valid e tag", () => {
+    const rootId = "1".repeat(64);
+    const reply = event({
+      id: "2".repeat(64),
+      tags: [
+        ["e", "not-an-event-id", "wss://invalid.example"],
+        ["e", rootId, "wss://root.example"],
+      ],
+    });
+
+    expect(feedActivityRootRef(reply)).toEqual({
+      id: rootId,
+      relays: ["wss://root.example"],
+    });
+  });
+
+  it("resolves parent-only replies through a bounded known parent chain", () => {
+    const root = event({ id: "1".repeat(64) });
+    const parent = event({
+      id: "2".repeat(64),
+      tags: [["e", root.id, "wss://root.example", "root"]],
+    });
+    const nested = event({
+      id: "3".repeat(64),
+      tags: [["e", parent.id, "wss://parent.example"]],
+    });
+
+    expect(feedActivityRootRef(nested, buildFeedEventMap([root, parent, nested]))).toEqual({
+      id: root.id,
+      relays: ["wss://parent.example", "wss://root.example"],
+    });
+  });
+});
+
+describe("createFeedCandidateTracker", () => {
+  it("accepts a reply activity only when its work qualifies", () => {
+    const rootId = "1".repeat(64);
+    const lowerWorkReply = event({
+      id: "2".repeat(64),
+      tags: [["e", rootId, "", "root"], ["nonce", "lower", "15"]],
+    });
+    const qualifyingReply = event({
+      id: "3".repeat(64),
+      tags: [["e", rootId, "", "root"], ["nonce", "higher", "16"]],
+    });
+    const tracker = createFeedCandidateTracker(16);
+
+    expect(tracker.check(lowerWorkReply).accepted).toBe(false);
+    expect(tracker.check(qualifyingReply)).toMatchObject({
+      accepted: true,
+      rootId,
+    });
+  });
+});

--- a/src/nostr/feed-candidates.ts
+++ b/src/nostr/feed-candidates.ts
@@ -3,22 +3,26 @@ import { isRootNote } from "../shared/lib/noteEvents.js";
 import { verifyPow } from "../shared/pow/core.js";
 
 const EVENT_ID_PATTERN = /^[0-9a-f]{64}$/i;
-const ROOT_RESOLUTION_DEPTH = 4;
+
+export const ROOT_RESOLUTION_DEPTH = 4;
+export const ROOT_QUERY_LIMIT = 500;
 
 export type FeedRootRef = {
   id: string;
   relays: string[];
 };
 
-export type FeedCandidateDecision = {
-  accepted: boolean;
-  rootId: string | null;
-  rootRef: FeedRootRef | null;
-  replyRootId: string | null;
+export type FeedRootResolutionPlan = {
+  rootEvents: Event[];
+  refsToFetch: FeedRootRef[];
 };
 
 export function isEventId(value: string | undefined): value is string {
   return Boolean(value && EVENT_ID_PATTERN.test(value));
+}
+
+function eventId(id: string): string {
+  return id.toLowerCase();
 }
 
 function normalizeRelayUrl(relay: string): string {
@@ -35,24 +39,14 @@ export function uniqueRelayUrls(relays: readonly string[]): string[] {
   ];
 }
 
-function eventId(id: string): string {
-  return id.toLowerCase();
-}
-
-function rootRefFromTag(tag: string[]): FeedRootRef | null {
-  if (tag[0] !== "e" || !isEventId(tag[1])) return null;
-
-  return {
-    id: eventId(tag[1]),
-    relays: tag[2] ? uniqueRelayUrls([tag[2]]) : [],
-  };
-}
-
 export function mergeFeedRootRefs(refs: readonly FeedRootRef[]): FeedRootRef[] {
   const byId = new Map<string, string[]>();
 
   refs.forEach((ref) => {
-    byId.set(ref.id, uniqueRelayUrls([...(byId.get(ref.id) ?? []), ...ref.relays]));
+    byId.set(eventId(ref.id), uniqueRelayUrls([
+      ...(byId.get(eventId(ref.id)) ?? []),
+      ...ref.relays,
+    ]));
   });
 
   return [...byId.entries()].map(([id, relays]) => ({ id, relays }));
@@ -68,12 +62,13 @@ export function buildFeedEventMap(events: readonly Event[]): Map<string, Event> 
   return eventsById;
 }
 
-export function isFeedThreadRootEvent(event: Event): boolean {
-  return event.kind === 1 && isRootNote(event);
-}
+function rootRefFromTag(tag: string[]): FeedRootRef | null {
+  if (tag[0] !== "e" || !isEventId(tag[1])) return null;
 
-export function isFeedPostEvent(event: Event): boolean {
-  return isFeedThreadRootEvent(event) || event.kind === 1068;
+  return {
+    id: eventId(tag[1]),
+    relays: tag[2] ? uniqueRelayUrls([tag[2]]) : [],
+  };
 }
 
 function taggedRootRef(event: Event): FeedRootRef | null {
@@ -89,18 +84,22 @@ function taggedRootRef(event: Event): FeedRootRef | null {
     .find((ref): ref is FeedRootRef => ref !== null) ?? null;
 }
 
-export function feedActivityRootRef(
+export function isFeedThreadRootEvent(event: Event): boolean {
+  return event.kind === 1 && isRootNote(event);
+}
+
+export function isFeedPostEvent(event: Event): boolean {
+  return isFeedThreadRootEvent(event);
+}
+
+export function resolveFeedRootRef(
   event: Event,
   eventsById?: ReadonlyMap<string, Event>,
   maxDepth = ROOT_RESOLUTION_DEPTH,
 ): FeedRootRef | null {
-  if (event.kind === 1068) {
-    return { id: eventId(event.id), relays: [] };
-  }
-
   if (event.kind !== 1) return null;
 
-  if (isRootNote(event)) {
+  if (isFeedThreadRootEvent(event)) {
     return { id: eventId(event.id), relays: [] };
   }
 
@@ -117,7 +116,7 @@ export function feedActivityRootRef(
       return currentRef;
     }
 
-    if (isFeedPostEvent(linkedEvent)) {
+    if (isFeedThreadRootEvent(linkedEvent)) {
       return {
         id: eventId(linkedEvent.id),
         relays: uniqueRelayUrls(currentRef.relays),
@@ -137,76 +136,57 @@ export function feedActivityRootRef(
   return currentRef;
 }
 
-export function feedRootEventId(
-  event: Event,
-  eventsById?: ReadonlyMap<string, Event>,
-): string | null {
-  return feedActivityRootRef(event, eventsById)?.id ?? null;
-}
-
-export function feedReplyRootId(
-  event: Event,
-  eventsById?: ReadonlyMap<string, Event>,
-): string | null {
-  return feedRootEventId(event, eventsById);
-}
-
-export function feedActivityRootRefs(
-  event: Event,
-  eventsById?: ReadonlyMap<string, Event>,
-): FeedRootRef[] {
-  const ref = feedActivityRootRef(event, eventsById);
-  return ref ? [ref] : [];
-}
-
-export function feedRootRefsFromActivity(
+export function feedRootRefsFromQualifyingActivity(
   events: readonly Event[],
   filterDifficulty = 0,
   eventsById: ReadonlyMap<string, Event> = buildFeedEventMap(events),
 ): FeedRootRef[] {
-  const candidates = createFeedCandidateTracker(filterDifficulty);
   const refs: FeedRootRef[] = [];
 
   events.forEach((event) => {
-    const decision = candidates.check(event, eventsById);
-    if (decision.rootRef) refs.push(decision.rootRef);
+    if (event.kind !== 1 || verifyPow(event) < filterDifficulty) return;
+
+    const ref = resolveFeedRootRef(event, eventsById);
+    if (ref) refs.push(ref);
   });
 
   return mergeFeedRootRefs(refs);
 }
 
-export function isQualifyingFeedActivity(
-  event: Event,
-  filterDifficulty = 0,
-): boolean {
-  return event.kind === 1 && verifyPow(event) >= filterDifficulty;
-}
+export function planFeedRootResolution(
+  rootRefs: readonly FeedRootRef[],
+  eventsById: ReadonlyMap<string, Event>,
+  requestedIds: ReadonlySet<string>,
+  limit = ROOT_QUERY_LIMIT,
+): FeedRootResolutionPlan {
+  const rootEvents: Event[] = [];
+  const refsToFetch: FeedRootRef[] = [];
 
-export function createFeedCandidateTracker(filterDifficulty = 0) {
+  mergeFeedRootRefs(rootRefs).forEach((ref) => {
+    const knownEvent = eventsById.get(ref.id);
+    if (!knownEvent) {
+      refsToFetch.push(ref);
+      return;
+    }
+
+    if (isFeedThreadRootEvent(knownEvent)) {
+      rootEvents.push(knownEvent);
+      return;
+    }
+
+    const nextRef = resolveFeedRootRef(knownEvent, eventsById);
+    if (nextRef && nextRef.id !== ref.id) {
+      refsToFetch.push({
+        id: nextRef.id,
+        relays: uniqueRelayUrls([...ref.relays, ...nextRef.relays]),
+      });
+    }
+  });
+
   return {
-    check(
-      event: Event,
-      eventsById?: ReadonlyMap<string, Event>,
-    ): FeedCandidateDecision {
-      if (event.kind !== 1 && event.kind !== 1068) {
-        return { accepted: false, rootId: null, rootRef: null, replyRootId: null };
-      }
-
-      const rootRef = feedActivityRootRef(event, eventsById);
-      if (!rootRef) {
-        return { accepted: false, rootId: null, rootRef: null, replyRootId: null };
-      }
-
-      if (verifyPow(event) < filterDifficulty) {
-        return { accepted: false, rootId: null, rootRef: null, replyRootId: null };
-      }
-
-      return {
-        accepted: true,
-        rootId: rootRef.id,
-        rootRef,
-        replyRootId: rootRef.id,
-      };
-    },
+    rootEvents,
+    refsToFetch: mergeFeedRootRefs(refsToFetch)
+      .filter((ref) => !requestedIds.has(ref.id))
+      .slice(0, limit),
   };
 }

--- a/src/nostr/feed-candidates.ts
+++ b/src/nostr/feed-candidates.ts
@@ -2,32 +2,211 @@ import type { Event } from "nostr-tools";
 import { isRootNote } from "../shared/lib/noteEvents.js";
 import { verifyPow } from "../shared/pow/core.js";
 
+const EVENT_ID_PATTERN = /^[0-9a-f]{64}$/i;
+const ROOT_RESOLUTION_DEPTH = 4;
+
+export type FeedRootRef = {
+  id: string;
+  relays: string[];
+};
+
 export type FeedCandidateDecision = {
   accepted: boolean;
+  rootId: string | null;
+  rootRef: FeedRootRef | null;
   replyRootId: string | null;
 };
 
-export function feedReplyRootId(event: Event): string | null {
-  return event.kind === 1 && isRootNote(event) ? event.id : null;
+export function isEventId(value: string | undefined): value is string {
+  return Boolean(value && EVENT_ID_PATTERN.test(value));
+}
+
+function normalizeRelayUrl(relay: string): string {
+  return relay.trim().replace(/\/+$/, "");
+}
+
+export function uniqueRelayUrls(relays: readonly string[]): string[] {
+  return [
+    ...new Set(
+      relays
+        .map(normalizeRelayUrl)
+        .filter((relay) => relay.startsWith("ws://") || relay.startsWith("wss://")),
+    ),
+  ];
+}
+
+function eventId(id: string): string {
+  return id.toLowerCase();
+}
+
+function rootRefFromTag(tag: string[]): FeedRootRef | null {
+  if (tag[0] !== "e" || !isEventId(tag[1])) return null;
+
+  return {
+    id: eventId(tag[1]),
+    relays: tag[2] ? uniqueRelayUrls([tag[2]]) : [],
+  };
+}
+
+export function mergeFeedRootRefs(refs: readonly FeedRootRef[]): FeedRootRef[] {
+  const byId = new Map<string, string[]>();
+
+  refs.forEach((ref) => {
+    byId.set(ref.id, uniqueRelayUrls([...(byId.get(ref.id) ?? []), ...ref.relays]));
+  });
+
+  return [...byId.entries()].map(([id, relays]) => ({ id, relays }));
+}
+
+export function buildFeedEventMap(events: readonly Event[]): Map<string, Event> {
+  const eventsById = new Map<string, Event>();
+
+  events.forEach((event) => {
+    eventsById.set(eventId(event.id), event);
+  });
+
+  return eventsById;
+}
+
+export function isFeedThreadRootEvent(event: Event): boolean {
+  return event.kind === 1 && isRootNote(event);
+}
+
+export function isFeedPostEvent(event: Event): boolean {
+  return isFeedThreadRootEvent(event) || event.kind === 1068;
+}
+
+function taggedRootRef(event: Event): FeedRootRef | null {
+  const rootMarkedRef = event.tags
+    .filter((tag) => tag[3] === "root")
+    .map(rootRefFromTag)
+    .find((ref): ref is FeedRootRef => ref !== null);
+
+  if (rootMarkedRef) return rootMarkedRef;
+
+  return event.tags
+    .map(rootRefFromTag)
+    .find((ref): ref is FeedRootRef => ref !== null) ?? null;
+}
+
+export function feedActivityRootRef(
+  event: Event,
+  eventsById?: ReadonlyMap<string, Event>,
+  maxDepth = ROOT_RESOLUTION_DEPTH,
+): FeedRootRef | null {
+  if (event.kind === 1068) {
+    return { id: eventId(event.id), relays: [] };
+  }
+
+  if (event.kind !== 1) return null;
+
+  if (isRootNote(event)) {
+    return { id: eventId(event.id), relays: [] };
+  }
+
+  const firstRef = taggedRootRef(event);
+  if (!firstRef) return null;
+  if (!eventsById) return firstRef;
+
+  const seen = new Set<string>([eventId(event.id)]);
+  let currentRef = firstRef;
+
+  for (let depth = 0; depth < maxDepth; depth += 1) {
+    const linkedEvent = eventsById.get(currentRef.id);
+    if (!linkedEvent || seen.has(eventId(linkedEvent.id))) {
+      return currentRef;
+    }
+
+    if (isFeedPostEvent(linkedEvent)) {
+      return {
+        id: eventId(linkedEvent.id),
+        relays: uniqueRelayUrls(currentRef.relays),
+      };
+    }
+
+    const parentRef = taggedRootRef(linkedEvent);
+    if (!parentRef) return currentRef;
+
+    seen.add(eventId(linkedEvent.id));
+    currentRef = {
+      id: parentRef.id,
+      relays: uniqueRelayUrls([...currentRef.relays, ...parentRef.relays]),
+    };
+  }
+
+  return currentRef;
+}
+
+export function feedRootEventId(
+  event: Event,
+  eventsById?: ReadonlyMap<string, Event>,
+): string | null {
+  return feedActivityRootRef(event, eventsById)?.id ?? null;
+}
+
+export function feedReplyRootId(
+  event: Event,
+  eventsById?: ReadonlyMap<string, Event>,
+): string | null {
+  return feedRootEventId(event, eventsById);
+}
+
+export function feedActivityRootRefs(
+  event: Event,
+  eventsById?: ReadonlyMap<string, Event>,
+): FeedRootRef[] {
+  const ref = feedActivityRootRef(event, eventsById);
+  return ref ? [ref] : [];
+}
+
+export function feedRootRefsFromActivity(
+  events: readonly Event[],
+  filterDifficulty = 0,
+  eventsById: ReadonlyMap<string, Event> = buildFeedEventMap(events),
+): FeedRootRef[] {
+  const candidates = createFeedCandidateTracker(filterDifficulty);
+  const refs: FeedRootRef[] = [];
+
+  events.forEach((event) => {
+    const decision = candidates.check(event, eventsById);
+    if (decision.rootRef) refs.push(decision.rootRef);
+  });
+
+  return mergeFeedRootRefs(refs);
+}
+
+export function isQualifyingFeedActivity(
+  event: Event,
+  filterDifficulty = 0,
+): boolean {
+  return event.kind === 1 && verifyPow(event) >= filterDifficulty;
 }
 
 export function createFeedCandidateTracker(filterDifficulty = 0) {
   return {
-    check(event: Event): FeedCandidateDecision {
+    check(
+      event: Event,
+      eventsById?: ReadonlyMap<string, Event>,
+    ): FeedCandidateDecision {
       if (event.kind !== 1 && event.kind !== 1068) {
-        return { accepted: false, replyRootId: null };
+        return { accepted: false, rootId: null, rootRef: null, replyRootId: null };
       }
 
-      const replyRootId = feedReplyRootId(event);
-      if (event.kind === 1 && !replyRootId) {
-        return { accepted: false, replyRootId: null };
+      const rootRef = feedActivityRootRef(event, eventsById);
+      if (!rootRef) {
+        return { accepted: false, rootId: null, rootRef: null, replyRootId: null };
       }
 
       if (verifyPow(event) < filterDifficulty) {
-        return { accepted: false, replyRootId: null };
+        return { accepted: false, rootId: null, rootRef: null, replyRootId: null };
       }
 
-      return { accepted: true, replyRootId };
+      return {
+        accepted: true,
+        rootId: rootRef.id,
+        rootRef,
+        replyRootId: rootRef.id,
+      };
     },
   };
 }

--- a/src/nostr/processEvents.test.ts
+++ b/src/nostr/processEvents.test.ts
@@ -257,6 +257,54 @@ describe("processFeedEvents", () => {
       rankingReplyCount: 16,
     });
   });
+
+  it("includes an old low-work root when fresh qualifying activity points at it", () => {
+    const oldRoot = event({
+      id: "1".repeat(64),
+      pubkey: "1".repeat(64),
+      created_at: 1,
+      tags: [["nonce", "root", "0"]],
+    });
+    const freshPowReply = event({
+      id: "2".repeat(64),
+      pubkey: "2".repeat(64),
+      created_at: 100,
+      tags: [
+        ["e", oldRoot.id, "wss://relay.example", "root"],
+        ["nonce", "reply", "24"],
+      ],
+    });
+
+    const result = processFeedEvents([oldRoot, freshPowReply], 16);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      postEvent: oldRoot,
+      replies: [freshPowReply],
+      replyWork: Math.pow(2, 24),
+      rankingReplyCount: 1,
+    });
+  });
+
+  it("does not include an old low-work root for below-threshold activity", () => {
+    const oldRoot = event({
+      id: "1".repeat(64),
+      pubkey: "1".repeat(64),
+      created_at: 1,
+      tags: [["nonce", "root", "0"]],
+    });
+    const weakReply = event({
+      id: "2".repeat(64),
+      pubkey: "2".repeat(64),
+      created_at: 100,
+      tags: [
+        ["e", oldRoot.id, "wss://relay.example", "root"],
+        ["nonce", "reply", "15"],
+      ],
+    });
+
+    expect(processFeedEvents([oldRoot, weakReply], 16)).toEqual([]);
+  });
 });
 
 describe("collectThreadReplies", () => {

--- a/src/nostr/processEvents.test.ts
+++ b/src/nostr/processEvents.test.ts
@@ -177,6 +177,74 @@ describe("processFeedEvents", () => {
     });
   });
 
+  it("promotes an older root when a fresh reply qualifies", () => {
+    const oldRoot = event({
+      id: "1".repeat(64),
+      created_at: 1,
+    });
+    const qualifyingReply = event({
+      id: "2".repeat(64),
+      created_at: 100,
+      tags: [["e", oldRoot.id, "", "root"], ["nonce", "reply", "16"]],
+    });
+
+    const result = processFeedEvents([oldRoot, qualifyingReply], 16);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      postEvent: oldRoot,
+      replies: [qualifyingReply],
+      rootWork: 1,
+      replyWork: Math.pow(2, 16),
+      rankingReplyCount: 1,
+    });
+  });
+
+  it("resolves parent-only reply activity when the parent event is available", () => {
+    const oldRoot = event({
+      id: "1".repeat(64),
+      created_at: 1,
+    });
+    const parentReply = event({
+      id: "2".repeat(64),
+      created_at: 50,
+      tags: [["e", oldRoot.id]],
+    });
+    const qualifyingNestedReply = event({
+      id: "3".repeat(64),
+      created_at: 100,
+      tags: [["e", parentReply.id], ["nonce", "nested", "16"]],
+    });
+
+    const result = processFeedEvents(
+      [oldRoot, parentReply, qualifyingNestedReply],
+      16,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      postEvent: oldRoot,
+      replies: [parentReply, qualifyingNestedReply],
+      replyWork: Math.pow(2, 16),
+      rankingReplyCount: 1,
+      threadReplyCount: 2,
+    });
+  });
+
+  it("does not render an unresolved reply parent as a feed post", () => {
+    const missingRootId = "1".repeat(64);
+    const parentReply = event({
+      id: "2".repeat(64),
+      tags: [["e", missingRootId]],
+    });
+    const qualifyingNestedReply = event({
+      id: "3".repeat(64),
+      tags: [["e", parentReply.id], ["nonce", "nested", "16"]],
+    });
+
+    expect(processFeedEvents([parentReply, qualifyingNestedReply], 16)).toEqual([]);
+  });
+
   it("ignores plain repost events", () => {
     const repost = event({ kind: 6, content: JSON.stringify(event()) });
 

--- a/src/nostr/processEvents.test.ts
+++ b/src/nostr/processEvents.test.ts
@@ -108,7 +108,7 @@ describe("processFeedEvents", () => {
     expect(result[0].relayHints).toEqual(["wss://relay.wiredsignal.online"]);
   });
 
-  it("uses the same feed root eligibility for articles and root notes", () => {
+  it("does not include articles as main feed posts", () => {
     const article = event({
       id: "1".repeat(64),
       kind: 1068,
@@ -139,7 +139,6 @@ describe("processFeedEvents", () => {
     expect(result.map((item) => item.postEvent.id)).toEqual([
       acceptedRoot.id,
       sameAuthorRoot.id,
-      article.id,
     ]);
     expect(result.find((item) => item.postEvent.id === acceptedRoot.id)?.replies).toEqual([
       reply,

--- a/src/nostr/processEvents.ts
+++ b/src/nostr/processEvents.ts
@@ -1,7 +1,7 @@
 import type { Event } from "nostr-tools";
 import {
   buildFeedEventMap,
-  feedRootRefsFromActivity,
+  feedRootRefsFromQualifyingActivity,
   isFeedPostEvent,
 } from "./feed-candidates.js";
 import { workScoreBreakdown } from "./processing/pow-score.js";
@@ -107,7 +107,11 @@ export const processFeedEvents = (
     [...(options.activityRootIds ?? [])].map((id) => id.toLowerCase()),
   );
 
-  feedRootRefsFromActivity(events, filterDifficulty, eventsById).forEach((ref) => {
+  feedRootRefsFromQualifyingActivity(
+    events,
+    filterDifficulty,
+    eventsById,
+  ).forEach((ref) => {
     activityRootIds.add(ref.id);
   });
 

--- a/src/nostr/processEvents.ts
+++ b/src/nostr/processEvents.ts
@@ -1,5 +1,9 @@
 import type { Event } from "nostr-tools";
-import { createFeedCandidateTracker } from "./feed-candidates.js";
+import {
+  buildFeedEventMap,
+  feedRootRefsFromActivity,
+  isFeedPostEvent,
+} from "./feed-candidates.js";
 import { workScoreBreakdown } from "./processing/pow-score.js";
 import type { ProcessedEvent, RelayHintsByEventId } from "./types.js";
 
@@ -66,6 +70,10 @@ export function collectThreadReplies(
   return replies;
 }
 
+export type ProcessFeedEventsOptions = {
+  activityRootIds?: Iterable<string>;
+};
+
 export function toProcessedEvents(
   posts: Event[],
   replySource: Event[],
@@ -91,15 +99,21 @@ export const processFeedEvents = (
   events: Event[],
   filterDifficulty = 0,
   relayHintsByEventId?: RelayHintsByEventId,
+  options: ProcessFeedEventsOptions = {},
 ): ProcessedEvent[] => {
+  const eventsById = buildFeedEventMap(events);
   const repliesByParent = buildRepliesByParent(events);
-  const candidates = createFeedCandidateTracker(filterDifficulty);
-  const posts: Event[] = [];
+  const activityRootIds = new Set(
+    [...(options.activityRootIds ?? [])].map((id) => id.toLowerCase()),
+  );
 
-  events.forEach((event) => {
-    if (!candidates.check(event).accepted) return;
-    posts.push(event);
+  feedRootRefsFromActivity(events, filterDifficulty, eventsById).forEach((ref) => {
+    activityRootIds.add(ref.id);
   });
+
+  const posts = [...activityRootIds]
+    .map((id) => eventsById.get(id))
+    .filter((event): event is Event => !!event && isFeedPostEvent(event));
 
   return posts
     .map((postEvent) => {

--- a/src/nostr/subscriptions/global-feed.test.ts
+++ b/src/nostr/subscriptions/global-feed.test.ts
@@ -54,9 +54,17 @@ describe("subGlobalFeed", () => {
     const onEvent = vi.fn() as SubCallback;
     subGlobalFeed(onEvent, 24);
 
-    expect(subscribeMock).toHaveBeenCalledTimes(2);
+    expect(subscribeMock).toHaveBeenCalledTimes(3);
 
-    const replyRequest = subscribeMock.mock.calls[1][0][0];
+    const rootFetchRequest = subscribeMock.mock.calls[1][0][0];
+    expect(rootFetchRequest.filter).toMatchObject({
+      ids: ["1".repeat(64)],
+      kinds: [1, 1068],
+      limit: 1,
+    });
+    expect(rootFetchRequest.closeOnEose).toBe(true);
+
+    const replyRequest = subscribeMock.mock.calls[2][0][0];
     expect(replyRequest.filter).toMatchObject({
       "#e": ["1".repeat(64)],
       kinds: [1],
@@ -94,7 +102,7 @@ describe("subGlobalFeed", () => {
         return { id, close: vi.fn() };
       }
 
-      if (id === "2") {
+      if (id === "3") {
         const { cb, onEose } = requests[0];
         cb(rootNote(replyId), enrichmentRelays[0]);
         onEose?.();
@@ -112,12 +120,20 @@ describe("subGlobalFeed", () => {
       replyDepth: 2,
     });
 
-    expect(subscribeMock).toHaveBeenCalledTimes(3);
+    expect(subscribeMock).toHaveBeenCalledTimes(4);
 
     const rootRequest = subscribeMock.mock.calls[0][0][0];
     expect(rootRequest.relayUrls).toEqual(powRelays);
 
-    const replyRequest = subscribeMock.mock.calls[1][0][0];
+    const rootFetchRequest = subscribeMock.mock.calls[1][0][0];
+    expect(rootFetchRequest.filter).toMatchObject({
+      ids: [rootId],
+      kinds: [1, 1068],
+      limit: 1,
+    });
+    expect(rootFetchRequest.relayUrls).toEqual(enrichmentRelays);
+
+    const replyRequest = subscribeMock.mock.calls[2][0][0];
     expect(replyRequest.filter).toMatchObject({
       "#e": [rootId],
       kinds: [1],
@@ -126,7 +142,7 @@ describe("subGlobalFeed", () => {
     });
     expect(replyRequest.relayUrls).toEqual(enrichmentRelays);
 
-    const nestedReplyRequest = subscribeMock.mock.calls[2][0][0];
+    const nestedReplyRequest = subscribeMock.mock.calls[3][0][0];
     expect(nestedReplyRequest.filter).toMatchObject({
       "#e": [replyId],
       kinds: [1],
@@ -167,11 +183,50 @@ describe("subGlobalFeed", () => {
 
     subGlobalFeed(vi.fn(), 24, { rootFilterDifficulty: 0 });
 
-    expect(subscribeMock).toHaveBeenCalledTimes(2);
-    expect(subscribeMock.mock.calls[1][0][0].filter["#e"]).toEqual([
+    expect(subscribeMock).toHaveBeenCalledTimes(3);
+    expect(subscribeMock.mock.calls[1][0][0].filter.ids).toEqual([
       sameAuthorRootId,
       acceptedRootId,
     ]);
+    expect(subscribeMock.mock.calls[2][0][0].filter["#e"]).toEqual([
+      sameAuthorRootId,
+      acceptedRootId,
+    ]);
+  });
+
+  it("uses fresh PoW replies to fetch and enrich their root threads", () => {
+    const rootId = `${"1".repeat(64)}`;
+    const replyId = `${"2".repeat(64)}`;
+
+    const powReply = rootNote(replyId);
+    powReply.tags = [["e", rootId, "wss://relay.example", "root"]];
+
+    subscribeMock.mockImplementation((requests) => {
+      const id = String(subscribeMock.mock.calls.length);
+
+      if (id === "1") {
+        const { cb, onEose } = requests[0];
+        cb(powReply, "wss://powrelay.xyz");
+        onEose?.();
+      }
+
+      return { id, close: vi.fn() };
+    });
+
+    subGlobalFeed(vi.fn(), 24, { rootFilterDifficulty: 0 });
+
+    expect(subscribeMock).toHaveBeenCalledTimes(3);
+    expect(subscribeMock.mock.calls[1][0][0].filter).toMatchObject({
+      ids: [rootId],
+      kinds: [1, 1068],
+      limit: 1,
+    });
+    expect(subscribeMock.mock.calls[2][0][0].filter).toMatchObject({
+      "#e": [rootId],
+      kinds: [1],
+      limit: REPLY_QUERY_LIMIT,
+      since: expect.any(Number),
+    });
   });
 
   it("can enrich replies for known root ids", () => {

--- a/src/nostr/subscriptions/global-feed.test.ts
+++ b/src/nostr/subscriptions/global-feed.test.ts
@@ -54,17 +54,9 @@ describe("subGlobalFeed", () => {
     const onEvent = vi.fn() as SubCallback;
     subGlobalFeed(onEvent, 24);
 
-    expect(subscribeMock).toHaveBeenCalledTimes(3);
+    expect(subscribeMock).toHaveBeenCalledTimes(2);
 
-    const rootFetchRequest = subscribeMock.mock.calls[1][0][0];
-    expect(rootFetchRequest.filter).toMatchObject({
-      ids: ["1".repeat(64)],
-      kinds: [1, 1068],
-      limit: 1,
-    });
-    expect(rootFetchRequest.closeOnEose).toBe(true);
-
-    const replyRequest = subscribeMock.mock.calls[2][0][0];
+    const replyRequest = subscribeMock.mock.calls[1][0][0];
     expect(replyRequest.filter).toMatchObject({
       "#e": ["1".repeat(64)],
       kinds: [1],
@@ -102,7 +94,7 @@ describe("subGlobalFeed", () => {
         return { id, close: vi.fn() };
       }
 
-      if (id === "3") {
+      if (id === "2") {
         const { cb, onEose } = requests[0];
         cb(rootNote(replyId), enrichmentRelays[0]);
         onEose?.();
@@ -120,20 +112,12 @@ describe("subGlobalFeed", () => {
       replyDepth: 2,
     });
 
-    expect(subscribeMock).toHaveBeenCalledTimes(4);
+    expect(subscribeMock).toHaveBeenCalledTimes(3);
 
     const rootRequest = subscribeMock.mock.calls[0][0][0];
     expect(rootRequest.relayUrls).toEqual(powRelays);
 
-    const rootFetchRequest = subscribeMock.mock.calls[1][0][0];
-    expect(rootFetchRequest.filter).toMatchObject({
-      ids: [rootId],
-      kinds: [1, 1068],
-      limit: 1,
-    });
-    expect(rootFetchRequest.relayUrls).toEqual(enrichmentRelays);
-
-    const replyRequest = subscribeMock.mock.calls[2][0][0];
+    const replyRequest = subscribeMock.mock.calls[1][0][0];
     expect(replyRequest.filter).toMatchObject({
       "#e": [rootId],
       kinds: [1],
@@ -142,7 +126,7 @@ describe("subGlobalFeed", () => {
     });
     expect(replyRequest.relayUrls).toEqual(enrichmentRelays);
 
-    const nestedReplyRequest = subscribeMock.mock.calls[3][0][0];
+    const nestedReplyRequest = subscribeMock.mock.calls[2][0][0];
     expect(nestedReplyRequest.filter).toMatchObject({
       "#e": [replyId],
       kinds: [1],
@@ -150,6 +134,130 @@ describe("subGlobalFeed", () => {
       since: expect.any(Number),
     });
     expect(nestedReplyRequest.relayUrls).toEqual(enrichmentRelays);
+  });
+
+  it("fetches missing roots by id from thread relays plus tag relay hints", () => {
+    const rootId = `${"1".repeat(64)}`;
+    const replyId = `${"2".repeat(64)}`;
+    const powRelays = ["wss://powrelay.xyz"];
+    const threadRelays = ["wss://relay.damus.io"];
+    const reply = {
+      ...rootNote(replyId),
+      tags: [["e", rootId, "wss://hint.example/", "root"], ["nonce", "reply", "16"]],
+    };
+
+    subscribeMock.mockImplementation((requests) => {
+      const id = String(subscribeMock.mock.calls.length);
+
+      if (id === "1") {
+        const { cb, onEose } = requests[0];
+        cb(reply, powRelays[0]);
+        onEose?.();
+      }
+
+      if (id === "2") {
+        const { cb, onEose } = requests[0];
+        cb(rootNote(rootId), "wss://hint.example");
+        onEose?.();
+      }
+
+      return { id, close: vi.fn() };
+    });
+
+    subGlobalFeed(vi.fn(), 24, {
+      rootRelayUrls: powRelays,
+      replyRelayUrls: threadRelays,
+      rootFilterDifficulty: 0,
+    });
+
+    expect(subscribeMock).toHaveBeenCalledTimes(3);
+
+    const rootFetchRequest = subscribeMock.mock.calls[1][0][0];
+    expect(rootFetchRequest.filter).toEqual({
+      ids: [rootId],
+      kinds: [1, 1068],
+      limit: 1,
+    });
+    expect(rootFetchRequest.filter).not.toHaveProperty("since");
+    expect(rootFetchRequest.relayUrls).toEqual([
+      ...threadRelays,
+      "wss://hint.example",
+    ]);
+
+    const replyRequest = subscribeMock.mock.calls[2][0][0];
+    expect(replyRequest.filter).toMatchObject({
+      "#e": [rootId],
+      kinds: [1],
+    });
+    expect(replyRequest.relayUrls).toEqual(threadRelays);
+  });
+
+  it("resolves parent-only reply activity before enriching the root thread", () => {
+    const rootId = `${"1".repeat(64)}`;
+    const parentId = `${"2".repeat(64)}`;
+    const nestedReplyId = `${"3".repeat(64)}`;
+    const threadRelays = ["wss://relay.damus.io"];
+    const nestedReply = {
+      ...rootNote(nestedReplyId),
+      tags: [["e", parentId, "wss://parent.example"], ["nonce", "nested", "16"]],
+    };
+    const parentReply = {
+      ...rootNote(parentId),
+      tags: [["e", rootId, "wss://root.example", "root"]],
+    };
+
+    subscribeMock.mockImplementation((requests) => {
+      const id = String(subscribeMock.mock.calls.length);
+
+      if (id === "1") {
+        const { cb, onEose } = requests[0];
+        cb(nestedReply, "wss://powrelay.xyz");
+        onEose?.();
+      }
+
+      if (id === "2") {
+        const { cb, onEose } = requests[0];
+        cb(parentReply, "wss://parent.example");
+        onEose?.();
+      }
+
+      if (id === "3") {
+        const { cb, onEose } = requests[0];
+        cb(rootNote(rootId), "wss://root.example");
+        onEose?.();
+      }
+
+      return { id, close: vi.fn() };
+    });
+
+    subGlobalFeed(vi.fn(), 24, {
+      replyRelayUrls: threadRelays,
+      rootFilterDifficulty: 0,
+    });
+
+    expect(subscribeMock).toHaveBeenCalledTimes(4);
+    expect(subscribeMock.mock.calls[1][0][0].filter).toEqual({
+      ids: [parentId],
+      kinds: [1, 1068],
+      limit: 1,
+    });
+    expect(subscribeMock.mock.calls[1][0][0].relayUrls).toEqual([
+      ...threadRelays,
+      "wss://parent.example",
+    ]);
+    expect(subscribeMock.mock.calls[2][0][0].filter).toEqual({
+      ids: [rootId],
+      kinds: [1, 1068],
+      limit: 1,
+    });
+    expect(subscribeMock.mock.calls[2][0][0].relayUrls).toEqual([
+      ...threadRelays,
+      "wss://root.example",
+    ]);
+    expect(subscribeMock.mock.calls[3][0][0].filter).toMatchObject({
+      "#e": [rootId],
+      kinds: [1],
+    });
   });
 
   it("uses processable feed root eligibility for PoW reply enrichment", () => {
@@ -183,12 +291,8 @@ describe("subGlobalFeed", () => {
 
     subGlobalFeed(vi.fn(), 24, { rootFilterDifficulty: 0 });
 
-    expect(subscribeMock).toHaveBeenCalledTimes(3);
-    expect(subscribeMock.mock.calls[1][0][0].filter.ids).toEqual([
-      sameAuthorRootId,
-      acceptedRootId,
-    ]);
-    expect(subscribeMock.mock.calls[2][0][0].filter["#e"]).toEqual([
+    expect(subscribeMock).toHaveBeenCalledTimes(2);
+    expect(subscribeMock.mock.calls[1][0][0].filter["#e"]).toEqual([
       sameAuthorRootId,
       acceptedRootId,
     ]);
@@ -207,6 +311,13 @@ describe("subGlobalFeed", () => {
       if (id === "1") {
         const { cb, onEose } = requests[0];
         cb(powReply, "wss://powrelay.xyz");
+        onEose?.();
+        return { id, close: vi.fn() };
+      }
+
+      if (id === "2") {
+        const { cb, onEose } = requests[0];
+        cb(rootNote(rootId), "wss://relay.example");
         onEose?.();
       }
 

--- a/src/nostr/subscriptions/global-feed.test.ts
+++ b/src/nostr/subscriptions/global-feed.test.ts
@@ -175,7 +175,7 @@ describe("subGlobalFeed", () => {
     const rootFetchRequest = subscribeMock.mock.calls[1][0][0];
     expect(rootFetchRequest.filter).toEqual({
       ids: [rootId],
-      kinds: [1, 1068],
+      kinds: [1],
       limit: 1,
     });
     expect(rootFetchRequest.filter).not.toHaveProperty("since");
@@ -238,7 +238,7 @@ describe("subGlobalFeed", () => {
     expect(subscribeMock).toHaveBeenCalledTimes(4);
     expect(subscribeMock.mock.calls[1][0][0].filter).toEqual({
       ids: [parentId],
-      kinds: [1, 1068],
+      kinds: [1],
       limit: 1,
     });
     expect(subscribeMock.mock.calls[1][0][0].relayUrls).toEqual([
@@ -247,7 +247,7 @@ describe("subGlobalFeed", () => {
     ]);
     expect(subscribeMock.mock.calls[2][0][0].filter).toEqual({
       ids: [rootId],
-      kinds: [1, 1068],
+      kinds: [1],
       limit: 1,
     });
     expect(subscribeMock.mock.calls[2][0][0].relayUrls).toEqual([
@@ -260,7 +260,7 @@ describe("subGlobalFeed", () => {
     });
   });
 
-  it("uses processable feed root eligibility for PoW reply enrichment", () => {
+  it("does not treat articles as main-feed roots", () => {
     const articleId = `${"1".repeat(64)}`;
     const sameAuthorRootId = `${"2".repeat(64)}`;
     const acceptedRootId = `${"3".repeat(64)}`;
@@ -329,7 +329,7 @@ describe("subGlobalFeed", () => {
     expect(subscribeMock).toHaveBeenCalledTimes(3);
     expect(subscribeMock.mock.calls[1][0][0].filter).toMatchObject({
       ids: [rootId],
-      kinds: [1, 1068],
+      kinds: [1],
       limit: 1,
     });
     expect(subscribeMock.mock.calls[2][0][0].filter).toMatchObject({

--- a/src/nostr/subscriptions/global-feed.ts
+++ b/src/nostr/subscriptions/global-feed.ts
@@ -92,7 +92,7 @@ class FeedRootFetch {
     private readonly onEvent: SubCallback,
     private readonly fallbackRelayUrls: readonly string[] | undefined,
     private readonly eventsById: Map<string, Event>,
-    private readonly onRootEvent: (event: Event) => void,
+    private readonly onRootEvents: (events: Event[]) => void,
   ) {}
 
   get handle(): SubHandle {
@@ -103,6 +103,7 @@ class FeedRootFetch {
     if (rootRefs.length === 0) return;
 
     const fetchRefs: FeedRootRef[] = [];
+    const rootEvents: Event[] = [];
 
     mergeFeedRootRefs(rootRefs).forEach((ref) => {
       const knownEvent = this.eventsById.get(ref.id);
@@ -112,7 +113,7 @@ class FeedRootFetch {
       }
 
       if (isFeedThreadRootEvent(knownEvent)) {
-        this.onRootEvent(knownEvent);
+        rootEvents.push(knownEvent);
         return;
       }
 
@@ -124,6 +125,10 @@ class FeedRootFetch {
         });
       }
     });
+
+    if (rootEvents.length > 0) {
+      this.onRootEvents(rootEvents);
+    }
 
     if (depth <= 0) return;
 
@@ -159,7 +164,7 @@ class FeedRootFetch {
             this.onEvent(evt, relay);
 
             if (isFeedThreadRootEvent(evt)) {
-              this.onRootEvent(evt);
+              this.onRootEvents([evt]);
               return;
             }
 
@@ -217,18 +222,22 @@ export const subGlobalFeed = (
     replyDepth,
     since,
   );
-  const startRepliesForRoot = (event: Event) => {
-    const rootId = event.id.toLowerCase();
-    if (replyRootIds.has(rootId)) return;
+  const startRepliesForRoots = (events: Event[]) => {
+    const rootIds = events
+      .map((event) => event.id.toLowerCase())
+      .filter((rootId) => {
+        if (replyRootIds.has(rootId)) return false;
+        replyRootIds.add(rootId);
+        return true;
+      });
 
-    replyRootIds.add(rootId);
-    replies.start([rootId]);
+    replies.start(rootIds);
   };
   const rootFetch = new FeedRootFetch(
     onEvent,
     options.replyRelayUrls ?? options.rootRelayUrls,
     eventsById,
-    startRepliesForRoot,
+    startRepliesForRoots,
   );
 
   owner.add(replies.handle);

--- a/src/nostr/subscriptions/global-feed.ts
+++ b/src/nostr/subscriptions/global-feed.ts
@@ -2,10 +2,11 @@ import type { Event } from "nostr-tools";
 import { getRegistry } from "../client";
 import type { SubCallback, SubHandle } from "../types";
 import {
-  feedActivityRootRef,
-  feedRootRefsFromActivity,
-  isFeedThreadRootEvent,
+  ROOT_RESOLUTION_DEPTH,
+  feedRootRefsFromQualifyingActivity,
   mergeFeedRootRefs,
+  planFeedRootResolution,
+  resolveFeedRootRef,
   uniqueRelayUrls,
   type FeedRootRef,
 } from "../feed-candidates";
@@ -22,9 +23,6 @@ type GlobalFeedOptions = {
   rootFilterDifficulty?: number;
   replyDepth?: number;
 };
-
-const ROOT_FETCH_DEPTH = 4;
-const ROOT_QUERY_LIMIT = 500;
 
 function uniqueRelays(relays: readonly string[]): string[] {
   return uniqueRelayUrls(relays);
@@ -99,32 +97,14 @@ class FeedRootFetch {
     return this.owner.handle();
   }
 
-  start(rootRefs: FeedRootRef[], depth = ROOT_FETCH_DEPTH) {
+  start(rootRefs: FeedRootRef[], depth = ROOT_RESOLUTION_DEPTH) {
     if (rootRefs.length === 0) return;
 
-    const fetchRefs: FeedRootRef[] = [];
-    const rootEvents: Event[] = [];
-
-    mergeFeedRootRefs(rootRefs).forEach((ref) => {
-      const knownEvent = this.eventsById.get(ref.id);
-      if (!knownEvent) {
-        fetchRefs.push(ref);
-        return;
-      }
-
-      if (isFeedThreadRootEvent(knownEvent)) {
-        rootEvents.push(knownEvent);
-        return;
-      }
-
-      const nextRef = feedActivityRootRef(knownEvent, this.eventsById);
-      if (nextRef && nextRef.id !== ref.id) {
-        fetchRefs.push({
-          id: nextRef.id,
-          relays: uniqueRelays([...ref.relays, ...nextRef.relays]),
-        });
-      }
-    });
+    const { rootEvents, refsToFetch } = planFeedRootResolution(
+      rootRefs,
+      this.eventsById,
+      this.requestedIds,
+    );
 
     if (rootEvents.length > 0) {
       this.onRootEvents(rootEvents);
@@ -132,53 +112,48 @@ class FeedRootFetch {
 
     if (depth <= 0) return;
 
-    const pendingRefs = mergeFeedRootRefs(fetchRefs)
-      .filter((ref) => !this.requestedIds.has(ref.id))
-      .slice(0, ROOT_QUERY_LIMIT);
+    refsToFetch.forEach((ref) => this.requestedIds.add(ref.id));
 
-    pendingRefs.forEach((ref) => this.requestedIds.add(ref.id));
-
-    for (let index = 0; index < pendingRefs.length; index += ROOT_QUERY_LIMIT) {
-      const chunk = pendingRefs.slice(index, index + ROOT_QUERY_LIMIT);
+    {
+      const chunk = mergeFeedRootRefs(refsToFetch);
       const ids = chunk.map((ref) => ref.id);
-      if (ids.length === 0) continue;
-      const nextRefs = new Map<string, FeedRootRef>();
-      const addNextRef = (ref: FeedRootRef) => {
-        const [merged] = mergeFeedRootRefs([
-          ...(nextRefs.get(ref.id) ? [nextRefs.get(ref.id)!] : []),
-          ref,
-        ]);
-        nextRefs.set(ref.id, merged);
-      };
+      if (ids.length > 0) {
+        const nextRefs = new Map<string, FeedRootRef>();
+        const addNextRef = (ref: FeedRootRef) => {
+          const [merged] = mergeFeedRootRefs([
+            ...(nextRefs.get(ref.id) ? [nextRefs.get(ref.id)!] : []),
+            ref,
+          ]);
+          nextRefs.set(ref.id, merged);
+        };
 
-      this.owner.add(getRegistry().subscribe([
-        {
-          filter: {
-            ids,
-            kinds: [1, 1068],
-            limit: ids.length,
-          },
-          relayUrls: rootRelayUrls(chunk, this.fallbackRelayUrls),
-          cb: (evt, relay) => {
-            this.eventsById.set(evt.id.toLowerCase(), evt);
-            this.onEvent(evt, relay);
+        this.owner.add(getRegistry().subscribe([
+          {
+            filter: {
+              ids,
+              kinds: [1],
+              limit: ids.length,
+            },
+            relayUrls: rootRelayUrls(chunk, this.fallbackRelayUrls),
+            cb: (evt, relay) => {
+              this.eventsById.set(evt.id.toLowerCase(), evt);
+              this.onEvent(evt, relay);
 
-            if (isFeedThreadRootEvent(evt)) {
-              this.onRootEvents([evt]);
-              return;
-            }
+              const nextRef = resolveFeedRootRef(evt, this.eventsById);
+              if (nextRef?.id === evt.id.toLowerCase()) {
+                this.onRootEvents([evt]);
+                return;
+              }
 
-            const nextRef = feedActivityRootRef(evt, this.eventsById);
-            if (nextRef && nextRef.id !== evt.id.toLowerCase()) {
-              addNextRef(nextRef);
-            }
+              if (nextRef) addNextRef(nextRef);
+            },
+            closeOnEose: true,
+            onEose: () => {
+              this.start([...nextRefs.values()], depth - 1);
+            },
           },
-          closeOnEose: true,
-          onEose: () => {
-            this.start([...nextRefs.values()], depth - 1);
-          },
-        },
-      ]));
+        ]));
+      }
     }
   }
 }
@@ -247,7 +222,7 @@ export const subGlobalFeed = (
     registry.subscribe([
       {
         filter: {
-          kinds: [1, 1068],
+          kinds: [1],
           since,
           limit: 500,
         },
@@ -261,7 +236,7 @@ export const subGlobalFeed = (
         },
         closeOnEose: true,
         onEose: () => {
-          const rootRefs = feedRootRefsFromActivity(
+          const rootRefs = feedRootRefsFromQualifyingActivity(
             activityEvents,
             options.rootFilterDifficulty ?? 0,
             eventsById,

--- a/src/nostr/subscriptions/global-feed.ts
+++ b/src/nostr/subscriptions/global-feed.ts
@@ -2,8 +2,12 @@ import type { Event } from "nostr-tools";
 import { getRegistry } from "../client";
 import type { SubCallback, SubHandle } from "../types";
 import {
-  createFeedCandidateTracker,
-  feedReplyRootId,
+  feedActivityRootRef,
+  feedRootRefsFromActivity,
+  isFeedThreadRootEvent,
+  mergeFeedRootRefs,
+  uniqueRelayUrls,
+  type FeedRootRef,
 } from "../feed-candidates";
 import { createSubHandleOwner } from "./utils";
 import {
@@ -19,12 +23,24 @@ type GlobalFeedOptions = {
   replyDepth?: number;
 };
 
-const trackRootNote = (notes: Set<string>, evt: Event) => {
-  const replyRootId = feedReplyRootId(evt);
-  if (replyRootId) {
-    notes.add(replyRootId);
-  }
-};
+const ROOT_FETCH_DEPTH = 4;
+const ROOT_QUERY_LIMIT = 500;
+
+function uniqueRelays(relays: readonly string[]): string[] {
+  return uniqueRelayUrls(relays);
+}
+
+function rootRelayUrls(
+  roots: Iterable<FeedRootRef>,
+  fallbackRelays: readonly string[] | undefined,
+): string[] | undefined {
+  const relays = uniqueRelays([
+    ...(fallbackRelays ?? []),
+    ...[...roots].flatMap((ref) => ref.relays),
+  ]);
+
+  return relays.length > 0 ? relays : undefined;
+}
 
 class FeedReplyTraversal {
   private readonly owner = createSubHandleOwner("feed-replies");
@@ -68,6 +84,100 @@ class FeedReplyTraversal {
   }
 }
 
+class FeedRootFetch {
+  private readonly owner = createSubHandleOwner("feed-roots");
+  private readonly requestedIds = new Set<string>();
+
+  constructor(
+    private readonly onEvent: SubCallback,
+    private readonly fallbackRelayUrls: readonly string[] | undefined,
+    private readonly eventsById: Map<string, Event>,
+    private readonly onRootEvent: (event: Event) => void,
+  ) {}
+
+  get handle(): SubHandle {
+    return this.owner.handle();
+  }
+
+  start(rootRefs: FeedRootRef[], depth = ROOT_FETCH_DEPTH) {
+    if (rootRefs.length === 0) return;
+
+    const fetchRefs: FeedRootRef[] = [];
+
+    mergeFeedRootRefs(rootRefs).forEach((ref) => {
+      const knownEvent = this.eventsById.get(ref.id);
+      if (!knownEvent) {
+        fetchRefs.push(ref);
+        return;
+      }
+
+      if (isFeedThreadRootEvent(knownEvent)) {
+        this.onRootEvent(knownEvent);
+        return;
+      }
+
+      const nextRef = feedActivityRootRef(knownEvent, this.eventsById);
+      if (nextRef && nextRef.id !== ref.id) {
+        fetchRefs.push({
+          id: nextRef.id,
+          relays: uniqueRelays([...ref.relays, ...nextRef.relays]),
+        });
+      }
+    });
+
+    if (depth <= 0) return;
+
+    const pendingRefs = mergeFeedRootRefs(fetchRefs)
+      .filter((ref) => !this.requestedIds.has(ref.id))
+      .slice(0, ROOT_QUERY_LIMIT);
+
+    pendingRefs.forEach((ref) => this.requestedIds.add(ref.id));
+
+    for (let index = 0; index < pendingRefs.length; index += ROOT_QUERY_LIMIT) {
+      const chunk = pendingRefs.slice(index, index + ROOT_QUERY_LIMIT);
+      const ids = chunk.map((ref) => ref.id);
+      if (ids.length === 0) continue;
+      const nextRefs = new Map<string, FeedRootRef>();
+      const addNextRef = (ref: FeedRootRef) => {
+        const [merged] = mergeFeedRootRefs([
+          ...(nextRefs.get(ref.id) ? [nextRefs.get(ref.id)!] : []),
+          ref,
+        ]);
+        nextRefs.set(ref.id, merged);
+      };
+
+      this.owner.add(getRegistry().subscribe([
+        {
+          filter: {
+            ids,
+            kinds: [1, 1068],
+            limit: ids.length,
+          },
+          relayUrls: rootRelayUrls(chunk, this.fallbackRelayUrls),
+          cb: (evt, relay) => {
+            this.eventsById.set(evt.id.toLowerCase(), evt);
+            this.onEvent(evt, relay);
+
+            if (isFeedThreadRootEvent(evt)) {
+              this.onRootEvent(evt);
+              return;
+            }
+
+            const nextRef = feedActivityRootRef(evt, this.eventsById);
+            if (nextRef && nextRef.id !== evt.id.toLowerCase()) {
+              addNextRef(nextRef);
+            }
+          },
+          closeOnEose: true,
+          onEose: () => {
+            this.start([...nextRefs.values()], depth - 1);
+          },
+        },
+      ]));
+    }
+  }
+}
+
 export const subRepliesForRootIds = (
   rootIds: string[],
   onEvent: SubCallback,
@@ -95,8 +205,9 @@ export const subGlobalFeed = (
 ): SubHandle => {
   const registry = getRegistry();
   const owner = createSubHandleOwner("global-feed");
-  const notes = new Set<string>();
-  const candidates = createFeedCandidateTracker(options.rootFilterDifficulty);
+  const activityEvents: Event[] = [];
+  const eventsById = new Map<string, Event>();
+  const replyRootIds = new Set<string>();
   const now = Math.floor(Date.now() / 1000);
   const since = sinceFromAgeHours(ageHours, now);
   const replyDepth = clampReplyDepth(options.replyDepth ?? 1);
@@ -106,8 +217,22 @@ export const subGlobalFeed = (
     replyDepth,
     since,
   );
+  const startRepliesForRoot = (event: Event) => {
+    const rootId = event.id.toLowerCase();
+    if (replyRootIds.has(rootId)) return;
+
+    replyRootIds.add(rootId);
+    replies.start([rootId]);
+  };
+  const rootFetch = new FeedRootFetch(
+    onEvent,
+    options.replyRelayUrls ?? options.rootRelayUrls,
+    eventsById,
+    startRepliesForRoot,
+  );
 
   owner.add(replies.handle);
+  owner.add(rootFetch.handle);
 
   owner.add(
     registry.subscribe([
@@ -121,23 +246,19 @@ export const subGlobalFeed = (
           ? [...options.rootRelayUrls]
           : undefined,
         cb: (evt, relay) => {
-          if (options.rootFilterDifficulty === undefined) {
-            trackRootNote(notes, evt);
-          } else {
-            const decision = candidates.check(evt);
-            if (decision.replyRootId) {
-              notes.add(decision.replyRootId);
-            }
-          }
+          eventsById.set(evt.id.toLowerCase(), evt);
+          activityEvents.push(evt);
           onEvent(evt, relay);
         },
         closeOnEose: true,
         onEose: () => {
-          if (notes.size === 0) return;
-
-          const noteIds = Array.from(notes);
-          notes.clear();
-          replies.start(noteIds);
+          const rootRefs = feedRootRefsFromActivity(
+            activityEvents,
+            options.rootFilterDifficulty ?? 0,
+            eventsById,
+          );
+          activityEvents.length = 0;
+          rootFetch.start(rootRefs);
         },
       },
     ]),

--- a/src/shared/lib/feedBootstrapClient.test.ts
+++ b/src/shared/lib/feedBootstrapClient.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { Event } from "nostr-tools";
 import {
-  eventsFromProcessed,
   eventsFromSnapshot,
   feedBootstrapUrls,
   fetchFeedBootstrapSnapshot,
+  processedEventsFromSnapshot,
   relayHintsFromSnapshot,
   resetFeedBootstrapSnapshotCache,
   threadEventsFromSnapshot,
@@ -23,34 +23,80 @@ const event = (overrides: Partial<Event> = {}): Event => ({
   ...overrides,
 });
 
-describe("eventsFromProcessed", () => {
-  it("deduplicates post and reply events", () => {
-    const root = event({ id: "1".repeat(64) });
-    const reply = event({ id: "2".repeat(64), pubkey: "c".repeat(64) });
-
-    const events = eventsFromProcessed([
-      { postEvent: root, replies: [reply, reply], totalWork: 0 },
-    ]);
-
-    expect(events).toHaveLength(2);
-    expect(events.map((item) => item.id)).toEqual([root.id, reply.id]);
-  });
+const snapshot = (
+  overrides: Partial<FeedBootstrapResponse> = {},
+): FeedBootstrapResponse => ({
+  version: 2,
+  fetchedAt: 1,
+  processedEvents: [],
+  eventsById: {},
+  relayHintsByEventId: {},
+  profiles: {},
+  scoring: {
+    ageHours: 24,
+    minPow: 16,
+    replyDepth: 2,
+    sort: "totalWork",
+  },
+  ...overrides,
 });
 
 describe("eventsFromSnapshot", () => {
-  it("deduplicates raw and processed events", () => {
+  it("returns normalized events", () => {
     const root = event({ id: "1".repeat(64) });
     const reply = event({ id: "2".repeat(64), pubkey: "c".repeat(64) });
 
     expect(
-      eventsFromSnapshot({
-        fetchedAt: 1,
-        events: [root],
-        relayHintsByEventId: {},
-        processedEvents: [{ postEvent: root, replies: [reply], totalWork: 0 }],
-        profiles: {},
-      }).map((item) => item.id),
+      eventsFromSnapshot(snapshot({
+        eventsById: {
+          [root.id]: root,
+          [reply.id]: reply,
+        },
+      })).map((item) => item.id),
     ).toEqual([root.id, reply.id]);
+  });
+});
+
+describe("processedEventsFromSnapshot", () => {
+  it("hydrates processed rows from event ids", () => {
+    const root = event({ id: "1".repeat(64) });
+    const reply = event({
+      id: "2".repeat(64),
+      pubkey: "c".repeat(64),
+      tags: [["e", root.id]],
+    });
+
+    expect(
+      processedEventsFromSnapshot(snapshot({
+        eventsById: {
+          [root.id]: root,
+          [reply.id]: reply,
+        },
+        processedEvents: [
+          {
+            postEventId: root.id,
+            replyIds: [reply.id],
+            relayHints: ["wss://relay.example"],
+            threadReplyCount: 1,
+            rootWork: 1,
+            replyWork: 2,
+            totalWork: 3,
+            rankingReplyCount: 1,
+          },
+        ],
+      })),
+    ).toEqual([
+      {
+        postEvent: root,
+        replies: [reply],
+        relayHints: ["wss://relay.example"],
+        threadReplyCount: 1,
+        rootWork: 1,
+        replyWork: 2,
+        totalWork: 3,
+        rankingReplyCount: 1,
+      },
+    ]);
   });
 });
 
@@ -60,22 +106,27 @@ describe("relayHintsFromSnapshot", () => {
     const reply = event({ id: "2".repeat(64), pubkey: "c".repeat(64) });
 
     expect(
-      relayHintsFromSnapshot({
-        fetchedAt: 1,
-        events: [root, reply],
+      relayHintsFromSnapshot(snapshot({
+        eventsById: {
+          [root.id]: root,
+          [reply.id]: reply,
+        },
         relayHintsByEventId: {
           [reply.id]: ["wss://reply.example"],
         },
         processedEvents: [
           {
-            postEvent: root,
-            replies: [reply],
+            postEventId: root.id,
+            replyIds: [reply.id],
             relayHints: ["wss://relay.example"],
+            threadReplyCount: 1,
+            rootWork: 1,
+            replyWork: 0,
             totalWork: 0,
+            rankingReplyCount: 0,
           },
         ],
-        profiles: {},
-      }),
+      })),
     ).toEqual(
       new Map([
         [reply.id, ["wss://reply.example"]],
@@ -101,13 +152,13 @@ describe("threadEventsFromSnapshot", () => {
 
     expect(
       threadEventsFromSnapshot(
-        {
-          fetchedAt: 1,
-          events: [root, directReply, nestedReply],
-          relayHintsByEventId: {},
-          processedEvents: [],
-          profiles: {},
-        },
+        snapshot({
+          eventsById: {
+            [root.id]: root,
+            [directReply.id]: directReply,
+            [nestedReply.id]: nestedReply,
+          },
+        }),
         root.id,
       ).map((item) => item.id),
     ).toEqual([root.id, directReply.id, nestedReply.id]);
@@ -128,14 +179,6 @@ describe("feedBootstrapUrls", () => {
 });
 
 describe("fetchFeedBootstrapSnapshot", () => {
-  const snapshot = (): FeedBootstrapResponse => ({
-    fetchedAt: 1,
-    processedEvents: [],
-    events: [],
-    relayHintsByEventId: {},
-    profiles: {},
-  });
-
   const jsonResponse = (body: unknown, init?: ResponseInit) =>
     new Response(JSON.stringify(body), {
       headers: { "content-type": "application/json" },

--- a/src/shared/lib/feedBootstrapClient.test.ts
+++ b/src/shared/lib/feedBootstrapClient.test.ts
@@ -26,7 +26,6 @@ const event = (overrides: Partial<Event> = {}): Event => ({
 const snapshot = (
   overrides: Partial<FeedBootstrapResponse> = {},
 ): FeedBootstrapResponse => ({
-  version: 2,
   fetchedAt: 1,
   processedEvents: [],
   eventsById: {},

--- a/src/shared/lib/feedBootstrapClient.ts
+++ b/src/shared/lib/feedBootstrapClient.ts
@@ -1,32 +1,11 @@
 import type { Event } from "nostr-tools";
 import type { ProcessedEvent, RelayHintsByEventId } from "../../nostr/types";
-import type { ProfileMetadata } from "./profile";
+import {
+  isFeedBootstrapSnapshot,
+  type FeedBootstrapSnapshot,
+} from "./feedBootstrapTypes";
 
-export type FeedBootstrapResponse = {
-  version: 2;
-  fetchedAt: number;
-  processedEvents: FeedBootstrapProcessedEvent[];
-  eventsById: Record<string, Event>;
-  relayHintsByEventId: Record<string, string[]>;
-  profiles: Record<string, ProfileMetadata>;
-  scoring: {
-    ageHours: number;
-    minPow: number;
-    replyDepth: number;
-    sort: "totalWork";
-  };
-};
-
-export type FeedBootstrapProcessedEvent = {
-  postEventId: string;
-  replyIds: string[];
-  relayHints?: string[];
-  threadReplyCount: number;
-  rootWork: number;
-  replyWork: number;
-  totalWork: number;
-  rankingReplyCount: number;
-};
+export type FeedBootstrapResponse = FeedBootstrapSnapshot;
 
 export const VERCEL_FEED_BOOTSTRAP_URL = "/api/feed/bootstrap";
 export const FEED_SNAPSHOT_URL_ENV = "VITE_FEED_SNAPSHOT_URL";
@@ -52,42 +31,6 @@ export function feedBootstrapUrls(
     : [VERCEL_FEED_BOOTSTRAP_URL];
 }
 
-function isEvent(value: unknown): value is Event {
-  if (!value || typeof value !== "object") return false;
-
-  const candidate = value as Partial<Event>;
-  return (
-    typeof candidate.id === "string" &&
-    typeof candidate.pubkey === "string" &&
-    typeof candidate.created_at === "number" &&
-    typeof candidate.kind === "number" &&
-    Array.isArray(candidate.tags) &&
-    typeof candidate.content === "string" &&
-    typeof candidate.sig === "string"
-  );
-}
-
-function isFeedBootstrapResponse(value: unknown): value is FeedBootstrapResponse {
-  if (!value || typeof value !== "object") return false;
-
-  const candidate = value as Partial<FeedBootstrapResponse>;
-
-  return (
-    candidate.version === 2 &&
-    typeof candidate.fetchedAt === "number" &&
-    Array.isArray(candidate.processedEvents) &&
-    !!candidate.eventsById &&
-    typeof candidate.eventsById === "object" &&
-    Object.values(candidate.eventsById).every(isEvent) &&
-    !!candidate.relayHintsByEventId &&
-    typeof candidate.relayHintsByEventId === "object" &&
-    !!candidate.profiles &&
-    typeof candidate.profiles === "object" &&
-    !!candidate.scoring &&
-    typeof candidate.scoring === "object"
-  );
-}
-
 export async function fetchFeedBootstrapSnapshot(
   fetcher: FetchLike = fetch,
   externalSnapshotUrl: string | null = configuredFeedSnapshotUrl(),
@@ -98,7 +41,7 @@ export async function fetchFeedBootstrapSnapshot(
       if (!response.ok) continue;
 
       const snapshot = (await response.json()) as unknown;
-      if (isFeedBootstrapResponse(snapshot)) {
+      if (isFeedBootstrapSnapshot(snapshot)) {
         return snapshot;
       }
     } catch {

--- a/src/shared/lib/feedBootstrapClient.ts
+++ b/src/shared/lib/feedBootstrapClient.ts
@@ -3,11 +3,29 @@ import type { ProcessedEvent, RelayHintsByEventId } from "../../nostr/types";
 import type { ProfileMetadata } from "./profile";
 
 export type FeedBootstrapResponse = {
+  version: 2;
   fetchedAt: number;
-  processedEvents: ProcessedEvent[];
-  events: Event[];
+  processedEvents: FeedBootstrapProcessedEvent[];
+  eventsById: Record<string, Event>;
   relayHintsByEventId: Record<string, string[]>;
   profiles: Record<string, ProfileMetadata>;
+  scoring: {
+    ageHours: number;
+    minPow: number;
+    replyDepth: number;
+    sort: "totalWork";
+  };
+};
+
+export type FeedBootstrapProcessedEvent = {
+  postEventId: string;
+  replyIds: string[];
+  relayHints?: string[];
+  threadReplyCount: number;
+  rootWork: number;
+  replyWork: number;
+  totalWork: number;
+  rankingReplyCount: number;
 };
 
 export const VERCEL_FEED_BOOTSTRAP_URL = "/api/feed/bootstrap";
@@ -34,19 +52,39 @@ export function feedBootstrapUrls(
     : [VERCEL_FEED_BOOTSTRAP_URL];
 }
 
+function isEvent(value: unknown): value is Event {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<Event>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.pubkey === "string" &&
+    typeof candidate.created_at === "number" &&
+    typeof candidate.kind === "number" &&
+    Array.isArray(candidate.tags) &&
+    typeof candidate.content === "string" &&
+    typeof candidate.sig === "string"
+  );
+}
+
 function isFeedBootstrapResponse(value: unknown): value is FeedBootstrapResponse {
   if (!value || typeof value !== "object") return false;
 
   const candidate = value as Partial<FeedBootstrapResponse>;
 
   return (
+    candidate.version === 2 &&
     typeof candidate.fetchedAt === "number" &&
     Array.isArray(candidate.processedEvents) &&
-    Array.isArray(candidate.events) &&
+    !!candidate.eventsById &&
+    typeof candidate.eventsById === "object" &&
+    Object.values(candidate.eventsById).every(isEvent) &&
     !!candidate.relayHintsByEventId &&
     typeof candidate.relayHintsByEventId === "object" &&
     !!candidate.profiles &&
-    typeof candidate.profiles === "object"
+    typeof candidate.profiles === "object" &&
+    !!candidate.scoring &&
+    typeof candidate.scoring === "object"
   );
 }
 
@@ -99,32 +137,32 @@ export function resetFeedBootstrapSnapshotCache(): void {
   snapshotPromise = null;
 }
 
-export function eventsFromProcessed(processedEvents: ProcessedEvent[]): Event[] {
-  const events: Event[] = [];
-  const seen = new Set<string>();
+export function processedEventsFromSnapshot(
+  snapshot: FeedBootstrapResponse,
+): ProcessedEvent[] {
+  return snapshot.processedEvents.flatMap((processed) => {
+    const postEvent = snapshot.eventsById[processed.postEventId];
+    if (!postEvent) return [];
 
-  processedEvents.forEach((processed) => {
-    [processed.postEvent, ...processed.replies].forEach((event) => {
-      if (seen.has(event.id)) return;
-      seen.add(event.id);
-      events.push(event);
-    });
+    const replies = processed.replyIds
+      .map((id) => snapshot.eventsById[id])
+      .filter((event): event is Event => Boolean(event));
+
+    return [{
+      postEvent,
+      replies,
+      relayHints: processed.relayHints,
+      threadReplyCount: processed.threadReplyCount,
+      rootWork: processed.rootWork,
+      replyWork: processed.replyWork,
+      totalWork: processed.totalWork,
+      rankingReplyCount: processed.rankingReplyCount,
+    }];
   });
-
-  return events;
 }
 
 export function eventsFromSnapshot(snapshot: FeedBootstrapResponse): Event[] {
-  const events: Event[] = [];
-  const seen = new Set<string>();
-
-  [...snapshot.events, ...eventsFromProcessed(snapshot.processedEvents)].forEach((event) => {
-    if (seen.has(event.id)) return;
-    seen.add(event.id);
-    events.push(event);
-  });
-
-  return events;
+  return Object.values(snapshot.eventsById);
 }
 
 export function relayHintsFromSnapshot(
@@ -136,7 +174,7 @@ export function relayHintsFromSnapshot(
     relayHintsByEventId.set(eventId, [...new Set(relays)]);
   });
 
-  snapshot.processedEvents.forEach((processed) => {
+  processedEventsFromSnapshot(snapshot).forEach((processed) => {
     if (!processed.relayHints || processed.relayHints.length === 0) return;
     const existing = relayHintsByEventId.get(processed.postEvent.id) ?? [];
     relayHintsByEventId.set(

--- a/src/shared/lib/feedBootstrapTypes.ts
+++ b/src/shared/lib/feedBootstrapTypes.ts
@@ -1,0 +1,89 @@
+import type { Event } from "nostr-tools";
+import type { ProfileMetadata } from "./profile";
+
+export type FeedBootstrapSnapshot = {
+  fetchedAt: number;
+  processedEvents: FeedBootstrapProcessedEvent[];
+  eventsById: Record<string, Event>;
+  relayHintsByEventId: Record<string, string[]>;
+  profiles: Record<string, ProfileMetadata>;
+  scoring: {
+    ageHours: number;
+    minPow: number;
+    replyDepth: number;
+    sort: "totalWork";
+  };
+};
+
+export type FeedBootstrapProcessedEvent = {
+  postEventId: string;
+  replyIds: string[];
+  relayHints?: string[];
+  threadReplyCount: number;
+  rootWork: number;
+  replyWork: number;
+  totalWork: number;
+  rankingReplyCount: number;
+};
+
+function isEvent(value: unknown): value is Event {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<Event>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.pubkey === "string" &&
+    typeof candidate.created_at === "number" &&
+    typeof candidate.kind === "number" &&
+    Array.isArray(candidate.tags) &&
+    typeof candidate.content === "string" &&
+    typeof candidate.sig === "string"
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isProcessedEvent(value: unknown): value is FeedBootstrapProcessedEvent {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<FeedBootstrapProcessedEvent>;
+  return (
+    typeof candidate.postEventId === "string" &&
+    isStringArray(candidate.replyIds) &&
+    (candidate.relayHints === undefined || isStringArray(candidate.relayHints)) &&
+    typeof candidate.threadReplyCount === "number" &&
+    typeof candidate.rootWork === "number" &&
+    typeof candidate.replyWork === "number" &&
+    typeof candidate.totalWork === "number" &&
+    typeof candidate.rankingReplyCount === "number"
+  );
+}
+
+export function isFeedBootstrapSnapshot(
+  value: unknown,
+): value is FeedBootstrapSnapshot {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<FeedBootstrapSnapshot>;
+  return (
+    typeof candidate.fetchedAt === "number" &&
+    Array.isArray(candidate.processedEvents) &&
+    candidate.processedEvents.every(isProcessedEvent) &&
+    !!candidate.eventsById &&
+    typeof candidate.eventsById === "object" &&
+    Object.values(candidate.eventsById).every(isEvent) &&
+    !!candidate.relayHintsByEventId &&
+    typeof candidate.relayHintsByEventId === "object" &&
+    Object.values(candidate.relayHintsByEventId).every(isStringArray) &&
+    !!candidate.profiles &&
+    typeof candidate.profiles === "object" &&
+    !!candidate.scoring &&
+    typeof candidate.scoring === "object" &&
+    typeof candidate.scoring.ageHours === "number" &&
+    typeof candidate.scoring.minPow === "number" &&
+    typeof candidate.scoring.replyDepth === "number" &&
+    candidate.scoring.sort === "totalWork"
+  );
+}


### PR DESCRIPTION
## Summary
- use fresh kind-1 PoW activity from PoW relays to nominate feed roots
- fetch nominated roots without a freshness limit, then enrich recent replies
- keep signal ranking based on total root/reply work and wire the preview branch to Wired Admin staging

## Validation
- npm test
- npm run typecheck
- npm run lint (existing fast-refresh warnings only)
- npm run build

## Preview wiring
Branch-specific Vercel preview env vars for `codex/main-feed-client` point to `https://staging.wiredsignal.online`.