### PR TITLE
Improve post card thread opening affordance

### DIFF
--- a/src/shared/ui/MetadataRow.tsx
+++ b/src/shared/ui/MetadataRow.tsx
@@ -1,12 +1,9 @@
-import type { MouseEvent } from "react";
 import { Activity, Network } from "lucide-react";
-import { Button } from "./Button";
 
 type MetadataRowProps = {
   signal: number;
   replyCount: number;
   timestamp: string;
-  onOpenThread?: () => void;
   forceSecondary?: boolean;
 };
 
@@ -18,26 +15,16 @@ export function MetadataRow({
   signal,
   replyCount,
   timestamp,
-  onOpenThread,
   forceSecondary = false,
 }: MetadataRowProps) {
-  const handleRowClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (!onOpenThread) return;
-    if (event.target === event.currentTarget) {
-      onOpenThread();
-    }
-  };
-
   return (
     <div
       className={[
         "metadata-row flex items-center justify-between gap-3 pt-3 text-meta",
         forceSecondary ? "metadata-row--secondary" : "",
-        onOpenThread ? "cursor-pointer" : "",
       ]
         .filter(Boolean)
         .join(" ")}
-      onClick={handleRowClick}
     >
       <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
         <span
@@ -56,18 +43,6 @@ export function MetadataRow({
         </span>
         <span className="whitespace-nowrap">{timestamp}</span>
       </div>
-      {onOpenThread && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={onOpenThread}
-          aria-label="open thread"
-          className="shrink-0"
-        >
-          open
-        </Button>
-      )}
     </div>
   );
 }

