### PR TITLE
Render Nostr profile mentions inline

### DIFF
--- a/src/shared/lib/content.test.ts
+++ b/src/shared/lib/content.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { Event } from "nostr-tools";
+import { Event, nip19 } from "nostr-tools";
 import { parseContent } from "./content";
+
+const PROFILE_PUBKEY = "82341f2e7e4b7ef002c65dde7dc0a22e7745af86f1b0638c1e1edf6b46e6e6a2";
 
 describe("parseContent", () => {
   it("strips media URLs from comment and returns media items", () => {
@@ -39,13 +41,24 @@ describe("parseContent", () => {
     });
   });
 
-  it("strips nostr bech32 identifiers from displayed content", () => {
+  it("strips nostr event identifiers from displayed content", () => {
     const content =
       "Wem nützt diese Näherung mehr?\nnostr:nevent1qqsyfzfk3zkvvmuyqd8hzu9008efyn4n53ucvx2353wknnltte0d33spz4mhxue69uhkummnw3ezuerpw3sju6rpw4esygy86n6j2pxy0rmwdj062z5y7mjngl2pyrz334pptd2jwjkh8slxwu6szplm";
     const event = { content } as Event;
 
     expect(parseContent(event)).toEqual({
       comment: "Wem nützt diese Näherung mehr?",
+      attachments: [],
+    });
+  });
+
+  it("preserves nostr profile identifiers for inline rendering", () => {
+    const nprofile = nip19.nprofileEncode({ pubkey: PROFILE_PUBKEY });
+    const content = `hello nostr:${nprofile} today`;
+    const event = { content } as Event;
+
+    expect(parseContent(event)).toEqual({
+      comment: content,
       attachments: [],
     });
   });

--- a/src/shared/lib/content.ts
+++ b/src/shared/lib/content.ts
@@ -8,11 +8,11 @@ import {
 import { type LinkItem } from "@lib/linkUtils";
 import { normalizeStrippedContent } from "@lib/textCleanup";
 import { HTTP_URL_PATTERN } from "@lib/url";
-import { NOSTR_REF_PATTERN } from "./quotedEvents";
+import { NOSTR_EVENT_REF_PATTERN } from "./quotedEvents";
 
-/** Remove Nostr URI tokens from visible text — kept in event data, not shown. */
-function stripNostrRefs(content: string): string {
-  return normalizeStrippedContent(content.replace(NOSTR_REF_PATTERN, ""));
+/** Remove quoted event URI tokens from visible text; profile refs render inline. */
+function stripQuotedEventRefs(content: string): string {
+  return normalizeStrippedContent(content.replace(NOSTR_EVENT_REF_PATTERN, ""));
 }
 
 export type { LinkItem };
@@ -119,7 +119,7 @@ export function parseContent(event: Event): ParsedContent {
   );
 
   return {
-    comment: stripNostrRefs(strippedContent),
+    comment: stripQuotedEventRefs(strippedContent),
     attachments,
   };
 }

--- a/src/shared/lib/quotedEvents.test.ts
+++ b/src/shared/lib/quotedEvents.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { Event } from "nostr-tools";
+import { Event, nip19 } from "nostr-tools";
 import {
+  decodeProfileRef,
   decodeNostrRef,
   extractMentionedEventRefs,
   extractQuotedRefs,
@@ -14,12 +15,34 @@ const NOTE_TAG_NOTE = "note1enxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxq
 const ISSUE_54_QUOTED_ID = "a38fb77ce8783c30bf64063fe78e8060f3b58e41476fb3a5cd94ddfb1b3837d1";
 const ISSUE_54_QUOTED_NEVENT =
   "nevent1qqs28rah0n58s0pshajqv0l836qxpua43eq5wman5hxefh0mrvur05gpzpmhxue69uhkummnw3ezumrpdejqygr2q2mat4wpemkr6zkj3ht3cn87awmrj7u4lm6u65pjey3r5y7s9gcs8lc6";
+const PROFILE_PUBKEY = "82341f2e7e4b7ef002c65dde7dc0a22e7745af86f1b0638c1e1edf6b46e6e6a2";
 
 describe("decodeNostrRef", () => {
   it("decodes nevent references to event ids and relay hints", () => {
     expect(decodeNostrRef(QUOTED_EVENT_NEVENT)).toEqual({
       id: QUOTED_EVENT_ID,
       relays: ["wss://relay.damus.io", "wss://offchain.pub"],
+    });
+  });
+});
+
+describe("decodeProfileRef", () => {
+  it("decodes npub references to pubkeys", () => {
+    expect(decodeProfileRef(`nostr:${nip19.npubEncode(PROFILE_PUBKEY)}`)).toEqual({
+      pubkey: PROFILE_PUBKEY,
+      relays: [],
+    });
+  });
+
+  it("decodes nprofile references to pubkeys and relay hints", () => {
+    const nprofile = nip19.nprofileEncode({
+      pubkey: PROFILE_PUBKEY,
+      relays: ["wss://relay.example/"],
+    });
+
+    expect(decodeProfileRef(`nostr:${nprofile}`)).toEqual({
+      pubkey: PROFILE_PUBKEY,
+      relays: ["wss://relay.example"],
     });
   });
 });
@@ -37,6 +60,15 @@ describe("extractQuotedRefs", () => {
         relays: ["wss://relay.damus.io", "wss://offchain.pub"],
       },
     ]);
+  });
+
+  it("does not treat inline profile references as quoted events", () => {
+    const event = {
+      content: `hello nostr:${nip19.nprofileEncode({ pubkey: PROFILE_PUBKEY })}`,
+      tags: [],
+    } as unknown as Event;
+
+    expect(extractQuotedRefs(event)).toEqual([]);
   });
 
   it("extracts refs from q tags", () => {

--- a/src/shared/lib/quotedEvents.ts
+++ b/src/shared/lib/quotedEvents.ts
@@ -1,10 +1,18 @@
 import { nip19, type Event } from "nostr-tools";
 
-export const NOSTR_REF_PATTERN =
-  /nostr:(?:note|nevent|naddr|npub|nprofile|nrelay)1[a-z0-9]+/gi;
+export const NOSTR_EVENT_REF_PATTERN =
+  /nostr:(?:note|nevent)1[a-z0-9]+/gi;
+export const NOSTR_PROFILE_REF_PATTERN =
+  /nostr:(?:npub|nprofile)1[a-z0-9]+/gi;
+export const NOSTR_REF_PATTERN = NOSTR_EVENT_REF_PATTERN;
 
 export type QuotedRef = {
   id: string;
+  relays: string[];
+};
+
+export type ProfileRef = {
+  pubkey: string;
   relays: string[];
 };
 
@@ -33,9 +41,28 @@ export function decodeNostrRef(ref: string): QuotedRef | null {
   return null;
 }
 
+export function decodeProfileRef(ref: string): ProfileRef | null {
+  const bech32 = ref.replace(/^nostr:/i, "");
+  try {
+    const decoded = nip19.decode(bech32);
+    if (decoded.type === "npub") {
+      return { pubkey: decoded.data as string, relays: [] };
+    }
+    if (decoded.type === "nprofile") {
+      return {
+        pubkey: decoded.data.pubkey,
+        relays: (decoded.data.relays ?? []).map(normalizeRelayUrl),
+      };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
 export function extractNostrRefs(content: string): QuotedRef[] {
   const refs: QuotedRef[] = [];
-  for (const match of content.matchAll(NOSTR_REF_PATTERN)) {
+  for (const match of content.matchAll(NOSTR_EVENT_REF_PATTERN)) {
     const ref = decodeNostrRef(match[0]);
     if (ref) refs.push(ref);
   }

--- a/src/shared/ui/LinkedBodyText.test.tsx
+++ b/src/shared/ui/LinkedBodyText.test.tsx
@@ -2,8 +2,19 @@
 
 import { createRoot, type Root } from "react-dom/client";
 import { act } from "react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { nip19 } from "nostr-tools";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LinkedBodyText } from "./LinkedBodyText";
+
+const mocks = vi.hoisted(() => ({
+  useProfile: vi.fn(),
+}));
+
+vi.mock("../hooks/useProfiles", () => ({
+  useProfile: mocks.useProfile,
+}));
+
+const PROFILE_PUBKEY = "82341f2e7e4b7ef002c65dde7dc0a22e7745af86f1b0638c1e1edf6b46e6e6a2";
 
 describe("LinkedBodyText", () => {
   let container: HTMLDivElement;
@@ -13,6 +24,7 @@ describe("LinkedBodyText", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+    mocks.useProfile.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -20,6 +32,7 @@ describe("LinkedBodyText", () => {
       root.unmount();
     });
     container.remove();
+    vi.clearAllMocks();
   });
 
   it("renders preserved body URLs as clickable hyperlinks", () => {
@@ -83,5 +96,23 @@ describe("LinkedBodyText", () => {
       "lain",
       "lain_happy",
     ]);
+  });
+
+  it("renders Nostr profile references as inline mentions", () => {
+    const nprofile = nip19.nprofileEncode({ pubkey: PROFILE_PUBKEY });
+    mocks.useProfile.mockReturnValue({ name: "jack" });
+
+    act(() => {
+      root.render(
+        <LinkedBodyText className="body">
+          {`hello nostr:${nprofile}`}
+        </LinkedBodyText>,
+      );
+    });
+
+    const link = container.querySelector("a");
+    expect(link?.textContent).toBe("@jack");
+    expect(link?.getAttribute("href")).toBe(`nostr:${nprofile}`);
+    expect(container.textContent).toBe("hello @jack");
   });
 });

--- a/src/shared/ui/LinkedBodyText.tsx
+++ b/src/shared/ui/LinkedBodyText.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import { normalizeUrl } from "@link/link";
 import { buildEmojiMap, getEmojiDisplayUrls, type BodyEmoji } from "@lib/customEmoji";
+import { getDisplayName } from "@lib/profile";
+import { decodeProfileRef, NOSTR_PROFILE_REF_PATTERN } from "@lib/quotedEvents";
 import { HTTP_URL_PATTERN } from "@lib/url";
+import { useProfile } from "../hooks/useProfiles";
 
 type LinkedBodyTextProps = {
   children: string;
@@ -12,11 +15,12 @@ type LinkedBodyTextProps = {
 const EMOJI_SHORTCODE_PATTERN = /:([A-Za-z0-9_+-]+):/g;
 
 type BodyToken = {
-  kind: "url" | "emoji";
+  kind: "url" | "emoji" | "profile";
   raw: string;
   index: number;
   url?: string;
   shortcode?: string;
+  pubkey?: string;
 };
 
 function InlineCustomEmoji({
@@ -51,6 +55,19 @@ function InlineCustomEmoji({
   );
 }
 
+function InlineProfileMention({ raw, pubkey }: { raw: string; pubkey: string }) {
+  const profile = useProfile(pubkey);
+
+  return (
+    <a
+      href={raw}
+      className="font-medium text-signal hover:underline"
+    >
+      @{getDisplayName(profile, pubkey)}
+    </a>
+  );
+}
+
 function getBodyTokens(content: string, emojiMap: Map<string, string>): BodyToken[] {
   const tokens: BodyToken[] = [];
 
@@ -64,6 +81,20 @@ function getBodyTokens(content: string, emojiMap: Map<string, string>): BodyToke
       raw,
       index,
       url: normalized || undefined,
+    });
+  }
+
+  for (const match of content.matchAll(NOSTR_PROFILE_REF_PATTERN)) {
+    const raw = match[0];
+    const profileRef = decodeProfileRef(raw);
+
+    if (!profileRef) continue;
+
+    tokens.push({
+      kind: "profile",
+      raw,
+      index: match.index ?? 0,
+      pubkey: profileRef.pubkey,
     });
   }
 
@@ -118,6 +149,14 @@ export function LinkedBodyText({ children, className, emojis = [] }: LinkedBodyT
           shortcode={token.shortcode}
           raw={token.raw}
           url={token.url}
+        />,
+      );
+    } else if (token.kind === "profile" && token.pubkey) {
+      parts.push(
+        <InlineProfileMention
+          key={`${token.pubkey}-${token.index}`}
+          raw={token.raw}
+          pubkey={token.pubkey}
         />,
       );
     } else if (token.kind === "url") {


### PR DESCRIPTION
## Summary
- stop stripping npub/nprofile references from visible post content
- decode profile Nostr refs separately from quote/event refs
- render profile refs inline as @displayName with profile metadata fallback

Fixes #90

## Tests
- npm test -- src/shared/lib/content.test.ts src/shared/lib/quotedEvents.test.ts src/shared/ui/LinkedBodyText.test.tsx
- npm test
- npm run typecheck
- npm run lint (passes with existing fast-refresh warnings)
- npm run build