### PR TITLE
Add notification activity empty states

### DIFF
--- a/src/features/notifications/NotificationsPage.test.tsx
+++ b/src/features/notifications/NotificationsPage.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import type { Event } from "nostr-tools";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import NotificationsPage from "./NotificationsPage";
+import type { NotificationSyncState } from "../../hooks/useNotificationEvents";
+
+type NotificationState = {
+  noteEvents: Event[];
+  pubkeys: string[];
+  syncState: NotificationSyncState;
+};
+
+const mocks = vi.hoisted(() => ({
+  notificationState: {
+    noteEvents: [] as Event[],
+    pubkeys: ["a".repeat(64)],
+    syncState: "synced" as NotificationSyncState,
+  },
+  openThread: vi.fn(),
+}));
+
+vi.mock("../../hooks/useNotificationEvents", () => ({
+  useNotificationEvents: () => mocks.notificationState,
+}));
+
+vi.mock("../thread/useThreadNavigation", () => ({
+  useThreadNavigation: () => mocks.openThread,
+}));
+
+vi.mock("../../shared/ui/PostCard", () => ({
+  PostCard: ({ event }: { event: Event }) => (
+    <article data-testid="post-card">{event.content}</article>
+  ),
+}));
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function setNotificationState(state: Partial<NotificationState>) {
+  mocks.notificationState = {
+    noteEvents: [],
+    pubkeys: ["a".repeat(64)],
+    syncState: "synced",
+    ...state,
+  };
+}
+
+describe("NotificationsPage", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    setNotificationState({});
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function renderPage() {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <NotificationsPage />
+        </MemoryRouter>,
+      );
+    });
+  }
+
+  it("shows explicit empty states and next actions after sync completes", () => {
+    setNotificationState({ syncState: "synced" });
+
+    renderPage();
+
+    expect(container.textContent).toContain("no local transmissions yet");
+    expect(container.textContent).toContain("start a transmission");
+    expect(container.textContent).toContain("no mentions yet");
+    expect(container.querySelector("a[href='/']")).not.toBeNull();
+  });
+
+  it("distinguishes syncing from an empty activity result", () => {
+    setNotificationState({ syncState: "syncing" });
+
+    renderPage();
+
+    expect(container.textContent).toContain("syncing your transmissions");
+    expect(container.textContent).toContain("syncing mentions");
+    expect(container.textContent).not.toContain("no local transmissions yet");
+    expect(container.textContent).not.toContain("no mentions yet");
+  });
+
+  it("shows a degraded state instead of an empty state while relay sync is delayed", () => {
+    setNotificationState({ syncState: "degraded" });
+
+    renderPage();
+
+    expect(container.textContent).toContain("activity sync delayed");
+    expect(container.textContent).not.toContain("no local transmissions yet");
+    expect(container.textContent).not.toContain("no mentions yet");
+  });
+
+  it("directs devices without local keys to settings", () => {
+    setNotificationState({ pubkeys: [], syncState: "idle" });
+
+    renderPage();
+
+    expect(container.textContent).toContain("no local signal keys");
+    expect(container.textContent).toContain("add a signal key");
+    expect(container.querySelector("a[href='/settings']")).not.toBeNull();
+  });
+
+  it("keeps the mobile segmented view and desktop column visibility classes", () => {
+    renderPage();
+
+    expect(container.querySelector("[role='radiogroup']")).not.toBeNull();
+    expect(container.querySelector(".hidden.sm\\:grid")).not.toBeNull();
+  });
+});

--- a/src/features/notifications/NotificationsPage.tsx
+++ b/src/features/notifications/NotificationsPage.tsx
@@ -1,15 +1,145 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { PostCard } from "../../shared/ui/PostCard";
 import { Event } from "nostr-tools";
-import { useNotificationEvents } from "../../hooks/useNotificationEvents";
+import {
+  useNotificationEvents,
+  type NotificationSyncState,
+} from "../../hooks/useNotificationEvents";
 import { SegmentedControl } from "../../shared/ui/SegmentedControl";
 import { PageShell } from "../../shared/ui/PageShell";
 import { useThreadNavigation } from "../thread/useThreadNavigation";
 