--- a/src/shared/ui/PostCard.test.tsx
+++ b/src/shared/ui/PostCard.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Event } from "nostr-tools";
+import { PostCard } from "./PostCard";
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  useProfile: vi.fn(),
+  useQuotedEvents: vi.fn(),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("../hooks/useProfiles", () => ({
+  useProfile: mocks.useProfile,
+}));
+
+vi.mock("../hooks/useQuotedEvents", () => ({
+  useQuotedEvents: mocks.useQuotedEvents,
+}));
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const event = (overrides: Partial<Event> = {}): Event => ({
+  id: "1".repeat(64),
+  pubkey: "a".repeat(64),
+  created_at: 1,
+  kind: 1,
+  tags: [],
+  content: "hello",
+  sig: "b".repeat(128),
+  ...overrides,
+});
+
+function click(target: Element) {
+  target.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }),
+  );
+}
+
+describe("PostCard thread opening", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.useProfile.mockReturnValue(null);
+    mocks.useQuotedEvents.mockReturnValue({
+      quotedEvents: [],
+      pendingRefs: [],
+      failedRefs: [],
+    });
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+        unobserve = vi.fn();
+        takeRecords = vi.fn(() => []);
+      },
+    );
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("opens the thread from the card surface", () => {
+    const onOpenThread = vi.fn();
+
+    act(() => {
+      root.render(
+        <PostCard
+          event={event()}
+          replies={[]}
+          totalWork={16}
+          onOpenThread={onOpenThread}
+        />,
+      );
+    });
+
+    const card = container.querySelector("article[role='link']");
+    expect(card).not.toBeNull();
+
+    act(() => {
+      click(card as Element);
+    });
+
+    expect(onOpenThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the thread with Enter when the card is focused", () => {
+    const onOpenThread = vi.fn();
+
+    act(() => {
+      root.render(
+        <PostCard
+          event={event()}
+          replies={[]}
+          totalWork={16}
+          onOpenThread={onOpenThread}
+        />,
+      );
+    });
+
+    const card = container.querySelector("article[role='link']");
+    expect(card).not.toBeNull();
+
+    act(() => {
+      card?.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "Enter",
+        }),
+      );
+    });
+
+    expect(onOpenThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not open the thread from a nested body link", () => {
+    const onOpenThread = vi.fn();
+
+    act(() => {
+      root.render(
+        <PostCard
+          event={event({ content: "read https://example.com/article" })}
+          replies={[]}
+          totalWork={16}
+          onOpenThread={onOpenThread}
+        />,
+      );
+    });
+
+    const link = container.querySelector(".post-content a");
+    expect(link).not.toBeNull();
+
+    act(() => {
+      click(link as Element);
+    });
+
+    expect(onOpenThread).not.toHaveBeenCalled();
+  });
+
+  it("does not open the thread from a nested button", () => {
+    const onOpenThread = vi.fn();
+
+    act(() => {
+      root.render(
+        <PostCard
+          event={event({ content: "x".repeat(800) })}
+          replies={[]}
+          totalWork={16}
+          onOpenThread={onOpenThread}
+        />,
+      );
+    });
+
+    const continueButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "continue",
+    );
+    expect(continueButton).not.toBeUndefined();
+
+    act(() => {
+      click(continueButton as Element);
+    });
+
+    expect(onOpenThread).not.toHaveBeenCalled();
+  });
+
+  it("does not open the thread from nested media", () => {
+    const onOpenThread = vi.fn();
+
+    act(() => {
+      root.render(
+        <PostCard
+          event={event({ content: "image https://example.com/photo.jpg" })}
+          replies={[]}
+          totalWork={16}
+          onOpenThread={onOpenThread}
+        />,
+      );
+    });
+
+    const image = container.querySelector(".post-content img");
+    expect(image).not.toBeNull();
+
+    act(() => {
+      click(image as Element);
+    });
+
+    expect(onOpenThread).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/ui/PostCard.tsx
+++ b/src/shared/ui/PostCard.tsx
@@ -9,7 +9,7 @@ import { MetadataRow } from "./MetadataRow";
 import { ReplyContext } from "./ReplyContext";
 import { SignalAvatar } from "./SignalAvatar";
 import { useProfile } from "../hooks/useProfiles";
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, type KeyboardEvent, type MouseEvent } from "react";
 import { useNavigate } from "react-router-dom";
 
 interface PostCardProps {
@@ -40,10 +40,52 @@ const depthClasses: Record<number, string> = {
   3: "pl-12 opacity-[0.76]",
 };
 const EMPTY_RELAY_HINTS: readonly string[] = [];
+const NESTED_INTERACTIVE_SELECTOR = [
+  "a[href]",
+  "button",
+  "input",
+  "textarea",
+  "select",
+  "summary",
+  "audio",
+  "video",
+  "img",
+  "[aria-label='attachment']",
+  "[aria-label$='attachments']",
+  "[contenteditable='true']",
+  "[role='button']",
+  "[role='link']",
+  "[role='menuitem']",
+  "[role='checkbox']",
+  "[role='radio']",
+  "[role='switch']",
+  "[role='img']",
+  "[data-post-card-interactive='true']",
+].join(",");
 
 function getDepthClass(depth?: number): string {
   if (depth === undefined) return "";
   return depthClasses[Math.min(depth, 3)] ?? depthClasses[3];
+}
+
+function getEventElement(target: EventTarget | null): Element | null {
+  if (target instanceof Element) return target;
+  if (target instanceof Node) return target.parentElement;
+  return null;
+}
+
+function isNestedInteractiveTarget(
+  target: EventTarget | null,
+  currentTarget: Element,
+): boolean {
+  const targetElement = getEventElement(target);
+  const nestedTarget = targetElement?.closest(NESTED_INTERACTIVE_SELECTOR);
+
+  return Boolean(
+    nestedTarget &&
+      nestedTarget !== currentTarget &&
+      currentTarget.contains(nestedTarget),
+  );
 }
 
 export function PostCard({
@@ -82,14 +124,46 @@ export function PostCard({
     navigate(buildThreadPath(event.id, relayHints));
   }, [event, onOpenThread, relatedEvents, relayHints, navigate]);
 
+  const handleCardClick = useCallback(
+    (clickEvent: MouseEvent<HTMLElement>) => {
+      if (!isNavigable) return;
+      if (clickEvent.defaultPrevented || clickEvent.button !== 0) return;
+      if (clickEvent.metaKey || clickEvent.altKey || clickEvent.ctrlKey || clickEvent.shiftKey) {
+        return;
+      }
+      if (isNestedInteractiveTarget(clickEvent.target, clickEvent.currentTarget)) return;
+
+      handleNavigate();
+    },
+    [handleNavigate, isNavigable],
+  );
+
+  const handleCardKeyDown = useCallback(
+    (keyEvent: KeyboardEvent<HTMLElement>) => {
+      if (!isNavigable || keyEvent.defaultPrevented || keyEvent.key !== "Enter") return;
+      if (isNestedInteractiveTarget(keyEvent.target, keyEvent.currentTarget)) return;
+
+      keyEvent.preventDefault();
+      handleNavigate();
+    },
+    [handleNavigate, isNavigable],
+  );
+
   const roleClass = role === "threadContext" ? "opacity-70" : "";
+  const ariaLabel = isNavigable
+    ? `Open thread by ${authorLabel}, signal ${signal}, ${timestamp}`
+    : `Post by ${authorLabel}, signal ${signal}, ${timestamp}`;
 
   return (
     <article
-      role="group"
-      aria-label={`Post by ${authorLabel}, signal ${signal}, ${timestamp}`}
+      role={isNavigable ? "link" : "group"}
+      tabIndex={isNavigable ? 0 : undefined}
+      aria-label={ariaLabel}
+      onClick={handleCardClick}
+      onKeyDown={handleCardKeyDown}
       className={[
         "group py-4 border-b border-ghost",
+        isNavigable ? "post-card--openable" : "",
         roleClass,
         getDepthClass(depth),
         animate ? "motion-safe:animate-resolve-in" : "",
@@ -121,7 +195,6 @@ export function PostCard({
         signal={signal}
         replyCount={displayedReplyCount}
         timestamp={timestamp}
-        onOpenThread={isNavigable ? handleNavigate : undefined}
         forceSecondary={role === "threadOp"}
       />
     </article>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -106,6 +106,25 @@ body {
   transform: translateY(1px) scale(0.98);
 }
 
+.post-card--openable {
+  cursor: pointer;
+  border-radius: 0.125rem;
+  touch-action: manipulation;
+  transition:
+    background-color var(--duration-hover) var(--ease-out),
+    box-shadow var(--duration-focus) var(--ease-out),
+    transform var(--duration-hover) var(--ease-out);
+}
+
+.post-card--openable:active {
+  background-color: rgba(255, 255, 255, 0.045);
+  transform: translateY(1px);
+}
+
+.post-card--openable:focus-visible {
+  background-color: rgba(255, 255, 255, 0.035);
+}
+
 .noise-overlay {
   position: fixed;
   inset: 0;
@@ -155,6 +174,10 @@ body {
   .group:hover .metadata-row:not(.metadata-row--secondary),
   .group:focus-within .metadata-row:not(.metadata-row--secondary) {
     color: var(--text-secondary);
+  }
+
+  .post-card--openable:hover {
+    background-color: rgba(255, 255, 255, 0.025);
   }
 }
 


### PR DESCRIPTION
## Summary
- Make navigable post cards act as a full-card thread link with Enter-key support.
- Add hover, focus, and press feedback for the card/open affordance.
- Guard nested links, media, controls, and interactive roles from accidentally opening the parent thread.

## Tests
- npm test -- src/shared/ui/PostCard.test.tsx
- npm run typecheck
- npm run lint
- npm test