### PR TITLE
Fix feed/thread signal score mismatch

### DIFF
--- a/src/features/thread/ThreadPage.tsx
+++ b/src/features/thread/ThreadPage.tsx
@@ -9,7 +9,6 @@ import { ContentColumn, PageShell } from "../../shared/ui/PageShell";
 import { ThreadComposer } from "../compose/ThreadComposer";
 import { useInfiniteScroll } from "../../shared/hooks/useInfiniteScroll";
 import { useThreadViewModel } from "../../hooks/useThreadViewModel";
-import { eventWork } from "../../nostr/processing/pow-score";
 import {
   readThreadSeedEvents,
   useSnapshotThreadSeedEvents,
@@ -29,6 +28,7 @@ function ThreadView({ hexID, relayHints }: { hexID: string; relayHints: string[]
   const openThread = useThreadNavigation();
   const {
     opEvent,
+    opScore,
     earlierEvents,
     replyEvents,
     eventsById,
@@ -36,13 +36,6 @@ function ThreadView({ hexID, relayHints }: { hexID: string; relayHints: string[]
     setShowAllReplies,
     uniqMentions,
   } = useThreadViewModel(hexID, seedEvents, relayHints);
-  const directReplyEvents = replyEvents.filter((event) =>
-    event.postEvent.tags.some((tag) => tag[0] === "e" && tag[1] === hexID),
-  );
-  const opTotalWork = opEvent
-    ? eventWork(opEvent) +
-      directReplyEvents.reduce((total, event) => total + event.totalWork, 0)
-    : undefined;
 
   if (opEvent) {
     return (
@@ -61,10 +54,10 @@ function ThreadView({ hexID, relayHints }: { hexID: string; relayHints: string[]
           ))}
           <PostCard
             event={opEvent}
-            replies={replyEvents.flatMap((event) => event.replies)}
+            replies={opScore?.replies ?? []}
             role="threadOp"
-            totalWork={opTotalWork || undefined}
-            replyCount={directReplyEvents.length}
+            totalWork={opScore?.totalWork}
+            replyCount={opScore?.threadReplyCount}
           />
         </ContentColumn>
         <ThreadComposer OPEvent={opEvent} />

--- a/src/hooks/useFeed.test.ts
+++ b/src/hooks/useFeed.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Event } from "nostr-tools";
 import type { ProcessedEvent } from "../nostr/types";
 import { mergeProcessedFeedEvents } from "./useFeed";
+
+vi.mock("../shared/pow/core", () => ({
+  verifyPow: (event: Event) =>
+    Number(event.tags.find((tag) => tag[0] === "nonce")?.[2] ?? 0),
+}));
 
 const event = (overrides: Partial<Event> = {}): Event => ({
   id: "f".repeat(64),
@@ -58,72 +63,98 @@ describe("mergeProcessedFeedEvents", () => {
     ]);
   });
 
-  it("does not let an incomplete live row downgrade a bootstrap row", () => {
-    const root = event({ id: "1".repeat(64) });
+  it("recomputes merged scores from the union of bootstrap and live replies", () => {
+    const root = event({
+      id: "1".repeat(64),
+      tags: [["nonce", "root", "18"]],
+    });
+    const bootstrapReply = event({
+      id: "2".repeat(64),
+      tags: [["e", root.id], ["nonce", "bootstrap", "24"]],
+    });
+    const liveReplyA = event({
+      id: "3".repeat(64),
+      tags: [["e", root.id], ["nonce", "live-a", "16"]],
+    });
+    const liveReplyB = event({
+      id: "4".repeat(64),
+      tags: [["e", root.id], ["nonce", "live-b", "16"]],
+    });
     const bootstrapRow = processed(root, {
-      replies: [event({ id: "2".repeat(64), tags: [["e", root.id]] })],
-      totalWork: Math.pow(2, 20),
+      replies: [bootstrapReply],
+      totalWork: Math.pow(2, 24) + Math.pow(2, 18),
+      threadReplyCount: 1,
+    });
+    const liveRow = processed(root, {
+      replies: [liveReplyA, liveReplyB],
+      totalWork: Math.pow(2, 18) + Math.pow(2, 17),
+      threadReplyCount: 2,
+    });
+
+    const [merged] = mergeProcessedFeedEvents([bootstrapRow], [liveRow], 21);
+
+    expect(merged.replies.map((reply) => reply.id)).toEqual([
+      bootstrapReply.id,
+      liveReplyA.id,
+      liveReplyB.id,
+    ]);
+    expect(merged).toMatchObject({
+      threadReplyCount: 3,
+      replyWork: Math.pow(2, 24),
+      totalWork: Math.pow(2, 24) + Math.pow(2, 18),
+    });
+  });
+
+  it("keeps bootstrap reply work when live data is incomplete", () => {
+    const root = event({
+      id: "1".repeat(64),
+      tags: [["nonce", "root", "20"]],
+    });
+    const bootstrapReply = event({
+      id: "2".repeat(64),
+      tags: [["e", root.id], ["nonce", "bootstrap", "20"]],
+    });
+    const bootstrapRow = processed(root, {
+      replies: [bootstrapReply],
+      totalWork: Math.pow(2, 21),
+      threadReplyCount: 1,
     });
     const incompleteLiveRow = processed(root, {
       replies: [],
-      totalWork: Math.pow(2, 16),
-    });
-
-    expect(mergeProcessedFeedEvents([bootstrapRow], [incompleteLiveRow])).toEqual([
-      bootstrapRow,
-    ]);
-  });
-
-  it("does not treat more low-work live replies as a feed-score upgrade", () => {
-    const root = event({ id: "1".repeat(64) });
-    const bootstrapRow = processed(root, {
-      replies: [event({ id: "2".repeat(64), tags: [["e", root.id]] })],
-      totalWork: Math.pow(2, 24),
-      threadReplyCount: 1,
-    });
-    const lowerWorkLiveRow = processed(root, {
-      replies: [
-        event({ id: "3".repeat(64), tags: [["e", root.id]] }),
-        event({ id: "4".repeat(64), tags: [["e", root.id]] }),
-      ],
-      totalWork: Math.pow(2, 16),
-      threadReplyCount: 2,
-    });
-
-    expect(mergeProcessedFeedEvents([bootstrapRow], [lowerWorkLiveRow])).toEqual([
-      bootstrapRow,
-    ]);
-  });
-
-  it("uses reply count as a tie-breaker when live work matches the snapshot", () => {
-    const root = event({ id: "1".repeat(64) });
-    const bootstrapRow = processed(root, {
-      replies: [event({ id: "2".repeat(64), tags: [["e", root.id]] })],
       totalWork: Math.pow(2, 20),
-      threadReplyCount: 1,
-    });
-    const fullerLiveRow = processed(root, {
-      replies: [
-        event({ id: "3".repeat(64), tags: [["e", root.id]] }),
-        event({ id: "4".repeat(64), tags: [["e", root.id]] }),
-      ],
-      totalWork: Math.pow(2, 20),
-      threadReplyCount: 2,
+      threadReplyCount: 0,
     });
 
-    expect(mergeProcessedFeedEvents([bootstrapRow], [fullerLiveRow])).toEqual([
-      fullerLiveRow,
-    ]);
+    const [merged] = mergeProcessedFeedEvents(
+      [bootstrapRow],
+      [incompleteLiveRow],
+      16,
+    );
+
+    expect(merged).toMatchObject({
+      replies: [bootstrapReply],
+      threadReplyCount: 1,
+      replyWork: Math.pow(2, 20),
+      totalWork: Math.pow(2, 21),
+    });
   });
 
-  it("lets live rows upgrade or add feed items", () => {
+  it("lets live rows add feed items that are missing from bootstrap", () => {
     const existingRoot = event({ id: "1".repeat(64), created_at: 1 });
-    const newRoot = event({ id: "2".repeat(64), created_at: 2 });
+    const newRoot = event({
+      id: "2".repeat(64),
+      created_at: 2,
+      tags: [["nonce", "root", "18"]],
+    });
     const bootstrapRow = processed(existingRoot, {
       totalWork: Math.pow(2, 16),
     });
+    const upgradedReply = event({
+      id: "3".repeat(64),
+      tags: [["e", existingRoot.id], ["nonce", "reply", "20"]],
+    });
     const upgradedLiveRow = processed(existingRoot, {
-      replies: [event({ id: "3".repeat(64), tags: [["e", existingRoot.id]] })],
+      replies: [upgradedReply],
       totalWork: Math.pow(2, 20),
     });
     const newLiveRow = processed(newRoot, {
@@ -133,8 +164,18 @@ describe("mergeProcessedFeedEvents", () => {
     const result = mergeProcessedFeedEvents(
       [bootstrapRow],
       [newLiveRow, upgradedLiveRow],
+      16,
     );
 
-    expect(result).toEqual([upgradedLiveRow, newLiveRow]);
+    expect(result.map((item) => item.postEvent.id)).toEqual([
+      existingRoot.id,
+      newRoot.id,
+    ]);
+    expect(result[0]).toMatchObject({
+      replies: [upgradedReply],
+      threadReplyCount: 1,
+      totalWork: Math.pow(2, 20) + 1,
+    });
+    expect(result[1]).toEqual(newLiveRow);
   });
 });

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -4,6 +4,7 @@ import { subGlobalFeed, subRepliesForRootIds } from "../nostr/subscriptions";
 import {
   compareProcessedEventsByWork,
   processFeedEvents,
+  scoreThreadPost,
 } from "../nostr/processEvents";
 import type { ProcessedEvent, RelayHintsByEventId } from "../nostr/types";
 import { useSettings } from "../app/settings";
@@ -78,9 +79,38 @@ function isProcessedEventModerated(
   );
 }
 
+function unionEvents(...eventGroups: Event[][]): Event[] {
+  const merged = new Map<string, Event>();
+  eventGroups.forEach((events) => {
+    events.forEach((event) => merged.set(event.id, event));
+  });
+  return [...merged.values()];
+}
+
+function rescoreMergedProcessedEvent(
+  existing: ProcessedEvent,
+  incoming: ProcessedEvent,
+  filterDifficulty: number,
+): ProcessedEvent {
+  const postEvent = existing.postEvent;
+  const mergedEvents = unionEvents(
+    [postEvent],
+    existing.replies,
+    incoming.replies,
+  );
+
+  return {
+    ...scoreThreadPost(postEvent, mergedEvents, {
+      minReplyDifficulty: filterDifficulty,
+    }),
+    relayHints: existing.relayHints ?? incoming.relayHints,
+  };
+}
+
 export function mergeProcessedFeedEvents(
   bootstrapEvents: ProcessedEvent[],
   liveEvents: ProcessedEvent[],
+  filterDifficulty = 0,
 ): ProcessedEvent[] {
   if (liveEvents.length === 0) return bootstrapEvents;
 
@@ -92,14 +122,15 @@ export function mergeProcessedFeedEvents(
 
   liveEvents.forEach((event) => {
     const existing = mergedByRootId.get(event.postEvent.id);
-    if (
-      !existing ||
-      event.totalWork > existing.totalWork ||
-      (event.totalWork === existing.totalWork &&
-        event.replies.length > existing.replies.length)
-    ) {
+    if (!existing) {
       mergedByRootId.set(event.postEvent.id, event);
+      return;
     }
+
+    mergedByRootId.set(
+      event.postEvent.id,
+      rescoreMergedProcessedEvent(existing, event, filterDifficulty),
+    );
   });
 
   return [...mergedByRootId.values()].sort(compareProcessedEventsByWork);
@@ -266,8 +297,14 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
       mergeProcessedFeedEvents(
         bootstrapEligible ? visibleBootstrapProcessedEvents : [],
         liveProcessedEvents,
+        settings.filterDifficulty,
       ),
-    [bootstrapEligible, visibleBootstrapProcessedEvents, liveProcessedEvents],
+    [
+      bootstrapEligible,
+      visibleBootstrapProcessedEvents,
+      liveProcessedEvents,
+      settings.filterDifficulty,
+    ],
   );
 
   return { processedEvents, noteEvents: visibleNoteEvents };

--- a/src/hooks/useThreadViewModel.ts
+++ b/src/hooks/useThreadViewModel.ts
@@ -1,12 +1,13 @@
 import { useMemo, useState } from "react";
 import type { Event } from "nostr-tools";
 import { subNotesOnce } from "../nostr/subscriptions";
-import { toProcessedEvents } from "../nostr/processEvents";
+import { scoreThreadPost } from "../nostr/processEvents";
 import { uniqBy } from "@lib/collections";
 import { useThreadEvents } from "./useThreadEvents";
 import { useNostrSubscription } from "../shared/hooks/useNostrSubscription";
 import { useModerationManifest } from "../shared/hooks/useModerationManifest";
 import { filterModeratedEvents } from "../shared/lib/moderation";
+import { useSettings } from "../app/settings";
 
 export function useThreadViewModel(
   hexID: string,
@@ -14,8 +15,13 @@ export function useThreadViewModel(
   relayHints: readonly string[] = [],
 ) {
   const [showAllReplies, setShowAllReplies] = useState(true);
+  const { settings } = useSettings();
   const moderationManifest = useModerationManifest();
   const { noteEvents } = useThreadEvents(hexID, relayHints);
+  const scoreOptions = useMemo(
+    () => ({ minReplyDifficulty: settings.filterDifficulty }),
+    [settings.filterDifficulty],
+  );
 
   const allEvents = useMemo(() => {
     return filterModeratedEvents([...noteEvents, ...seedEvents], moderationManifest);
@@ -56,11 +62,15 @@ export function useThreadViewModel(
       (event) => !earlierIds.has(event.id) && opEvent.id !== event.id,
     );
 
-    return toProcessedEvents(
-      posts,
-      allEvents,
-    );
-  }, [opEvent, prevMentions, allEvents, moderationManifest]);
+    return posts
+      .map((postEvent) => scoreThreadPost(postEvent, allEvents, scoreOptions))
+      .sort((a, b) => a.postEvent.created_at - b.postEvent.created_at);
+  }, [opEvent, prevMentions, allEvents, moderationManifest, scoreOptions]);
+
+  const opScore = useMemo(() => {
+    if (!opEvent) return undefined;
+    return scoreThreadPost(opEvent, allEvents, scoreOptions);
+  }, [opEvent, allEvents, scoreOptions]);
 
   const earlierEvents = useMemo(() => {
     if (!opEvent) return [];
@@ -78,6 +88,7 @@ export function useThreadViewModel(
 
   return {
     opEvent,
+    opScore,
     earlierEvents,
     replyEvents,
     eventsById,

--- a/src/nostr/processEvents.test.ts
+++ b/src/nostr/processEvents.test.ts
@@ -4,6 +4,7 @@ import {
   collectThreadReplies,
   compareProcessedEventsByWork,
   processFeedEvents,
+  scoreThreadPost,
   toProcessedEvents,
 } from "./processEvents";
 
@@ -371,6 +372,40 @@ describe("processFeedEvents", () => {
     });
 
     expect(processFeedEvents([oldRoot, weakReply], 16)).toEqual([]);
+  });
+});
+
+describe("scoreThreadPost", () => {
+  it("matches processFeedEvents scoring for nested high-PoW replies", () => {
+    const root = event({
+      id: "1".repeat(64),
+      tags: [["nonce", "root", "18"]],
+    });
+    const directReply = event({
+      id: "2".repeat(64),
+      tags: [["e", root.id], ["nonce", "direct", "16"]],
+    });
+    const nestedReply = event({
+      id: "3".repeat(64),
+      tags: [["e", directReply.id], ["nonce", "nested", "16"]],
+    });
+    const highPowReply = event({
+      id: "4".repeat(64),
+      tags: [["e", nestedReply.id], ["nonce", "high", "25"]],
+    });
+    const allEvents = [root, directReply, nestedReply, highPowReply];
+
+    const feedScore = processFeedEvents(allEvents, 16)[0];
+    const threadScore = scoreThreadPost(root, allEvents, {
+      minReplyDifficulty: 16,
+    });
+
+    expect(threadScore).toMatchObject({
+      totalWork: feedScore.totalWork,
+      replyWork: feedScore.replyWork,
+      threadReplyCount: feedScore.threadReplyCount,
+      replies: feedScore.replies,
+    });
   });
 });
 

--- a/src/nostr/processEvents.ts
+++ b/src/nostr/processEvents.ts
@@ -4,7 +4,10 @@ import {
   feedRootRefsFromQualifyingActivity,
   isFeedPostEvent,
 } from "./feed-candidates.js";
-import { workScoreBreakdown } from "./processing/pow-score.js";
+import {
+  workScoreBreakdown,
+  type WorkScoreOptions,
+} from "./processing/pow-score.js";
 import type { ProcessedEvent, RelayHintsByEventId } from "./types.js";
 
 export type { ProcessedEvent } from "./types.js";
@@ -68,6 +71,22 @@ export function collectThreadReplies(
   }
 
   return replies;
+}
+
+export function scoreThreadPost(
+  postEvent: Event,
+  allEvents: Event[],
+  options: WorkScoreOptions = {},
+): ProcessedEvent {
+  const repliesByParent = buildRepliesByParent(allEvents);
+  const replies = collectThreadReplies(postEvent.id, repliesByParent);
+
+  return {
+    postEvent,
+    replies,
+    threadReplyCount: replies.length,
+    ...workScoreBreakdown(postEvent, replies, options),
+  };
 }
 
 export type ProcessFeedEventsOptions = {


### PR DESCRIPTION
## Summary

Fixes a bug where the main feed showed higher PoW/signal scores than the thread view for the same post (e.g. feed **25** vs thread **18**).

**Root cause:** Feed and thread used different `totalWork` calculations:
- Feed used `collectThreadReplies` + `workScoreBreakdown` (full subtree)
- Thread OP used a custom formula that only rolled up one level of children per direct reply, missing deeply nested high-PoW work
- Feed merge could preserve frozen bootstrap `totalWork` even when live data had a different reply tree

## Changes

- Add shared `scoreThreadPost()` helper in `processEvents.ts`
- Thread OP and reply cards now use the same scorer as the feed (with `filterDifficulty`)
- `mergeProcessedFeedEvents` recomputes scores from the union of bootstrap + live reply events
- Regression tests for nested high-PoW parity and updated merge behavior

## Test plan

- [x] `npm test` — all 259 tests pass
- [x] Added `scoreThreadPost` parity test with `processFeedEvents` for `root → A → B → highPoW`
- [x] Updated `mergeProcessedFeedEvents` tests for union-based rescoring