### PR TITLE
Separate signal filter from total work scoring

### DIFF
--- a/lib/feedBootstrap.ts
+++ b/lib/feedBootstrap.ts
@@ -1,7 +1,7 @@
-import { DEFAULT_DIFFICULTY } from "../src/config.js";
+import { DEFAULT_FILTER_DIFFICULTY } from "../src/config.js";
 
 export const BOOTSTRAP_AGE_HOURS = 24;
-export const BOOTSTRAP_FILTER_DIFFICULTY = DEFAULT_DIFFICULTY;
+export const BOOTSTRAP_FILTER_DIFFICULTY = DEFAULT_FILTER_DIFFICULTY;
 export const BOOTSTRAP_CACHE_KEY = "feed:bootstrap:default";
 export const BOOTSTRAP_CACHE_TAG = "feed:bootstrap";
 export const BOOTSTRAP_CACHE_TTL_SECONDS = 300;

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -6,7 +6,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { DEFAULT_DIFFICULTY } from "../config";
+import { DEFAULT_FILTER_DIFFICULTY, DEFAULT_POST_DIFFICULTY } from "../config";
 
 export type Settings = {
   difficulty: number;
@@ -23,8 +23,8 @@ type SettingsContextValue = {
 const SettingsContext = createContext<SettingsContextValue | null>(null);
 
 const loadSettings = (): Settings => ({
-  difficulty: Number(localStorage.getItem("difficulty")) || DEFAULT_DIFFICULTY,
-  filterDifficulty: Number(localStorage.getItem("filterDifficulty")) || DEFAULT_DIFFICULTY,
+  difficulty: Number(localStorage.getItem("difficulty")) || DEFAULT_POST_DIFFICULTY,
+  filterDifficulty: Number(localStorage.getItem("filterDifficulty")) || DEFAULT_FILTER_DIFFICULTY,
   ageHours: Number(localStorage.getItem("age")) || 24,
   sortByPow: localStorage.getItem("sortBy") !== "false",
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,9 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_DIFFICULTY, DEFAULT_RELAYS, configuredRelays } from "./config";
+import {
+  DEFAULT_DIFFICULTY,
+  DEFAULT_FILTER_DIFFICULTY,
+  DEFAULT_POST_DIFFICULTY,
+  DEFAULT_RELAYS,
+  configuredRelays,
+} from "./config";
 
 describe("DEFAULT_DIFFICULTY", () => {
-  it("defaults new posts to signal 21", () => {
-    expect(DEFAULT_DIFFICULTY).toBe(21);
+  it("defaults new posts to signal 20", () => {
+    expect(DEFAULT_POST_DIFFICULTY).toBe(20);
+    expect(DEFAULT_DIFFICULTY).toBe(DEFAULT_POST_DIFFICULTY);
+  });
+
+  it("defaults feed signal filtering to 16", () => {
+    expect(DEFAULT_FILTER_DIFFICULTY).toBe(16);
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,6 @@
-export const DEFAULT_DIFFICULTY = 21;
+export const DEFAULT_POST_DIFFICULTY = 20;
+export const DEFAULT_FILTER_DIFFICULTY = 16;
+export const DEFAULT_DIFFICULTY = DEFAULT_POST_DIFFICULTY;
 
 export const DEFAULT_RELAYS = [
   "wss://relay.wiredsignal.online",

--- a/src/hooks/useFeed.test.ts
+++ b/src/hooks/useFeed.test.ts
@@ -91,7 +91,7 @@ describe("mergeProcessedFeedEvents", () => {
       threadReplyCount: 2,
     });
 
-    const [merged] = mergeProcessedFeedEvents([bootstrapRow], [liveRow], 21);
+    const [merged] = mergeProcessedFeedEvents([bootstrapRow], [liveRow]);
 
     expect(merged.replies.map((reply) => reply.id)).toEqual([
       bootstrapReply.id,
@@ -100,8 +100,8 @@ describe("mergeProcessedFeedEvents", () => {
     ]);
     expect(merged).toMatchObject({
       threadReplyCount: 3,
-      replyWork: Math.pow(2, 24),
-      totalWork: Math.pow(2, 24) + Math.pow(2, 18),
+      replyWork: Math.pow(2, 24) + Math.pow(2, 17),
+      totalWork: Math.pow(2, 24) + Math.pow(2, 18) + Math.pow(2, 17),
     });
   });
 
@@ -125,11 +125,7 @@ describe("mergeProcessedFeedEvents", () => {
       threadReplyCount: 0,
     });
 
-    const [merged] = mergeProcessedFeedEvents(
-      [bootstrapRow],
-      [incompleteLiveRow],
-      16,
-    );
+    const [merged] = mergeProcessedFeedEvents([bootstrapRow], [incompleteLiveRow]);
 
     expect(merged).toMatchObject({
       replies: [bootstrapReply],
@@ -161,11 +157,7 @@ describe("mergeProcessedFeedEvents", () => {
       totalWork: Math.pow(2, 18),
     });
 
-    const result = mergeProcessedFeedEvents(
-      [bootstrapRow],
-      [newLiveRow, upgradedLiveRow],
-      16,
-    );
+    const result = mergeProcessedFeedEvents([bootstrapRow], [newLiveRow, upgradedLiveRow]);
 
     expect(result.map((item) => item.postEvent.id)).toEqual([
       existingRoot.id,

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -90,7 +90,6 @@ function unionEvents(...eventGroups: Event[][]): Event[] {
 function rescoreMergedProcessedEvent(
   existing: ProcessedEvent,
   incoming: ProcessedEvent,
-  filterDifficulty: number,
 ): ProcessedEvent {
   const postEvent = existing.postEvent;
   const mergedEvents = unionEvents(
@@ -100,9 +99,7 @@ function rescoreMergedProcessedEvent(
   );
 
   return {
-    ...scoreThreadPost(postEvent, mergedEvents, {
-      minReplyDifficulty: filterDifficulty,
-    }),
+    ...scoreThreadPost(postEvent, mergedEvents),
     relayHints: existing.relayHints ?? incoming.relayHints,
   };
 }
@@ -110,7 +107,6 @@ function rescoreMergedProcessedEvent(
 export function mergeProcessedFeedEvents(
   bootstrapEvents: ProcessedEvent[],
   liveEvents: ProcessedEvent[],
-  filterDifficulty = 0,
 ): ProcessedEvent[] {
   if (liveEvents.length === 0) return bootstrapEvents;
 
@@ -129,7 +125,7 @@ export function mergeProcessedFeedEvents(
 
     mergedByRootId.set(
       event.postEvent.id,
-      rescoreMergedProcessedEvent(existing, event, filterDifficulty),
+      rescoreMergedProcessedEvent(existing, event),
     );
   });
 
@@ -297,13 +293,11 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
       mergeProcessedFeedEvents(
         bootstrapEligible ? visibleBootstrapProcessedEvents : [],
         liveProcessedEvents,
-        settings.filterDifficulty,
       ),
     [
       bootstrapEligible,
       visibleBootstrapProcessedEvents,
       liveProcessedEvents,
-      settings.filterDifficulty,
     ],
   );
 

--- a/src/hooks/useThreadViewModel.ts
+++ b/src/hooks/useThreadViewModel.ts
@@ -7,7 +7,6 @@ import { useThreadEvents } from "./useThreadEvents";
 import { useNostrSubscription } from "../shared/hooks/useNostrSubscription";
 import { useModerationManifest } from "../shared/hooks/useModerationManifest";
 import { filterModeratedEvents } from "../shared/lib/moderation";
-import { useSettings } from "../app/settings";
 
 export function useThreadViewModel(
   hexID: string,
@@ -15,13 +14,8 @@ export function useThreadViewModel(
   relayHints: readonly string[] = [],
 ) {
   const [showAllReplies, setShowAllReplies] = useState(true);
-  const { settings } = useSettings();
   const moderationManifest = useModerationManifest();
   const { noteEvents } = useThreadEvents(hexID, relayHints);
-  const scoreOptions = useMemo(
-    () => ({ minReplyDifficulty: settings.filterDifficulty }),
-    [settings.filterDifficulty],
-  );
 
   const allEvents = useMemo(() => {
     return filterModeratedEvents([...noteEvents, ...seedEvents], moderationManifest);
@@ -63,14 +57,14 @@ export function useThreadViewModel(
     );
 
     return posts
-      .map((postEvent) => scoreThreadPost(postEvent, allEvents, scoreOptions))
+      .map((postEvent) => scoreThreadPost(postEvent, allEvents))
       .sort((a, b) => a.postEvent.created_at - b.postEvent.created_at);
-  }, [opEvent, prevMentions, allEvents, moderationManifest, scoreOptions]);
+  }, [opEvent, prevMentions, allEvents, moderationManifest]);
 
   const opScore = useMemo(() => {
     if (!opEvent) return undefined;
-    return scoreThreadPost(opEvent, allEvents, scoreOptions);
-  }, [opEvent, allEvents, scoreOptions]);
+    return scoreThreadPost(opEvent, allEvents);
+  }, [opEvent, allEvents]);
 
   const earlierEvents = useMemo(() => {
     if (!opEvent) return [];

--- a/src/nostr/processEvents.test.ts
+++ b/src/nostr/processEvents.test.ts
@@ -225,8 +225,8 @@ describe("processFeedEvents", () => {
     expect(result[0]).toMatchObject({
       postEvent: oldRoot,
       replies: [parentReply, qualifyingNestedReply],
-      replyWork: Math.pow(2, 16),
-      rankingReplyCount: 1,
+      replyWork: 1 + Math.pow(2, 16),
+      rankingReplyCount: 2,
       threadReplyCount: 2,
     });
   });
@@ -251,7 +251,7 @@ describe("processFeedEvents", () => {
     expect(processFeedEvents([repost])).toEqual([]);
   });
 
-  it("uses the active filter difficulty as the minimum reply work difficulty", () => {
+  it("uses the active filter difficulty for eligibility without dropping reply work", () => {
     const lowerWorkRoot = event({
       id: "1".repeat(64),
       pubkey: "1".repeat(64),
@@ -284,8 +284,8 @@ describe("processFeedEvents", () => {
     ]);
     expect(result.find((item) => item.postEvent.id === lowerWorkRoot.id)).toMatchObject({
       replies: lowPowReplies,
-      replyWork: 0,
-      rankingReplyCount: 0,
+      replyWork: 20 * Math.pow(2, 15),
+      rankingReplyCount: 20,
     });
   });
 
@@ -396,9 +396,7 @@ describe("scoreThreadPost", () => {
     const allEvents = [root, directReply, nestedReply, highPowReply];
 
     const feedScore = processFeedEvents(allEvents, 16)[0];
-    const threadScore = scoreThreadPost(root, allEvents, {
-      minReplyDifficulty: 16,
-    });
+    const threadScore = scoreThreadPost(root, allEvents);
 
     expect(threadScore).toMatchObject({
       totalWork: feedScore.totalWork,

--- a/src/nostr/processEvents.ts
+++ b/src/nostr/processEvents.ts
@@ -146,9 +146,7 @@ export const processFeedEvents = (
         replies,
         relayHints: relayHintsForEvent(postEvent.id, relayHintsByEventId),
         threadReplyCount: replies.length,
-        ...workScoreBreakdown(postEvent, replies, {
-          minReplyDifficulty: filterDifficulty,
-        }),
+        ...workScoreBreakdown(postEvent, replies),
       };
     })
     .sort(compareProcessedEventsByWork);

--- a/src/nostr/processing/pow-score.test.ts
+++ b/src/nostr/processing/pow-score.test.ts
@@ -31,28 +31,28 @@ describe("pow-score", () => {
     expect(eventWork(evt)).toBe(Math.pow(2, verifyPow(evt)));
   });
 
-  it("replyWork mirrors reply PoW when it meets the minimum difficulty", () => {
+  it("replyWork mirrors reply PoW", () => {
     const reply = event({ tags: [["nonce", "1", "16"]] });
 
-    expect(replyWork(reply, { minReplyDifficulty: 16 })).toBe(Math.pow(2, 16));
+    expect(replyWork(reply)).toBe(Math.pow(2, 16));
   });
 
-  it("replyWork ignores replies below the minimum difficulty", () => {
+  it("replyWork includes replies below the feed filter difficulty", () => {
     const reply = event({ tags: [["nonce", "1", "15"]] });
 
-    expect(replyWork(reply, { minReplyDifficulty: 16 })).toBe(0);
+    expect(replyWork(reply, { minReplyDifficulty: 16 })).toBe(Math.pow(2, 15));
   });
 
-  it("totalWork sums root work and qualifying reply work", () => {
+  it("totalWork sums root work and all linked reply work", () => {
     const root = event();
     const qualifyingReply = event({ tags: [["nonce", "1", "16"]] });
-    const ignoredReply = event({ tags: [["nonce", "1", "15"]] });
+    const lowerPowReply = event({ tags: [["nonce", "1", "15"]] });
 
     expect(
-      totalWork(root, [qualifyingReply, ignoredReply], {
+      totalWork(root, [qualifyingReply, lowerPowReply], {
         minReplyDifficulty: 16,
       }),
-    ).toBe(eventWork(root) + replyWork(qualifyingReply));
+    ).toBe(eventWork(root) + replyWork(qualifyingReply) + replyWork(lowerPowReply));
   });
 
   it("sixteen 16-PoW replies equal one 20-PoW event worth of reply work", () => {
@@ -66,7 +66,6 @@ describe("pow-score", () => {
     const { replyWork: totalReplyWork, rankingReplyCount } = workScoreBreakdown(
       event({ tags: [["nonce", "root", "0"]] }),
       replies,
-      { minReplyDifficulty: 16 },
     );
 
     expect(totalReplyWork).toBe(Math.pow(2, 20));

--- a/src/nostr/processing/pow-score.ts
+++ b/src/nostr/processing/pow-score.ts
@@ -18,11 +18,7 @@ export function eventWork(event: Event): number {
 
 export function replyWork(reply: Event, options: WorkScoreOptions = {}): number {
   const difficulty = verifyPow(reply);
-  const minDifficulty = options.minReplyDifficulty ?? 0;
-
-  if (difficulty < minDifficulty) {
-    return 0;
-  }
+  void options;
 
   return Math.pow(2, difficulty);
 }


### PR DESCRIPTION
## Summary
- default posting difficulty is now signal 20
- default signal/feed filter is now 16
- totalWork scoring no longer drops linked replies based on the active signal filter
- feed/thread merge scoring now recomputes totals from all linked reply work

## Verification
- npm run typecheck
- npm test
- npm run build

Note: this commit was already pushed to main during production debugging. This PR is opened against a temporary pre-change base branch so the diff remains reviewable.
