### PR TITLE
Prime video previews near viewport

### DIFF
--- a/src/shared/ui/NoteMedia.test.tsx
+++ b/src/shared/ui/NoteMedia.test.tsx
@@ -2,8 +2,8 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { NoteMedia } from "./NoteMedia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MediaAttachment, NoteMedia } from "./NoteMedia";
 
 (
   globalThis as typeof globalThis & {
@@ -14,11 +14,31 @@ import { NoteMedia } from "./NoteMedia";
 describe("NoteMedia video previews", () => {
   let container: HTMLDivElement;
   let root: Root;
+  let intersectionCallback: IntersectionObserverCallback = () => undefined;
+  let loadMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+    loadMock = vi.fn();
+    Object.defineProperty(HTMLMediaElement.prototype, "load", {
+      configurable: true,
+      value: loadMock,
+    });
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback;
+        }
+
+        observe = vi.fn();
+        disconnect = vi.fn();
+        unobserve = vi.fn();
+        takeRecords = vi.fn(() => []);
+      },
+    );
   });
 
   afterEach(() => {
@@ -26,9 +46,10 @@ describe("NoteMedia video previews", () => {
       root.unmount();
     });
     container.remove();
+    vi.unstubAllGlobals();
   });
 
-  it("requests a first frame for bare video URLs", () => {
+  it("primes a first frame for bare video URLs when they approach the viewport", () => {
     act(() => {
       root.render(
         <NoteMedia
@@ -47,11 +68,12 @@ describe("NoteMedia video previews", () => {
     const video = container.querySelector("video");
     expect(video).not.toBeNull();
     expect(video?.getAttribute("src")).toBe("https://example.com/bare.mp4");
-    expect(video?.getAttribute("preload")).toBe("auto");
+    expect(video?.getAttribute("preload")).toBe("metadata");
     expect(video?.hasAttribute("controls")).toBe(true);
     expect(video?.getAttribute("poster")).toBeNull();
     expect(video?.parentElement?.style.aspectRatio).toBe("640 / 360");
     expect(container.textContent).toContain("video preview");
+    expect(loadMock).not.toHaveBeenCalled();
 
     Object.defineProperty(video, "duration", {
       configurable: true,
@@ -59,9 +81,14 @@ describe("NoteMedia video previews", () => {
     });
 
     act(() => {
-      video?.dispatchEvent(new Event("loadedmetadata", { bubbles: true }));
+      intersectionCallback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
     });
 
+    expect(video?.getAttribute("preload")).toBe("auto");
+    expect(loadMock).toHaveBeenCalledTimes(1);
     expect(video?.currentTime).toBe(0.001);
 
     act(() => {
@@ -69,6 +96,25 @@ describe("NoteMedia video previews", () => {
     });
 
     expect(container.textContent).not.toContain("video preview");
+  });
+
+  it("primes priority video previews immediately", () => {
+    act(() => {
+      root.render(
+        <MediaAttachment
+          priority
+          item={{
+            url: "https://example.com/top-feed.mp4",
+            type: "video",
+          }}
+        />,
+      );
+    });
+
+    const video = container.querySelector("video");
+    expect(video).not.toBeNull();
+    expect(video?.getAttribute("preload")).toBe("auto");
+    expect(loadMock).toHaveBeenCalledTimes(1);
   });
 
   it("preserves imeta posters without seeking for a preview frame", () => {
@@ -91,6 +137,7 @@ describe("NoteMedia video previews", () => {
     expect(video?.getAttribute("poster")).toBe("https://example.com/poster.jpg");
     expect(video?.getAttribute("preload")).toBe("metadata");
     expect(container.textContent).not.toContain("video preview");
+    expect(loadMock).not.toHaveBeenCalled();
 
     Object.defineProperty(video, "duration", {
       configurable: true,

--- a/src/shared/ui/NoteMedia.tsx
+++ b/src/shared/ui/NoteMedia.tsx
@@ -1,10 +1,11 @@
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { MediaItem } from "@lib/mediaUtils";
 import {
   optimizedImageSrcSet,
   optimizedImageUrl,
   pickOptimizedWidth,
 } from "@lib/optimizedImageUrl";
+import { useInView } from "../hooks/useInView";
 
 function MediaFallback() {
   return (
@@ -138,21 +139,24 @@ function GridImage({
 function MediaVideo({
   item,
   compact,
+  priority = false,
 }: {
   item: MediaItem;
   compact?: boolean;
+  priority?: boolean;
 }) {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const primedRef = useRef(false);
+  const { ref: inViewRef, inView } = useInView({ rootMargin: "600px" });
   const [failed, setFailed] = useState(false);
   const [started, setStarted] = useState(false);
   const [previewReady, setPreviewReady] = useState(false);
 
-  if (failed) return <MediaFallback />;
-
   const hasDimensions = Boolean(item.width && item.height);
   const aspectRatio = hasDimensions ? `${item.width} / ${item.height}` : "16 / 9";
   const hasPoster = Boolean(item.posterUrl);
-  const requestFirstFrame = () => {
+  const shouldPrimePreview = priority || inView;
+  const requestFirstFrame = useCallback(() => {
     if (hasPoster) return;
 
     const video = videoRef.current;
@@ -170,10 +174,24 @@ function MediaVideo({
     } catch {
       // Cross-origin or streaming media may reject seeking; native controls remain usable.
     }
-  };
+  }, [hasPoster]);
+
+  useEffect(() => {
+    if (hasPoster || !shouldPrimePreview || primedRef.current) return;
+
+    const video = videoRef.current;
+    if (!video) return;
+
+    primedRef.current = true;
+    video.load();
+    requestFirstFrame();
+  }, [hasPoster, requestFirstFrame, shouldPrimePreview]);
+
+  if (failed) return <MediaFallback />;
 
   return (
     <div
+      ref={inViewRef}
       className={[
         "relative overflow-hidden rounded border border-ghost bg-surface",
         compact ? "max-h-[120px]" : "max-h-[min(60vh,24rem)]",
@@ -185,10 +203,12 @@ function MediaVideo({
         src={item.url}
         poster={item.posterUrl}
         controls
-        preload={hasPoster ? "metadata" : "auto"}
+        preload={hasPoster || !shouldPrimePreview ? "metadata" : "auto"}
         playsInline
         onPlay={() => setStarted(true)}
-        onLoadedMetadata={requestFirstFrame}
+        onLoadedMetadata={() => {
+          if (shouldPrimePreview) requestFirstFrame();
+        }}
         onLoadedData={() => setPreviewReady(true)}
         onCanPlay={() => setPreviewReady(true)}
         onSeeked={() => setPreviewReady(true)}
@@ -239,7 +259,7 @@ export function MediaAttachment({
     case "image":
       return <MediaImage item={item} compact={compact} priority={priority} />;
     case "video":
-      return <MediaVideo item={item} compact={compact} />;
+      return <MediaVideo item={item} compact={compact} priority={priority} />;
     case "audio":
       return <MediaAudio item={item} />;
   }


### PR DESCRIPTION
## Summary
- Fixes #76
- Primes bare video previews when they approach the viewport instead of waiting for user playback.
- Carries the existing priority media path through to videos so top feed videos prime immediately.
- Keeps videos with `imeta` posters conservative and avoids forced seeking/loading for those.

## Verification
- `npm test -- --run src/shared/ui/NoteMedia.test.tsx src/shared/lib/mediaUtils.test.ts src/shared/lib/content.test.ts src/shared/lib/attachmentSegments.test.ts src/shared/hooks/useLinkMetadata.test.tsx` - passed, 28 tests.
- `npm run typecheck` - passed.
- `npm run lint` - passed with existing Fast Refresh warnings in `src/app/providers.tsx` and `src/app/settings.tsx` only.

## Notes
- Test output includes existing jsdom act warnings from `useLinkMetadata.test.tsx`; no failures.