### PR TITLE
Show PoW ETA below signal selector

### DIFF
--- a/src/features/compose/PostForm.test.tsx
+++ b/src/features/compose/PostForm.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { PostForm } from "./PostForm";
+
+type ReactActGlobal = typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+const mocks = vi.hoisted(() => ({
+  useSubmitForm: vi.fn(),
+}));
+
+vi.mock("../../app/settings", () => ({
+  useSettings: () => ({ settings: { difficulty: 21 } }),
+}));
+
+vi.mock("../../shared/hooks/useSubmitForm", () => ({
+  useSubmitForm: mocks.useSubmitForm,
+}));
+
+vi.mock("../thread/useThreadNavigation", () => ({
+  useThreadNavigation: () => vi.fn(),
+}));
+
+vi.mock("./buildUnsignedEvent", () => ({
+  buildUnsignedEvent: () => ({
+    kind: 1,
+    tags: [["client", "getwired.app"]],
+    content: "test",
+    created_at: 1,
+    pubkey: "",
+  }),
+}));
+
+vi.mock("./CustomEmojiPicker", () => ({
+  CustomEmojiPicker: () => <button type="button">emoji</button>,
+}));
+
+describe("PostForm", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.useSubmitForm.mockReturnValue({
+      handleSubmit: vi.fn(),
+      doingWorkProp: false,
+      submitStatus: "idle",
+      submitError: null,
+      acceptedRelays: [],
+      hashrate: 0,
+      bestPow: 0,
+      signedPoWEvent: undefined,
+      powEta: "12s",
+      willUseWiredAccount: false,
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows the PoW ETA with the signal selector", () => {
+    act(() => {
+      root.render(<PostForm />);
+    });
+
+    expect(container.textContent).toContain("signal");
+    expect(container.textContent).toContain("estimated mine time ~12s");
+  });
+});

--- a/src/features/compose/PostForm.tsx
+++ b/src/features/compose/PostForm.tsx
@@ -55,6 +55,7 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
     hashrate,
     bestPow,
     signedPoWEvent,
+    powEta,
     willUseWiredAccount,
   } =
     useSubmitForm(unsigned, difficulty);
@@ -110,13 +111,16 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
           rows={comment.split("\n").length || 1}
         />
         {tagType === "Quote" && refEvent && <QuotePreview event={refEvent} />}
-        <div className="min-h-14 flex items-center justify-between gap-4 mt-2">
-          <SignalStepper
-            value={difficulty}
-            onChange={setDifficulty}
-            min={16}
-            active={willUseWiredAccount}
-          />
+        <div className="min-h-14 flex items-start justify-between gap-4 mt-2">
+          <div className="flex flex-col items-start gap-1">
+            <SignalStepper
+              value={difficulty}
+              onChange={setDifficulty}
+              min={16}
+              active={willUseWiredAccount}
+            />
+            <p className="text-meta text-secondary">estimated mine time ~{powEta}</p>
+          </div>
           <div className="flex items-center gap-3">
             <CustomEmojiPicker onSelect={handleEmojiSelect} />
             <Button type="submit" variant="primary" size="sm" disabled={doingWorkProp} loading={doingWorkProp}>

--- a/src/shared/hooks/usePowMining.ts
+++ b/src/shared/hooks/usePowMining.ts
@@ -5,6 +5,7 @@ import type { MinedPowEvent, PowWorkerRequest, PowWorkerResponse } from "../../w
 type StartWorkOptions = {
   unsigned?: UnsignedEvent;
   difficulty?: string;
+  onHashrate?: (hashrate: number) => void;
   onMined: (event: MinedPowEvent) => void;
   onError?: () => void;
 };
