### PR TITLE
Improve compose transmit feedback

### DIFF
--- a/src/features/compose/PostForm.test.tsx
+++ b/src/features/compose/PostForm.test.tsx
@@ -87,6 +87,29 @@ describe("PostForm", () => {
     expect(container.textContent).toContain("estimated mine time ~12s");
   });
 
+  it("does not duplicate the PoW ETA while mining", () => {
+    mocks.useSubmitForm.mockReturnValue({
+      handleSubmit: mocks.handleSubmit,
+      doingWorkProp: true,
+      submitStatus: "mining",
+      submitError: null,
+      acceptedRelays: [],
+      hashrate: 10,
+      bestPow: 17,
+      signedPoWEvent: undefined,
+      powEta: "52m 20s",
+      willUseWiredAccount: false,
+    });
+
+    act(() => {
+      root.render(<PostForm />);
+    });
+
+    expect(container.textContent).not.toContain("estimated mine time");
+    expect(container.textContent).toContain("mining signal");
+    expect(container.textContent).toContain("pb:17");
+  });
+
   it("shows a visible first-use compose affordance", () => {
     act(() => {
       root.render(<PostForm />);

--- a/src/features/compose/PostForm.test.tsx
+++ b/src/features/compose/PostForm.test.tsx
@@ -8,6 +8,7 @@ import { PostForm } from "./PostForm";
 type ReactActGlobal = typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
 
 const mocks = vi.hoisted(() => ({
+  handleSubmit: vi.fn(),
   useSubmitForm: vi.fn(),
 }));
 
@@ -53,8 +54,10 @@ describe("PostForm", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+    mocks.handleSubmit.mockReset();
+    mocks.handleSubmit.mockResolvedValue(undefined);
     mocks.useSubmitForm.mockReturnValue({
-      handleSubmit: vi.fn(),
+      handleSubmit: mocks.handleSubmit,
       doingWorkProp: false,
       submitStatus: "idle",
       submitError: null,
@@ -82,5 +85,63 @@ describe("PostForm", () => {
 
     expect(container.textContent).toContain("signal");
     expect(container.textContent).toContain("estimated mine time ~12s");
+  });
+
+  it("shows a visible first-use compose affordance", () => {
+    act(() => {
+      root.render(<PostForm />);
+    });
+
+    const label = container.querySelector("label");
+    const textarea = container.querySelector("textarea");
+
+    expect(label?.textContent).toBe("Write a note");
+    expect(textarea?.getAttribute("placeholder")).toBe("Share a note with the network");
+    expect(textarea?.id).toBe(label?.getAttribute("for"));
+  });
+
+  it("keeps empty transmits local and focuses the composer with feedback", async () => {
+    act(() => {
+      root.render(<PostForm />);
+    });
+
+    await act(async () => {
+      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    const textarea = container.querySelector("textarea");
+    const message = container.querySelector("[role='status']");
+
+    expect(mocks.handleSubmit).not.toHaveBeenCalled();
+    expect(message?.textContent).toBe("Write something before transmitting.");
+    expect(textarea?.getAttribute("aria-invalid")).toBe("true");
+    expect(textarea?.getAttribute("aria-describedby")).toBe(message?.id);
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it("delegates non-empty transmits to the submit hook", async () => {
+    act(() => {
+      root.render(<PostForm />);
+    });
+
+    const textarea = container.querySelector("textarea");
+    act(() => {
+      if (!textarea) throw new Error("missing textarea");
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      valueSetter?.call(textarea, "hello wired");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      textarea.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    await act(async () => {
+      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.handleSubmit).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/compose/PostForm.test.tsx
+++ b/src/features/compose/PostForm.test.tsx
@@ -107,7 +107,8 @@ describe("PostForm", () => {
 
     expect(container.textContent).not.toContain("estimated mine time");
     expect(container.textContent).toContain("mining signal");
-    expect(container.textContent).toContain("pb:17");
+    expect(container.textContent).toContain("ETA");
+    expect(container.textContent).toContain("best signal 17");
   });
 
   it("shows a visible first-use compose affordance", () => {

--- a/src/features/compose/PostForm.tsx
+++ b/src/features/compose/PostForm.tsx
@@ -62,6 +62,7 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
     willUseWiredAccount,
   } =
     useSubmitForm(unsigned, difficulty);
+  const showPowEta = !doingWorkProp && submitStatus !== "published";
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -132,7 +133,9 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
               min={16}
               active={willUseWiredAccount}
             />
-            <p className="text-meta text-secondary">estimated mine time ~{powEta}</p>
+            {showPowEta && (
+              <p className="text-meta text-secondary">estimated mine time ~{powEta}</p>
+            )}
           </div>
           <div className="flex items-center gap-3">
             <CustomEmojiPicker onSelect={handleEmojiSelect} />

--- a/src/features/compose/PostForm.tsx
+++ b/src/features/compose/PostForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useId, useMemo, useRef } from "react";
 import { Event as NostrEvent } from "nostr-tools";
 import { useSubmitForm } from "../../shared/hooks/useSubmitForm";
 import { buildUnsignedEvent, type CustomEmojiTag } from "./buildUnsignedEvent";
@@ -23,8 +23,11 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
   const openThread = useThreadNavigation();
   const [comment, setComment] = useState("");
   const [difficulty, setDifficulty] = useState(String(settings.difficulty));
+  const [emptySubmitMessage, setEmptySubmitMessage] = useState("");
   const [selectedEmojis, setSelectedEmojis] = useState<CustomEmojiTag[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const emptySubmitMessageId = useId();
+  const composerLabel = tagType === "Reply" ? "Write a reply" : tagType === "Quote" ? "Add your quote" : "Write a note";
 
   const activeEmojiTags = useMemo(
     () => selectedEmojis.filter((emoji) => comment.includes(`:${emoji.shortcode}:`)),
@@ -64,9 +67,12 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
     event.preventDefault();
 
     if (comment.trim() === "") {
+      setEmptySubmitMessage("Write something before transmitting.");
+      textareaRef.current?.focus();
       return;
     }
 
+    setEmptySubmitMessage("");
     await originalHandleSubmit(event);
   };
 
@@ -102,9 +108,16 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
           ref={textareaRef}
           name="com"
           variant="compose"
+          label={composerLabel}
+          placeholder="Share a note with the network"
           value={comment}
+          aria-invalid={emptySubmitMessage ? true : undefined}
+          aria-describedby={emptySubmitMessage ? emptySubmitMessageId : undefined}
           onChange={(e) => {
             setComment(e.target.value);
+            if (e.target.value.trim()) {
+              setEmptySubmitMessage("");
+            }
             e.target.style.height = "auto";
             e.target.style.height = `${e.target.scrollHeight}px`;
           }}
@@ -128,20 +141,21 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
             </Button>
           </div>
         </div>
+        {emptySubmitMessage && (
+          <p id={emptySubmitMessageId} className="text-danger text-meta text-right" role="status">
+            {emptySubmitMessage}
+          </p>
+        )}
         <PowTransmitStatus
-          active={doingWorkProp}
+          active={doingWorkProp || submitStatus === "published"}
           difficulty={difficulty}
           hashrate={hashrate}
           bestPow={bestPow}
           status={submitStatus}
+          acceptedRelayCount={acceptedRelays.length}
           className="text-right"
         />
         {submitError && <p className="text-danger text-meta text-right">{submitError}</p>}
-        {submitStatus === "published" && acceptedRelays.length > 0 && (
-          <p className="text-meta text-secondary text-right">
-            posted to {acceptedRelays.length} relay{acceptedRelays.length === 1 ? "" : "s"}
-          </p>
-        )}
         {signedPoWEvent && (
           <PostCard
             event={signedPoWEvent}

--- a/src/shared/ui/PowTransmitStatus.test.tsx
+++ b/src/shared/ui/PowTransmitStatus.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import type { ComponentProps } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { PowTransmitStatus } from "./PowTransmitStatus";
+
+type ReactActGlobal = typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+describe("PowTransmitStatus", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function renderStatus(props: Partial<ComponentProps<typeof PowTransmitStatus>> = {}) {
+    act(() => {
+      root.render(
+        <PowTransmitStatus
+          active={false}
+          difficulty="1"
+          hashrate={10}
+          {...props}
+        />,
+      );
+    });
+  }
+
+  it("describes mining progress while work is active", () => {
+    renderStatus({ active: true, status: "mining", bestPow: 4 });
+
+    expect(container.querySelector("[role='status']")?.textContent).toContain("mining signal");
+    expect(container.querySelector("[role='status']")?.textContent).toContain("pb:4");
+  });
+
+  it("describes relay publishing", () => {
+    renderStatus({ active: true, status: "publishing" });
+
+    expect(container.querySelector("[role='status']")?.textContent).toBe("publishing to relays…");
+  });
+
+  it("keeps the posted state visible after active work ends", () => {
+    renderStatus({ active: false, status: "published", acceptedRelayCount: 2 });
+
+    expect(container.querySelector("[role='status']")?.textContent).toBe("posted to 2 relays");
+  });
+});

--- a/src/shared/ui/PowTransmitStatus.test.tsx
+++ b/src/shared/ui/PowTransmitStatus.test.tsx
@@ -50,7 +50,8 @@ describe("PowTransmitStatus", () => {
     renderStatus({ active: true, status: "mining", bestPow: 4 });
 
     expect(container.querySelector("[role='status']")?.textContent).toContain("mining signal");
-    expect(container.querySelector("[role='status']")?.textContent).toContain("pb:4");
+    expect(container.querySelector("[role='status']")?.textContent).toContain("ETA");
+    expect(container.querySelector("[role='status']")?.textContent).toContain("best signal 4");
   });
 
   it("describes relay publishing", () => {

--- a/src/shared/ui/PowTransmitStatus.tsx
+++ b/src/shared/ui/PowTransmitStatus.tsx
@@ -42,8 +42,8 @@ export function PowTransmitStatus({
 
   return (
     <p className={classes} role="status">
-      mining signal… ~{timeToGoEst(String(difficulty), hashrate)}
-      {bestPow > 0 ? ` · pb:${bestPow}` : ""}
+      mining signal… ETA ~{timeToGoEst(String(difficulty), hashrate)}
+      {bestPow > 0 ? ` · best signal ${bestPow}` : ""}
     </p>
   );
 }

--- a/src/shared/ui/PowTransmitStatus.tsx
+++ b/src/shared/ui/PowTransmitStatus.tsx
@@ -7,6 +7,7 @@ interface PowTransmitStatusProps {
   hashrate: number;
   bestPow?: number;
   status?: SubmitStatus;
+  acceptedRelayCount?: number;
   className?: string;
 }
 
@@ -16,21 +17,32 @@ export function PowTransmitStatus({
   hashrate,
   bestPow = 0,
   status = "mining",
+  acceptedRelayCount = 0,
   className,
 }: PowTransmitStatusProps) {
+  const classes = `text-meta text-secondary ${className ?? ""}`.trim();
+
+  if (status === "published") {
+    return (
+      <p className={classes} role="status">
+        posted to {acceptedRelayCount} relay{acceptedRelayCount === 1 ? "" : "s"}
+      </p>
+    );
+  }
+
   if (!active) return null;
 
   if (status === "publishing") {
     return (
-      <p className={`text-meta text-secondary ${className ?? ""}`.trim()} role="status">
+      <p className={classes} role="status">
         publishing to relays…
       </p>
     );
   }
 
   return (
-    <p className={`text-meta text-secondary ${className ?? ""}`.trim()} role="status">
-      computing signal… ~{timeToGoEst(String(difficulty), hashrate)}
+    <p className={classes} role="status">
+      mining signal… ~{timeToGoEst(String(difficulty), hashrate)}
       {bestPow > 0 ? ` · pb:${bestPow}` : ""}
     </p>
   );


### PR DESCRIPTION
## Summary
- add a visible compose label and placeholder for first-use affordance
- show focused empty-submit feedback without starting mining/publish work
- keep mining, publishing, and posted relay feedback attached to the transmit area

## Tests
- npm test -- src/features/compose/PostForm.test.tsx src/shared/ui/PowTransmitStatus.test.tsx
- npm run typecheck
- npm test