+type NotificationSection = "yours" | "mentions";
+
+type ActivityStateProps = {
+  actionHref?: string;
+  actionLabel?: string;
+  message: string;
+  title: string;
+  tone?: "normal" | "warning";
+};
+
+function ActivityState({
+  actionHref,
+  actionLabel,
+  message,
+  title,
+  tone = "normal",
+}: ActivityStateProps) {
+  return (
+    <div
+      className={[
+        "rounded-sm border px-4 py-5",
+        tone === "warning"
+          ? "border-danger-dim bg-surface"
+          : "border-ghost bg-surface",
+      ].join(" ")}
+      role={tone === "warning" ? "status" : undefined}
+    >
+      <p className="text-body text-primary">{title}</p>
+      <p className="mt-1 text-meta text-muted">{message}</p>
+      {actionHref && actionLabel ? (
+        <Link
+          to={actionHref}
+          className="mt-4 inline-flex min-h-[24px] items-center rounded-sm border border-ghost bg-surface-raised px-3 py-1.5 text-meta text-primary transition-colors duration-hover hover:border-signal/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-signal-ghost focus-visible:ring-offset-2 focus-visible:ring-offset-void"
+        >
+          {actionLabel}
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+function ActivityLoadingState({ label }: { label: string }) {
+  return (
+    <div
+      className="rounded-sm border border-ghost bg-surface px-4 py-5"
+      role="status"
+      aria-live="polite"
+    >
+      <p className="text-body text-primary">syncing {label}</p>
+      <p className="mt-1 text-meta text-muted">Checking relays for saved signal keys.</p>
+      <div className="mt-4 grid gap-2" aria-hidden="true">
+        <div className="h-3 w-3/4 rounded bg-surface-raised" />
+        <div className="h-3 w-full rounded bg-surface-raised" />
+        <div className="h-3 w-1/2 rounded bg-surface-raised" />
+      </div>
+    </div>
+  );
+}
+
+type NotificationColumnProps = {
+  countReplies: (event: Event) => Event[];
+  emptyMessage: string;
+  emptyTitle: string;
+  events: Event[];
+  hasLocalKeys: boolean;
+  label: string;
+  onOpenThread: ReturnType<typeof useThreadNavigation>;
+  section: NotificationSection;
+  syncState: NotificationSyncState;
+};
+
+function NotificationColumn({
+  countReplies,
+  emptyMessage,
+  emptyTitle,
+  events,
+  hasLocalKeys,
+  label,
+  onOpenThread,
+  section,
+  syncState,
+}: NotificationColumnProps) {
+  const showLoading = hasLocalKeys && syncState === "syncing" && events.length === 0;
+  const showDegraded = hasLocalKeys && syncState === "degraded";
+  const showEmpty = !showLoading && !showDegraded && events.length === 0;
+  const actionHref = hasLocalKeys ? "/" : "/settings";
+  const actionLabel = hasLocalKeys ? "start a transmission" : "add a signal key";
+
+  return (
+    <>
+      <span className="text-meta text-muted">{label}</span>
+      {showLoading ? <ActivityLoadingState label={label} /> : null}
+      {showDegraded ? (
+        <ActivityState
+          title="activity sync delayed"
+          message={`Relay sync is taking longer than expected. Showing ${
+            section === "yours" ? "local transmissions" : "mentions"
+          } received so far.`}
+          tone="warning"
+        />
+      ) : null}
+      {showEmpty ? (
+        <ActivityState
+          title={hasLocalKeys ? emptyTitle : "no local signal keys"}
+          message={
+            hasLocalKeys
+              ? emptyMessage
+              : "This device has no saved signal keys to check for activity."
+          }
+          actionHref={actionHref}
+          actionLabel={actionLabel}
+        />
+      ) : null}
+      {events.map((event) => (
+        <PostCard
+          key={event.id}
+          event={event}
+          replies={countReplies(event)}
+          onOpenThread={onOpenThread}
+        />
+      ))}
+    </>
+  );
+}
+
 export default function NotificationsPage() {
-  const [notifsView, setNotifsView] = useState<"yours" | "mentions">("yours");
-  const { noteEvents, pubkeys } = useNotificationEvents();
+  const [notifsView, setNotifsView] = useState<NotificationSection>("yours");
+  const { noteEvents, pubkeys, syncState } = useNotificationEvents();
   const openThread = useThreadNavigation();
+  const hasLocalKeys = pubkeys.length > 0;
 
   const postEvents = noteEvents.filter(
     (event) => event.kind !== 0 && pubkeys.includes(event.pubkey),
@@ -43,26 +173,30 @@ export default function NotificationsPage() {
       </div>
       <div className="flex gap-8">
         <div className={`grid grid-cols-1 gap-4 flex-grow ${notifsView === "mentions" ? "hidden sm:grid" : ""}`}>
-          <span className="text-meta text-muted">your transmissions</span>
-          {sortedEvents.map((event) => (
-            <PostCard
-              key={event.id}
-              event={event}
-              replies={countReplies(event)}
-              onOpenThread={openThread}
-            />
-          ))}
+          <NotificationColumn
+            countReplies={countReplies}
+            emptyMessage="Transmit from the main feed to build this local history."
+            emptyTitle="no local transmissions yet"
+            events={sortedEvents}
+            hasLocalKeys={hasLocalKeys}
+            label="your transmissions"
+            onOpenThread={openThread}
+            section="yours"
+            syncState={syncState}
+          />
         </div>
         <div className={`grid grid-cols-1 gap-4 flex-grow ${notifsView === "yours" ? "hidden sm:grid" : ""}`}>
-          <span className="text-meta text-muted">mentions</span>
-          {sortedMentions.map((event) => (
-            <PostCard
-              key={event.id}
-              event={event}
-              replies={countReplies(event)}
-              onOpenThread={openThread}
-            />
-          ))}
+          <NotificationColumn
+            countReplies={countReplies}
+            emptyMessage="Post from the main feed so other signals can mention you."
+            emptyTitle="no mentions yet"
+            events={sortedMentions}
+            hasLocalKeys={hasLocalKeys}
+            label="mentions"
+            onOpenThread={openThread}
+            section="mentions"
+            syncState={syncState}
+          />
         </div>
       </div>
     </PageShell>

--- a/src/hooks/useNotificationEvents.ts
+++ b/src/hooks/useNotificationEvents.ts
@@ -1,19 +1,41 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { subNotifications } from "../nostr/subscriptions";
 import { useStoredKeys } from "../shared/hooks/useStoredKeys";
 import { useFilteredNoteSubscription } from "../shared/hooks/useFilteredNoteSubscription";
 
+export type NotificationSyncState = "idle" | "syncing" | "synced" | "degraded";
+
+const DEGRADED_SYNC_TIMEOUT_MS = 8_000;
+
 export function useNotificationEvents() {
   const { pubkeys } = useStoredKeys();
   const pubkeyKey = pubkeys.join(",");
+  const hasLocalKeys = pubkeys.length > 0;
+  const [syncState, setSyncState] = useState<NotificationSyncState>(
+    hasLocalKeys ? "syncing" : "idle",
+  );
+
+  useEffect(() => {
+    if (!hasLocalKeys) {
+      setSyncState("idle");
+      return;
+    }
+
+    setSyncState("syncing");
+    const timeout = setTimeout(() => {
+      setSyncState((current) => (current === "syncing" ? "degraded" : current));
+    }, DEGRADED_SYNC_TIMEOUT_MS);
+
+    return () => clearTimeout(timeout);
+  }, [hasLocalKeys, pubkeyKey]);
 
   const subscribe = useCallback(
     (onEvent: Parameters<typeof subNotifications>[1]) =>
-      subNotifications(pubkeys, onEvent),
+      subNotifications(pubkeys, onEvent, () => setSyncState("synced")),
     [pubkeys],
   );
 
-  const noteEvents = useFilteredNoteSubscription(subscribe, [pubkeyKey]);
+  const noteEvents = useFilteredNoteSubscription(subscribe, [pubkeyKey], hasLocalKeys);
 
-  return { noteEvents, pubkeys };
+  return { noteEvents, pubkeys, syncState };
 }

--- a/src/nostr/subscriptions/notifications.ts
+++ b/src/nostr/subscriptions/notifications.ts
@@ -2,10 +2,22 @@ import { getRegistry } from "../client";
 import type { SubCallback, SubHandle } from "../types";
 import { emptySubHandle } from "./utils";
 
-export const subNotifications = (pubkeys: string[], onEvent: SubCallback): SubHandle => {
+export const subNotifications = (
+  pubkeys: string[],
+  onEvent: SubCallback,
+  onEose?: () => void,
+): SubHandle => {
   if (pubkeys.length === 0) {
     return emptySubHandle("notifications:empty");
   }
+
+  let eoseCount = 0;
+  const handleEose = () => {
+    eoseCount += 1;
+    if (eoseCount >= 2) {
+      onEose?.();
+    }
+  };
 
   return getRegistry().subscribe([
     {
@@ -16,6 +28,7 @@ export const subNotifications = (pubkeys: string[], onEvent: SubCallback): SubHa
       },
       cb: onEvent,
       closeOnEose: true,
+      onEose: handleEose,
     },
     {
       filter: {
@@ -25,6 +38,7 @@ export const subNotifications = (pubkeys: string[], onEvent: SubCallback): SubHa
       },
       cb: onEvent,
       closeOnEose: true,
+      onEose: handleEose,
     },
   ]);
 };


### PR DESCRIPTION
## Summary
- add explicit notification empty states for local transmissions, mentions, and devices without local signal keys
- expose notification sync status from the hook using EOSE plus a delayed degraded state
- preserve mobile segmented navigation and desktop two-column rendering, with page tests for empty/loading/degraded states

## Tests
- npm test -- src/features/notifications/NotificationsPage.test.tsx
- npm run typecheck
- npm run lint (passes with existing fast-refresh warnings outside this change)