### PR TITLE
Fix media and link preview layout in posts and quotes

### DIFF
--- a/api/_shared/handlers.ts
+++ b/api/_shared/handlers.ts
@@ -6,7 +6,8 @@ import {
 import { unfurlUrl } from "../../lib/unfurl.js";
 
 const JSON_HEADERS = { "Content-Type": "application/json" };
-const UNFURL_CACHE_HEADER = "public, max-age=3600";
+const UNFURL_CACHE_HEADER =
+  "public, max-age=3600, s-maxage=86400, stale-while-revalidate=3600";
 export const FEED_BOOTSTRAP_CACHE_HEADER =
   "public, s-maxage=120, stale-while-revalidate=300";
 

--- a/lib/unfurl.test.ts
+++ b/lib/unfurl.test.ts
@@ -1,6 +1,6 @@
 import { lookup } from "node:dns/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { isSafeUrl, unfurlUrl } from "./unfurl";
+import { isSafeUrl, resetUnfurlCachesForTests, unfurlUrl } from "./unfurl";
 
 vi.mock("node:dns/promises", () => ({
   lookup: vi.fn(),
@@ -23,6 +23,7 @@ describe("isSafeUrl", () => {
 
 describe("unfurlUrl", () => {
   beforeEach(() => {
+    resetUnfurlCachesForTests();
     mockedLookup.mockReset();
     mockedLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
     vi.stubGlobal("fetch", vi.fn());
@@ -62,6 +63,61 @@ describe("unfurlUrl", () => {
       domain: "example.com",
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops reading HTML after the head closes", async () => {
+    const fetchMock = vi.mocked(fetch);
+    const body = [
+      "<html><head>",
+      '<meta property="og:title" content="Head title">',
+      "</head>",
+      "<body>",
+      "x".repeat(100_000),
+    ].join("");
+    const encoder = new TextEncoder();
+    const encoded = encoder.encode(body);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoded);
+        controller.close();
+      },
+    });
+
+    fetchMock.mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+
+    await expect(unfurlUrl("https://example.com/post")).resolves.toMatchObject({
+      title: "Head title",
+      domain: "example.com",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses cached DNS lookups across redirect hops", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "/next" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response("<html><head><title>Cached DNS</title></head></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+      );
+
+    await expect(unfurlUrl("https://example.com/post")).resolves.toMatchObject({
+      title: "Cached DNS",
+      domain: "example.com",
+    });
+    expect(mockedLookup).toHaveBeenCalledTimes(1);
   });
 
   it("uses the final redirect URL as the metadata base", async () => {

--- a/lib/unfurl.ts
+++ b/lib/unfurl.ts
@@ -6,7 +6,15 @@ export type { LinkMetadata };
 
 const FETCH_TIMEOUT_MS = 5000;
 const MAX_HTML_BYTES = 512_000;
+const MAX_HEAD_BYTES = 65_536;
 const MAX_REDIRECTS = 5;
+const HEAD_END_PATTERN = /<\/head>/i;
+
+const dnsResolutionCache = new Map<string, boolean>();
+
+export function resetUnfurlCachesForTests(): void {
+  dnsResolutionCache.clear();
+}
 const STANDARD_PORTS: Record<string, string> = {
   "http:": "80",
   "https:": "443",
@@ -65,16 +73,28 @@ export function isSafeUrl(url: string): boolean {
 }
 
 async function resolvesToPublicAddress(hostname: string): Promise<boolean> {
-  if (isIP(hostname)) {
-    return !isPrivateAddress(hostname);
+  const normalized = hostname.toLowerCase();
+  const cached = dnsResolutionCache.get(normalized);
+  if (cached !== undefined) {
+    return cached;
   }
 
-  try {
-    const records = await lookup(hostname, { all: true, verbatim: true });
-    return records.length > 0 && records.every((record) => !isPrivateAddress(record.address));
-  } catch {
-    return false;
+  let isPublic = false;
+
+  if (isIP(hostname)) {
+    isPublic = !isPrivateAddress(hostname);
+  } else {
+    try {
+      const records = await lookup(hostname, { all: true, verbatim: true });
+      isPublic =
+        records.length > 0 && records.every((record) => !isPrivateAddress(record.address));
+    } catch {
+      isPublic = false;
+    }
   }
+
+  dnsResolutionCache.set(normalized, isPublic);
+  return isPublic;
 }
 
 async function isSafeFetchUrl(url: string): Promise<boolean> {
@@ -155,10 +175,22 @@ function extractMetadata(html: string, pageUrl: string): LinkMetadata {
   };
 }
 
+function shouldStopReadingHtml(html: string, bytes: number): boolean {
+  if (HEAD_END_PATTERN.test(html)) return true;
+  if (bytes >= MAX_HEAD_BYTES) return true;
+  if (bytes > MAX_HTML_BYTES) return true;
+  return false;
+}
+
 async function readLimitedHtml(response: Response): Promise<string> {
   const reader = response.body?.getReader();
   if (!reader) {
-    return response.text();
+    const html = await response.text();
+    const headMatch = html.match(HEAD_END_PATTERN);
+    if (headMatch?.index !== undefined) {
+      return html.slice(0, headMatch.index + headMatch[0].length);
+    }
+    return html.slice(0, MAX_HEAD_BYTES);
   }
 
   const decoder = new TextDecoder();
@@ -169,12 +201,21 @@ async function readLimitedHtml(response: Response): Promise<string> {
     const { done, value } = await reader.read();
     if (done) break;
     bytes += value.byteLength;
-    if (bytes > MAX_HTML_BYTES) break;
     html += decoder.decode(value, { stream: true });
+    if (shouldStopReadingHtml(html, bytes)) {
+      reader.cancel().catch(() => undefined);
+      break;
+    }
   }
 
   html += decoder.decode();
-  return html;
+
+  const headMatch = html.match(HEAD_END_PATTERN);
+  if (headMatch?.index !== undefined) {
+    return html.slice(0, headMatch.index + headMatch[0].length);
+  }
+
+  return html.slice(0, MAX_HEAD_BYTES);
 }
 
 function isRedirectStatus(status: number): boolean {

--- a/src/features/compose/CustomEmojiPicker.test.tsx
+++ b/src/features/compose/CustomEmojiPicker.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CustomEmojiPicker,
+  emojiFailureKey,
+} from "./CustomEmojiPicker";
+import type { CustomEmoji } from "./customEmojiCatalog";
+
+const TEST_EMOJIS: CustomEmoji[] = [
+  {
+    shortcode: "00",
+    previewUrl: "https://poa.st/emoji/custom/00.png",
+    url: "https://poa.st/emoji/custom/00.png",
+  },
+  {
+    shortcode: "broken",
+    previewUrl: "https://poa.st/emoji/custom/broken.png",
+    url: "https://poa.st/emoji/custom/broken.png",
+  },
+];
+
+vi.mock("./customEmojiCatalog", () => ({
+  EMOJI_GROUPS: [{ label: "0-9", matches: (shortcode: string) => /^[0-9]/.test(shortcode) }],
+  filterCustomEmojis: (emojis: CustomEmoji[]) => emojis,
+  getCustomEmojiCatalogState: () => ({
+    status: "ready" as const,
+    emojis: TEST_EMOJIS,
+  }),
+  loadCustomEmojiCatalog: vi.fn(() => Promise.resolve(TEST_EMOJIS)),
+  subscribeCustomEmojiCatalog: () => () => undefined,
+}));
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("CustomEmojiPicker", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+  });
+
+  it("loads direct poa.st preview urls instead of the duckduckgo proxy", () => {
+    act(() => {
+      root.render(<CustomEmojiPicker onSelect={() => undefined} />);
+    });
+
+    act(() => {
+      container.querySelector("button[aria-label='open custom emoji picker']")?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    const image = container.querySelector("img");
+    expect(image?.getAttribute("src")).toBe("https://poa.st/emoji/custom/00.png");
+    expect(image?.getAttribute("src")).not.toContain("duckduckgo.com");
+  });
+
+  it("hides emojis that fail to render and persists the failure key", () => {
+    act(() => {
+      root.render(<CustomEmojiPicker onSelect={() => undefined} />);
+    });
+
+    act(() => {
+      container.querySelector("button[aria-label='open custom emoji picker']")?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    const images = [...container.querySelectorAll("img")];
+    expect(images).toHaveLength(2);
+
+    act(() => {
+      images
+        .find((image) => image.getAttribute("src")?.includes("broken.png"))
+        ?.dispatchEvent(new Event("error", { bubbles: true }));
+    });
+
+    expect(container.querySelectorAll("img")).toHaveLength(1);
+    expect(
+      window.localStorage.getItem("wired.failedCustomEmojis"),
+    ).toContain(emojiFailureKey(TEST_EMOJIS[1]));
+  });
+});

--- a/src/features/compose/CustomEmojiPicker.tsx
+++ b/src/features/compose/CustomEmojiPicker.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SmilePlus } from "lucide-react";
-import { getEmojiDisplayUrls } from "@lib/customEmoji";
+import { getEmojiPickerDisplayUrls } from "@lib/customEmoji";
 import { Button } from "../../shared/ui/Button";
 import { Input } from "../../shared/ui/Input";
 import {
@@ -13,8 +13,9 @@ import {
 } from "./customEmojiCatalog";
 
 const MAX_VISIBLE_EMOJIS = 120;
-const FAILED_EMOJI_STORAGE_KEY = "wired.failedCustomEmojiPreviewUrls";
-const MAX_STORED_FAILED_EMOJIS = 500;
+const FAILED_EMOJI_STORAGE_KEY = "wired.failedCustomEmojis";
+const LEGACY_FAILED_EMOJI_STORAGE_KEY = "wired.failedCustomEmojiPreviewUrls";
+const MAX_STORED_FAILED_EMOJIS = 2000;
 
 type CustomEmojiPickerProps = {
   onSelect: (emoji: CustomEmoji) => void;
@@ -23,38 +24,60 @@ type CustomEmojiPickerProps = {
 type EmojiButtonProps = {
   emoji: CustomEmoji;
   onSelect: () => void;
-  onPreviewFailure: (urls: string[]) => void;
+  onPreviewFailure: (emoji: CustomEmoji) => void;
 };
 
-function loadFailedPreviewUrls() {
+export function emojiFailureKey(emoji: CustomEmoji): string {
+  return `${emoji.shortcode}:${emoji.url}`;
+}
+
+function loadFailedEmojiKeys() {
   if (typeof window === "undefined") return new Set<string>();
 
   try {
-    const storedUrls = JSON.parse(window.localStorage.getItem(FAILED_EMOJI_STORAGE_KEY) ?? "[]") as unknown;
+    const storedKeys = JSON.parse(
+      window.localStorage.getItem(FAILED_EMOJI_STORAGE_KEY) ?? "[]",
+    ) as unknown;
 
-    if (!Array.isArray(storedUrls)) {
+    if (!Array.isArray(storedKeys)) {
       return new Set<string>();
     }
 
-    return new Set(storedUrls.filter((url): url is string => typeof url === "string"));
+    return new Set(storedKeys.filter((key): key is string => typeof key === "string"));
   } catch {
     return new Set<string>();
   }
 }
 
-function storeFailedPreviewUrls(urls: Set<string>) {
+function storeFailedEmojiKeys(keys: Set<string>) {
   if (typeof window === "undefined") return;
 
-  const compactUrls = Array.from(urls).slice(-MAX_STORED_FAILED_EMOJIS);
-  window.localStorage.setItem(FAILED_EMOJI_STORAGE_KEY, JSON.stringify(compactUrls));
+  const compactKeys = Array.from(keys).slice(-MAX_STORED_FAILED_EMOJIS);
+  window.localStorage.setItem(FAILED_EMOJI_STORAGE_KEY, JSON.stringify(compactKeys));
+  window.localStorage.removeItem(LEGACY_FAILED_EMOJI_STORAGE_KEY);
 }
 
 function EmojiButton({ emoji, onSelect, onPreviewFailure }: EmojiButtonProps) {
-  const displayUrls = getEmojiDisplayUrls(emoji.previewUrl);
+  const displayUrls = getEmojiPickerDisplayUrls(emoji.previewUrl, emoji.url);
   const [displayUrlIndex, setDisplayUrlIndex] = useState(0);
+  const [isHidden, setIsHidden] = useState(false);
   const displayUrl = displayUrls[displayUrlIndex];
 
-  if (!displayUrl) {
+  const failPreview = useCallback(() => {
+    setIsHidden(true);
+    onPreviewFailure(emoji);
+  }, [emoji, onPreviewFailure]);
+
+  const tryNextUrl = useCallback(() => {
+    if (displayUrlIndex + 1 < displayUrls.length) {
+      setDisplayUrlIndex((current) => current + 1);
+      return;
+    }
+
+    failPreview();
+  }, [displayUrlIndex, displayUrls.length, failPreview]);
+
+  if (isHidden || !displayUrl) {
     return null;
   }
 
@@ -70,14 +93,14 @@ function EmojiButton({ emoji, onSelect, onPreviewFailure }: EmojiButtonProps) {
         src={displayUrl}
         alt=""
         className="max-h-full max-w-full object-contain"
-        onError={() => {
-          if (displayUrlIndex + 1 < displayUrls.length) {
-            setDisplayUrlIndex((current) => current + 1);
-            return;
-          }
+        onLoad={(event) => {
+          const image = event.currentTarget;
 
-          onPreviewFailure(displayUrls);
+          if (image.naturalWidth === 0 || image.naturalHeight === 0) {
+            tryNextUrl();
+          }
         }}
+        onError={tryNextUrl}
       />
     </button>
   );
@@ -88,7 +111,7 @@ export function CustomEmojiPicker({ onSelect }: CustomEmojiPickerProps) {
   const [search, setSearch] = useState("");
   const [activeGroup, setActiveGroup] = useState(0);
   const [catalogState, setCatalogState] = useState(getCustomEmojiCatalogState);
-  const [failedPreviewUrls, setFailedPreviewUrls] = useState(loadFailedPreviewUrls);
+  const [failedEmojiKeys, setFailedEmojiKeys] = useState(loadFailedEmojiKeys);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -131,22 +154,22 @@ export function CustomEmojiPicker({ onSelect }: CustomEmojiPickerProps) {
   const filteredEmojis = useMemo(() => {
     const query = search.trim().toLowerCase();
 
-    return filterCustomEmojis(catalogState.emojis, query, activeGroup).filter((emoji) => {
-      const displayUrls = getEmojiDisplayUrls(emoji.previewUrl);
+    return filterCustomEmojis(catalogState.emojis, query, activeGroup).filter(
+      (emoji) => !failedEmojiKeys.has(emojiFailureKey(emoji)),
+    );
+  }, [activeGroup, catalogState.emojis, failedEmojiKeys, search]);
 
-      return !displayUrls.some((url) => failedPreviewUrls.has(url));
-    });
-  }, [activeGroup, catalogState.emojis, failedPreviewUrls, search]);
+  function handlePreviewFailure(emoji: CustomEmoji) {
+    const key = emojiFailureKey(emoji);
 
-  function handlePreviewFailure(urls: string[]) {
-    setFailedPreviewUrls((current) => {
-      if (urls.every((url) => current.has(url))) {
+    setFailedEmojiKeys((current) => {
+      if (current.has(key)) {
         return current;
       }
 
       const next = new Set(current);
-      urls.forEach((url) => next.add(url));
-      storeFailedPreviewUrls(next);
+      next.add(key);
+      storeFailedEmojiKeys(next);
       return next;
     });
   }

--- a/src/features/compose/CustomEmojiPicker.tsx
+++ b/src/features/compose/CustomEmojiPicker.tsx
@@ -169,7 +169,13 @@ export function CustomEmojiPicker({ onSelect }: CustomEmojiPickerProps) {
       </Button>
 
       {isOpen && (
-        <div className="fixed inset-x-3 bottom-20 z-50 max-h-[calc(100dvh-7rem)] rounded-sm border border-ghost bg-surface-raised shadow-2xl sm:absolute sm:inset-x-auto sm:bottom-full sm:right-0 sm:mb-2 sm:max-h-none sm:w-[min(22rem,calc(100vw-2rem))]">
+        <div
+          className={[
+            "z-50 flex max-h-[min(24rem,calc(100dvh-8rem))] w-[min(24rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-sm border border-ghost bg-surface-raised shadow-2xl",
+            "fixed bottom-20 left-1/2 -translate-x-1/2",
+            "sm:absolute sm:bottom-auto sm:left-auto sm:right-0 sm:top-full sm:mt-2 sm:max-h-[min(24rem,calc(100dvh-6rem))] sm:translate-x-0",
+          ].join(" ")}
+        >
           <div className="border-b border-ghost p-2">
             <Input
               type="search"
@@ -197,7 +203,7 @@ export function CustomEmojiPicker({ onSelect }: CustomEmojiPickerProps) {
             </div>
           )}
 
-          <div className="h-[min(16rem,calc(100dvh-16rem))] min-h-40 overflow-y-auto p-2 sm:h-64">
+          <div className="min-h-40 flex-1 overflow-y-auto p-2 sm:h-64 sm:flex-none">
             {visibleEmojis.length === 0 && (
               <p className="px-2 py-8 text-center text-meta text-secondary">
                 {catalogState.status === "error"

--- a/src/shared/hooks/useLinkMetadata.ts
+++ b/src/shared/hooks/useLinkMetadata.ts
@@ -73,6 +73,7 @@ export function useLinkMetadata(url: string, enabled = true): LinkMetadataState 
     }
 
     let cancelled = false;
+    setState({ status: "loading" });
 
     void loadMetadata(url).then((result) => {
       if (!cancelled) {

--- a/src/shared/lib/customEmoji.test.ts
+++ b/src/shared/lib/customEmoji.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getEmojiDisplayUrls, getEmojiPickerDisplayUrls } from "./customEmoji";
+
+describe("customEmoji display urls", () => {
+  it("prefers the duckduckgo proxy for inline post rendering", () => {
+    const url = "https://poa.st/emoji/custom/00.png";
+
+    expect(getEmojiDisplayUrls(url)).toEqual([
+      "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fpoa.st%2Femoji%2Fcustom%2F00.png",
+      url,
+    ]);
+  });
+
+  it("uses direct catalog urls in the picker", () => {
+    const previewUrl = "https://poa.st/emoji/custom/00.png";
+    const url = "https://poa.st/emoji/custom/00.png";
+
+    expect(getEmojiPickerDisplayUrls(previewUrl, url)).toEqual([previewUrl]);
+  });
+
+  it("dedupes distinct preview and canonical urls in the picker", () => {
+    expect(
+      getEmojiPickerDisplayUrls(
+        "https://example.com/preview.png",
+        "https://example.com/full.png",
+      ),
+    ).toEqual(["https://example.com/preview.png", "https://example.com/full.png"]);
+  });
+});

--- a/src/shared/lib/customEmoji.ts
+++ b/src/shared/lib/customEmoji.ts
@@ -35,3 +35,7 @@ export function getEmojiDisplayUrls(url: string) {
 
   return proxiedUrl ? [proxiedUrl, url] : [url];
 }
+
+export function getEmojiPickerDisplayUrls(previewUrl: string, url: string) {
+  return [...new Set([previewUrl, url].filter(Boolean))];
+}

--- a/src/shared/ui/LinkPreview.test.tsx
+++ b/src/shared/ui/LinkPreview.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LinkPreview } from "./LinkPreview";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("LinkPreview layout", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let intersectionCallback: IntersectionObserverCallback = () => undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.stubGlobal("fetch", vi.fn());
+
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback;
+        }
+
+        observe = vi.fn();
+        disconnect = vi.fn();
+        unobserve = vi.fn();
+        takeRecords = vi.fn(() => []);
+      },
+    );
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses a stable shell with an image slot before metadata resolves", () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => undefined));
+
+    act(() => {
+      root.render(<LinkPreview url="https://example.com/article-pending" />);
+    });
+
+    const idleShell = container.querySelector("a");
+    expect(idleShell?.className).toContain("overflow-hidden");
+    expect(container.querySelector('[aria-hidden="true"]')).not.toBeNull();
+
+    act(() => {
+      intersectionCallback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    const loadingShell = container.querySelector("a");
+    expect(loadingShell).not.toBeNull();
+    expect(container.querySelector('[role="status"]')?.textContent).toContain("resolving link");
+    expect(container.querySelector('[aria-hidden="true"]')).not.toBeNull();
+    expect(loadingShell?.querySelector(".min-h-\\[4\\.5rem\\]")).not.toBeNull();
+  });
+
+  it("fills the reserved shell when metadata arrives", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          title: "Example headline",
+          description: "Short summary",
+          domain: "example.com",
+          image: "https://example.com/og.png",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    act(() => {
+      root.render(<LinkPreview url="https://example.com/article-ready" />);
+    });
+
+    await act(async () => {
+      intersectionCallback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Example headline");
+    expect(container.textContent).toContain("Short summary");
+    expect(container.querySelector('img[src="https://example.com/og.png"]')).not.toBeNull();
+    expect(container.querySelector("a")?.className).toContain("overflow-hidden");
+  });
+});

--- a/src/shared/ui/LinkPreview.tsx
+++ b/src/shared/ui/LinkPreview.tsx
@@ -1,42 +1,177 @@
 import { useState } from "react";
+import type { LinkMetadata } from "@link/link";
 import { domainFromUrl } from "@lib/url";
 import { useInView } from "../hooks/useInView";
 import { useLinkMetadata } from "../hooks/useLinkMetadata";
 
-function DomainStub({ url, domain }: { url: string; domain: string }) {
+const SHELL_CLASS =
+  "block overflow-hidden rounded border border-[var(--border-ghost)] transition-colors duration-hover hover:border-signal/30 focus-visible:outline-none";
+
+function LinkPreviewImageSlot({
+  imageUrl,
+  onImageError,
+}: {
+  imageUrl?: string;
+  onImageError: () => void;
+}) {
+  if (imageUrl) {
+    return (
+      <img
+        src={imageUrl}
+        alt=""
+        loading="lazy"
+        decoding="async"
+        onError={onImageError}
+        className="aspect-[1.91/1] max-h-48 w-full object-cover"
+      />
+    );
+  }
+
+  return (
+    <div
+      aria-hidden="true"
+      className="aspect-[1.91/1] max-h-48 w-full bg-[var(--surface-raised)]"
+    />
+  );
+}
+
+function LinkPreviewSkeleton() {
+  return (
+    <div aria-hidden="true" className="space-y-2">
+      <div className="h-4 w-3/4 rounded bg-[var(--surface-raised)]" />
+      <div className="h-3 w-full rounded bg-[var(--surface-raised)]" />
+      <div className="h-3 w-1/2 rounded bg-[var(--surface-raised)]" />
+    </div>
+  );
+}
+
+function LinkPreviewText({
+  title,
+  description,
+  domain,
+  failed = false,
+}: {
+  title?: string;
+  description?: string;
+  domain: string;
+  failed?: boolean;
+}) {
+  return (
+    <div className="min-h-[4.5rem] px-3 py-2">
+      {failed ? (
+        <p className="text-meta text-muted" role="status">
+          signal lost
+        </p>
+      ) : (
+        <>
+          {title && <p className="line-clamp-2 text-body text-primary">{title}</p>}
+          {description && (
+            <p className="mt-1 line-clamp-1 text-body text-secondary">{description}</p>
+          )}
+        </>
+      )}
+      <p className="mt-1 text-meta text-muted">{domain}</p>
+    </div>
+  );
+}
+
+function LinkPreviewShell({
+  url,
+  domain,
+  label,
+  showImageSlot,
+  imageUrl,
+  title,
+  description,
+  loading = false,
+  failed = false,
+  onImageError,
+}: {
+  url: string;
+  domain: string;
+  label: string;
+  showImageSlot: boolean;
+  imageUrl?: string;
+  title?: string;
+  description?: string;
+  loading?: boolean;
+  failed?: boolean;
+  onImageError?: () => void;
+}) {
   return (
     <a
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label={`external link: ${domain}`}
-      className="block rounded border border-[var(--border-ghost)] px-3 py-2 transition-colors duration-hover hover:border-signal/30 focus-visible:outline-none"
+      aria-label={label}
+      className={SHELL_CLASS}
     >
-      <p className="text-meta text-muted">{domain}</p>
+      {showImageSlot && (
+        <LinkPreviewImageSlot imageUrl={imageUrl} onImageError={onImageError ?? (() => undefined)} />
+      )}
+      <div className="min-h-[4.5rem] px-3 py-2">
+        {loading ? (
+          <>
+            <p className="sr-only" role="status">
+              resolving link…
+            </p>
+            <LinkPreviewSkeleton />
+            <p className="mt-2 text-meta text-muted">{domain}</p>
+          </>
+        ) : (
+          <LinkPreviewText
+            title={title}
+            description={description}
+            domain={domain}
+            failed={failed}
+          />
+        )}
+      </div>
     </a>
   );
 }
 
+function idleLabel(domain: string): string {
+  return `external link: ${domain}`;
+}
+
+function readyLabel(metadata: LinkMetadata): string {
+  return metadata.title
+    ? `${metadata.title} — ${metadata.domain}`
+    : `external link: ${metadata.domain}`;
+}
+
 export function LinkPreview({ url }: { url: string }) {
-  const { ref, inView } = useInView();
+  const { ref, inView } = useInView({ rootMargin: "600px" });
   const state = useLinkMetadata(url, inView);
   const domain = domainFromUrl(url);
   const [imageFailed, setImageFailed] = useState(false);
 
-  if (!inView || state.status === "idle") {
+  if (!inView) {
     return (
       <div ref={ref}>
-        <DomainStub url={url} domain={domain} />
+        <LinkPreviewShell
+          url={url}
+          domain={domain}
+          label={idleLabel(domain)}
+          showImageSlot
+          title={undefined}
+          description={undefined}
+        />
       </div>
     );
   }
 
-  if (state.status === "loading") {
+  if (state.status === "loading" || state.status === "idle") {
     return (
       <div ref={ref}>
-        <p className="text-meta text-muted" role="status">
-          resolving link…
-        </p>
+        <LinkPreviewShell
+          url={url}
+          domain={domain}
+          label={idleLabel(domain)}
+          showImageSlot
+          loading
+        />
       </div>
     );
   }
@@ -44,58 +179,32 @@ export function LinkPreview({ url }: { url: string }) {
   if (state.status === "failed") {
     return (
       <div ref={ref}>
-        <a
-          href={url}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label={`external link: ${domain}`}
-          className="block rounded border border-[var(--border-ghost)] px-3 py-2 transition-colors duration-hover hover:border-signal/30 focus-visible:outline-none"
-        >
-          <p className="text-meta text-muted" role="status">
-            signal lost
-          </p>
-          <p className="mt-1 text-meta text-muted">{domain}</p>
-        </a>
+        <LinkPreviewShell
+          url={url}
+          domain={domain}
+          label={idleLabel(domain)}
+          showImageSlot={false}
+          failed
+        />
       </div>
     );
   }
 
   const { metadata } = state;
-  const label = metadata.title
-    ? `${metadata.title} — ${metadata.domain}`
-    : `external link: ${metadata.domain}`;
+  const showImage = Boolean(metadata.image && !imageFailed);
 
   return (
     <div ref={ref}>
-      <a
-        href={url}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label={label}
-        className="block overflow-hidden rounded border border-[var(--border-ghost)] transition-colors duration-hover hover:border-signal/30 focus-visible:outline-none"
-      >
-        {metadata.image && !imageFailed && (
-          <img
-            src={metadata.image}
-            alt=""
-            loading="lazy"
-            decoding="async"
-            onError={() => setImageFailed(true)}
-            className="max-h-48 w-full object-cover"
-          />
-        )}
-        <div className="px-3 py-2">
-          {metadata.title && (
-            <p className="line-clamp-2 text-body text-primary">{metadata.title}</p>
-          )}
-          {metadata.description && (
-            <p className="mt-1 line-clamp-1 text-body text-secondary">
-              {metadata.description}
-            </p>
-          )}
-          <p className="mt-1 text-meta text-muted">{metadata.domain}</p>
-        </div>
-      </a>
+      <LinkPreviewShell
+        url={url}
+        domain={metadata.domain}
+        label={readyLabel(metadata)}
+        showImageSlot={showImage}
+        imageUrl={showImage ? metadata.image : undefined}
+        title={metadata.title}
+        description={metadata.description}
+        onImageError={() => setImageFailed(true)}
+      />
     </div>
   );
 }

--- a/src/shared/ui/NoteMedia.test.tsx
+++ b/src/shared/ui/NoteMedia.test.tsx
@@ -151,6 +151,128 @@ describe("NoteMedia video previews", () => {
     expect(video?.currentTime).toBe(0);
   });
 
+  it("uses orientation-aware compact classes for quoted landscape images", () => {
+    act(() => {
+      root.render(
+        <MediaAttachment
+          compact
+          item={{
+            url: "https://example.com/comic.jpg",
+            type: "image",
+            width: 1200,
+            height: 400,
+          }}
+        />,
+      );
+    });
+
+    const image = container.querySelector("img");
+    expect(image?.className).toContain("mx-auto");
+    expect(image?.className).toContain("max-h-[12rem]");
+    expect(image?.className.split(/\s+/)).not.toContain("w-full");
+    expect(image?.className).not.toContain("max-h-[120px]");
+    expect(image?.style.aspectRatio).toBe("1200 / 400");
+  });
+
+  it("uses orientation-aware compact classes for quoted portrait images", () => {
+    act(() => {
+      root.render(
+        <MediaAttachment
+          compact
+          item={{
+            url: "https://example.com/panel.jpg",
+            type: "image",
+            width: 800,
+            height: 1400,
+          }}
+        />,
+      );
+    });
+
+    const image = container.querySelector("img");
+    expect(image?.className).toContain("mx-auto");
+    expect(image?.className).toContain("max-w-[min(100%,12rem)]");
+    expect(image?.className).toContain("max-h-[16rem]");
+    expect(image?.className.split(/\s+/)).not.toContain("w-full");
+    expect(image?.style.aspectRatio).toBe("800 / 1400");
+  });
+
+  it("uses orientation-aware compact classes for quoted landscape video", () => {
+    act(() => {
+      root.render(
+        <MediaAttachment
+          compact
+          item={{
+            url: "https://example.com/quoted.mp4",
+            type: "video",
+            width: 640,
+            height: 360,
+          }}
+        />,
+      );
+    });
+
+    const wrapper = container.querySelector("video")?.parentElement;
+    expect(wrapper?.className).toContain("mx-auto");
+    expect(wrapper?.className).toContain("max-h-[12rem]");
+    expect(wrapper?.className).not.toContain("max-h-[120px]");
+    expect(wrapper?.style.aspectRatio).toBe("640 / 360");
+  });
+
+  it("constrains portrait video width in full posts", () => {
+    act(() => {
+      root.render(
+        <MediaAttachment
+          item={{
+            url: "https://example.com/portrait.mp4",
+            type: "video",
+            width: 720,
+            height: 1280,
+          }}
+        />,
+      );
+    });
+
+    const wrapper = container.querySelector("video")?.parentElement;
+    expect(wrapper?.className).toContain("mx-auto");
+    expect(wrapper?.className).toContain("max-w-[min(100%,18rem)]");
+    expect(wrapper?.className).toContain("max-h-[min(60vh,32rem)]");
+    expect(wrapper?.style.aspectRatio).toBe("720 / 1280");
+  });
+
+  it("learns aspect ratio from loaded metadata when imeta dimensions are missing", () => {
+    act(() => {
+      root.render(
+        <MediaAttachment
+          item={{
+            url: "https://example.com/bare-portrait.mp4",
+            type: "video",
+          }}
+        />,
+      );
+    });
+
+    const video = container.querySelector("video");
+    const wrapper = video?.parentElement;
+    expect(wrapper?.style.aspectRatio).toBe("16 / 9");
+
+    Object.defineProperty(video, "videoWidth", {
+      configurable: true,
+      value: 720,
+    });
+    Object.defineProperty(video, "videoHeight", {
+      configurable: true,
+      value: 1280,
+    });
+
+    act(() => {
+      video?.dispatchEvent(new Event("loadedmetadata", { bubbles: true }));
+    });
+
+    expect(wrapper?.style.aspectRatio).toBe("720 / 1280");
+    expect(wrapper?.className).toContain("max-w-[min(100%,18rem)]");
+  });
+
   it("keeps the media fallback on video errors", () => {
     act(() => {
       root.render(

--- a/src/shared/ui/NoteMedia.tsx
+++ b/src/shared/ui/NoteMedia.tsx
@@ -15,6 +15,62 @@ function MediaFallback() {
   );
 }
 
+type MediaOrientation = "landscape" | "portrait" | "square";
+
+function getOrientation(width?: number, height?: number): MediaOrientation {
+  if (!width || !height) return "landscape";
+  const ratio = width / height;
+  if (ratio > 1.1) return "landscape";
+  if (ratio < 0.9) return "portrait";
+  return "square";
+}
+
+function aspectRatioFromDimensions(width?: number, height?: number): string {
+  if (width && height) return `${width} / ${height}`;
+  return "16 / 9";
+}
+
+function imageClasses(orientation: MediaOrientation, compact?: boolean): string {
+  const base = "rounded border border-ghost object-contain";
+
+  if (compact) {
+    switch (orientation) {
+      case "portrait":
+        return [base, "mx-auto block max-w-[min(100%,12rem)] max-h-[16rem]"].join(" ");
+      case "square":
+        return [base, "mx-auto block max-w-[14rem] max-h-[14rem]"].join(" ");
+      default:
+        return [base, "mx-auto block max-w-full max-h-[12rem]"].join(" ");
+    }
+  }
+
+  return [base, "w-full max-h-[32rem]"].join(" ");
+}
+
+function videoWrapperClasses(orientation: MediaOrientation, compact?: boolean): string {
+  const base = "relative overflow-hidden rounded border border-ghost bg-surface";
+
+  if (compact) {
+    switch (orientation) {
+      case "portrait":
+        return [base, "mx-auto max-w-[min(100%,10rem)] max-h-[14rem]"].join(" ");
+      case "square":
+        return [base, "mx-auto max-w-[12rem] max-h-[12rem]"].join(" ");
+      default:
+        return [base, "mx-auto max-w-full max-h-[12rem]"].join(" ");
+    }
+  }
+
+  switch (orientation) {
+    case "portrait":
+      return [base, "mx-auto w-full max-w-[min(100%,18rem)] max-h-[min(60vh,32rem)]"].join(" ");
+    case "square":
+      return [base, "mx-auto w-full max-w-[24rem] max-h-[32rem]"].join(" ");
+    default:
+      return [base, "w-full max-h-[min(60vh,32rem)]"].join(" ");
+  }
+}
+
 function useOptimizedImage(
   url: string,
   width: number,
@@ -51,6 +107,7 @@ function MediaImage({
   if (failed) return <MediaFallback />;
 
   const hasDimensions = Boolean(item.width && item.height);
+  const orientation = getOrientation(item.width, item.height);
 
   return (
     <img
@@ -65,14 +122,11 @@ function MediaImage({
         onError();
         if (src === item.url) setFailed(true);
       }}
-      className={[
-        "w-full rounded border border-ghost object-contain",
-        compact ? "max-h-[120px]" : "max-h-[32rem]",
-      ].join(" ")}
+      className={imageClasses(orientation, compact)}
       style={
         hasDimensions
           ? { aspectRatio: `${item.width} / ${item.height}` }
-          : { aspectRatio: "4 / 3", minHeight: compact ? "5rem" : "12rem" }
+          : { aspectRatio: "4 / 3", minHeight: compact ? "6rem" : "12rem" }
       }
     />
   );
@@ -151,9 +205,16 @@ function MediaVideo({
   const [failed, setFailed] = useState(false);
   const [started, setStarted] = useState(false);
   const [previewReady, setPreviewReady] = useState(false);
+  const [resolvedDimensions, setResolvedDimensions] = useState({
+    width: item.width,
+    height: item.height,
+  });
 
-  const hasDimensions = Boolean(item.width && item.height);
-  const aspectRatio = hasDimensions ? `${item.width} / ${item.height}` : "16 / 9";
+  const orientation = getOrientation(resolvedDimensions.width, resolvedDimensions.height);
+  const aspectRatio = aspectRatioFromDimensions(
+    resolvedDimensions.width,
+    resolvedDimensions.height,
+  );
   const hasPoster = Boolean(item.posterUrl);
   const shouldPrimePreview = priority || inView;
   const requestFirstFrame = useCallback(() => {
@@ -175,6 +236,24 @@ function MediaVideo({
       // Cross-origin or streaming media may reject seeking; native controls remain usable.
     }
   }, [hasPoster]);
+  const handleLoadedMetadata = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    if (
+      !item.width &&
+      !item.height &&
+      video.videoWidth > 0 &&
+      video.videoHeight > 0
+    ) {
+      setResolvedDimensions({
+        width: video.videoWidth,
+        height: video.videoHeight,
+      });
+    }
+
+    if (shouldPrimePreview) requestFirstFrame();
+  }, [item.width, item.height, requestFirstFrame, shouldPrimePreview]);
 
   useEffect(() => {
     if (hasPoster || !shouldPrimePreview || primedRef.current) return;
@@ -192,10 +271,7 @@ function MediaVideo({
   return (
     <div
       ref={inViewRef}
-      className={[
-        "relative overflow-hidden rounded border border-ghost bg-surface",
-        compact ? "max-h-[120px]" : "max-h-[min(60vh,24rem)]",
-      ].join(" ")}
+      className={videoWrapperClasses(orientation, compact)}
       style={{ aspectRatio }}
     >
       <video
@@ -206,9 +282,7 @@ function MediaVideo({
         preload={hasPoster || !shouldPrimePreview ? "metadata" : "auto"}
         playsInline
         onPlay={() => setStarted(true)}
-        onLoadedMetadata={() => {
-          if (shouldPrimePreview) requestFirstFrame();
-        }}
+        onLoadedMetadata={handleLoadedMetadata}
         onLoadedData={() => setPreviewReady(true)}
         onCanPlay={() => setPreviewReady(true)}
         onSeeked={() => setPreviewReady(true)}


### PR DESCRIPTION
## Summary

- Fixes awkward sizing for quoted post media (images and videos) using orientation-aware compact layout instead of full-width + 120px caps that caused heavy letterboxing
- Adds stable link preview card shells with reserved image/text slots to prevent layout shift while unfurls load
- Speeds up link unfurling via early `</head>` cutoff, DNS caching across redirects, earlier viewport prefetch, and stronger CDN cache headers

## Changes

**UI**
- `NoteMedia.tsx`: orientation-aware compact classes for images and videos; runtime video dimension correction from metadata
- `LinkPreview.tsx`: stable shell + skeleton states; 600px prefetch margin
- `useLinkMetadata.ts`: set `loading` when fetch starts

**API**
- `unfurl.ts`: stop reading HTML after `</head>` / 64KB; DNS resolution cache
- `handlers.ts`: `s-maxage=86400, stale-while-revalidate=3600` on unfurl responses

## Test plan

- [x] `npm test` — LinkPreview, NoteMedia, unfurl tests pass
- [ ] Quoted landscape video (bounty/Flock post) renders centered without side gutters
- [ ] Quoted portrait/wide comic image renders proportionally in quote card
- [ ] Link preview cards do not jump height when metadata resolves