### PR TITLE
Raise default post signal to 21

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_RELAYS, configuredRelays } from "./config";
+import { DEFAULT_DIFFICULTY, DEFAULT_RELAYS, configuredRelays } from "./config";
+
+describe("DEFAULT_DIFFICULTY", () => {
+  it("defaults new posts to signal 21", () => {
+    expect(DEFAULT_DIFFICULTY).toBe(21);
+  });
+});
 
 describe("DEFAULT_RELAYS", () => {
   it("includes the Wired relay in the main feed relay list", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_DIFFICULTY = 16;
+export const DEFAULT_DIFFICULTY = 21;
 
 export const DEFAULT_RELAYS = [
   "wss://relay.wiredsignal.online",


### PR DESCRIPTION
## Summary
- Raises the default compose post signal from 16 to 21 for new users/new browsers.
- Adds a regression test for the default difficulty constant.

## Verification
- `npm test -- --run src/config.test.ts` - passed, 6 tests.
- `npm run typecheck` - passed.
- `npm run lint` - passed with existing Fast Refresh warnings in `src/app/providers.tsx` and `src/app/settings.tsx` only.

## Notes
- Existing persisted user settings are unchanged; this only changes the fallback default.