@@ -58,7 +59,11 @@ export function usePowMining(numCores: number, unsigned: UnsignedEvent, difficul
 
         if (response.type === "progress") {
           const elapsedSeconds = (Date.now() - startTime) / 1000;
-          setHashrate(Math.floor(response.currentNonce / (elapsedSeconds || 1)));
+          const nextHashrate = Math.floor(response.currentNonce / (elapsedSeconds || 1));
+          setHashrate(nextHashrate);
+          if (nextHashrate > 0) {
+            options?.onHashrate?.(nextHashrate);
+          }
           setBestPow((currentBestPow) => Math.max(currentBestPow, response.bestPow));
           return;
         }

--- a/src/shared/hooks/useSubmitForm.test.tsx
+++ b/src/shared/hooks/useSubmitForm.test.tsx
@@ -131,6 +131,7 @@ describe("useSubmitForm", () => {
     mocks.fetchWiredAccountStatus.mockReset();
     mocks.submitWiredAccountPost.mockReset();
     mocks.fetchWiredAccountStatus.mockResolvedValue(disabledWiredAccountStatus);
+    window.localStorage.clear();
     vi.stubGlobal("Worker", MockWorker);
     Object.defineProperty(window.navigator, "hardwareConcurrency", {
       configurable: true,
@@ -180,6 +181,24 @@ describe("useSubmitForm", () => {
     });
 
     expect(state.willUseWiredAccount).toBe(true);
+  });
+
+  it("exposes a PoW ETA and caches measured mining hashrate", async () => {
+    act(() => {
+      root.render(<Probe difficulty="16" onState={(nextState) => (state = nextState)} />);
+    });
+
+    expect(state.powEta).toBe("1s");
+
+    await submitForm();
+
+    await act(async () => {
+      mockWorkers[0].emit({ type: "progress", currentNonce: 100_000, bestPow: 10 });
+    });
+
+    expect(state.hashrate).toBeGreaterThan(0);
+    expect(state.powEta).toBe("now");
+    expect(window.localStorage.getItem("wired:last-pow-hashrate")).toBe(String(state.hashrate));
   });
 
   it("reports willUseWiredAccount as false when signal is below the wired account minimum", async () => {

--- a/src/shared/hooks/useSubmitForm.ts
+++ b/src/shared/hooks/useSubmitForm.ts
@@ -9,8 +9,26 @@ import {
   submitWiredAccountPost,
   type WiredAccountStatus,
 } from "../../features/wiredAccount/api";
+import { timeToGoEst } from "@lib/timeEstimate";
 
 export type SubmitStatus = "idle" | "mining" | "publishing" | "published" | "failed";
+
+const POW_HASHRATE_STORAGE_KEY = "wired:last-pow-hashrate";
+const FALLBACK_POW_HASHRATE = 50_000;
+
+function readStoredHashrate(): number {
+  if (typeof window === "undefined") return FALLBACK_POW_HASHRATE;
+
+  const value = Number(window.localStorage.getItem(POW_HASHRATE_STORAGE_KEY));
+  return Number.isFinite(value) && value > 0 ? value : FALLBACK_POW_HASHRATE;
+}
+
+function storeHashrate(value: number): void {
+  if (typeof window === "undefined") return;
+  if (!Number.isFinite(value) || value <= 0) return;
+
+  window.localStorage.setItem(POW_HASHRATE_STORAGE_KEY, String(Math.floor(value)));
+}
 
 export function willUseWiredAccount(
   difficulty: string,
@@ -34,6 +52,7 @@ export const useSubmitForm = (unsigned: UnsignedEvent, difficulty: string) => {
   const unsignedWithPubkey = { ...unsigned, pubkey: getPublicKey(sk) };
   const [signedPoWEvent, setSignedPoWEvent] = useState<Event>();
   const [wiredAccountStatus, setWiredAccountStatus] = useState<WiredAccountStatus | null>(null);
+  const [estimatedHashrate, setEstimatedHashrate] = useState(readStoredHashrate);
   const activeSubmitId = useRef(0);
 
   const numCores = navigator.hardwareConcurrency || 4;
@@ -81,6 +100,10 @@ export const useSubmitForm = (unsigned: UnsignedEvent, difficulty: string) => {
     startWork({
       unsigned: submitUnsigned,
       difficulty: submitDifficulty,
+      onHashrate: (nextHashrate) => {
+        storeHashrate(nextHashrate);
+        setEstimatedHashrate(nextHashrate);
+      },
       onMined: async (minedEvent) => {
         if (activeSubmitId.current !== submitId) return;
 
@@ -152,6 +175,7 @@ export const useSubmitForm = (unsigned: UnsignedEvent, difficulty: string) => {
     hashrate,
     bestPow,
     signedPoWEvent,
+    powEta: timeToGoEst(difficulty, hashrate || estimatedHashrate),
     willUseWiredAccount: willUseWiredAccount(difficulty, wiredAccountStatus),
   };
 };


### PR DESCRIPTION
## Summary
- show an estimated mine time below the SignalStepper at all times
- use live mining hashrate when available, otherwise last measured local hashrate or a fallback baseline
- cache measured hashrate from mining progress for future estimates

Fixes #89

## Tests
- npm test -- src/shared/hooks/useSubmitForm.test.tsx src/features/compose/PostForm.test.tsx
- npm test
- npm run typecheck
- npm run lint (passes with existing fast-refresh warnings)
- npm run build