### PR TITLE
Improve touch targets and press feedback

### DIFF
--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -38,7 +38,7 @@ export function Button({
       disabled={isDisabled}
       aria-busy={loading || undefined}
       className={[
-        "inline-flex items-center justify-center rounded-sm min-h-[24px] min-w-[24px]",
+        "wired-touch-target wired-pressable inline-flex items-center justify-center rounded-sm min-h-[24px] min-w-[24px]",
         "transition-colors duration-hover",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-signal-ghost focus-visible:ring-offset-2 focus-visible:ring-offset-void",
         variantClasses[variant],

--- a/src/shared/ui/SegmentedControl.tsx
+++ b/src/shared/ui/SegmentedControl.tsx
@@ -85,7 +85,7 @@ export function SegmentedControl<T extends string>({
             onClick={() => onChange(option.value)}
             onKeyDown={(event) => handleKeyDown(event, index)}
             className={[
-              "min-h-[24px] min-w-[24px] px-3 py-1.5 text-meta rounded-sm transition-colors duration-hover",
+              "wired-touch-target wired-pressable min-h-[24px] min-w-[24px] px-3 py-1.5 text-meta rounded-sm transition-colors duration-hover",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-signal-ghost focus-visible:ring-offset-2 focus-visible:ring-offset-void",
               isSelected
                 ? "bg-surface-raised text-signal"

--- a/src/shared/ui/SignalStepper.tsx
+++ b/src/shared/ui/SignalStepper.tsx
@@ -39,7 +39,7 @@ export function SignalStepper({
         min={min}
         containerClassName="w-auto"
         className={[
-          "w-12 !min-h-[24px] !py-1 !px-2 text-meta border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
+          "wired-touch-field w-12 min-h-[24px] !py-1 !px-2 text-meta border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
           active ? "text-signal" : "",
         ].join(" ")}
         aria-label={difficultyLabel}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -93,6 +93,19 @@ body {
   box-shadow: 0 0 0 2px var(--void), 0 0 0 4px var(--signal-dim);
 }
 
+.wired-pressable {
+  touch-action: manipulation;
+  transform: translateY(0) scale(1);
+  transform-origin: center;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, transform;
+  transition-duration: var(--duration-hover);
+  transition-timing-function: var(--ease-out);
+}
+
+.wired-pressable:active:not(:disabled) {
+  transform: translateY(1px) scale(0.98);
+}
+
 .noise-overlay {
   position: fixed;
   inset: 0;
@@ -104,6 +117,15 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .wired-pressable {
+    transition-duration: 0ms;
+  }
+
+  .wired-pressable:active:not(:disabled) {
+    opacity: 0.82;
+    transform: none;
+  }
+
   .noise-overlay {
     opacity: 0;
   }
@@ -145,6 +167,15 @@ textarea {
   textarea,
   select {
     font-size: 16px !important;
+  }
+
+  .wired-touch-target {
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  .wired-touch-field {
+    min-height: 44px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared press feedback for buttons and segmented control options on pointer-down/active
- raise shared tappable controls and the signal stepper input to 44px minimums for coarse pointers only
- preserve compact desktop sizing and focus-visible rings, with reduced-motion press feedback falling back to opacity

## Validation
- npm run typecheck
- npm run lint (passes with existing fast-refresh warnings)
- npm run test
- npm run build