### PR TITLE
Add feed status and throttle relay fetches

### DIFF
--- a/src/app/FeedStatusIndicatorProvider.tsx
+++ b/src/app/FeedStatusIndicatorProvider.tsx
@@ -1,0 +1,17 @@
+import { useMemo, useState, type ReactNode } from "react";
+import type { FeedStatusKind } from "../hooks/useFeed";
+import { FeedStatusIndicatorContext } from "./feedStatusIndicator";
+
+export function FeedStatusIndicatorProvider({ children }: { children: ReactNode }) {
+  const [statusKind, setStatusKind] = useState<FeedStatusKind | undefined>();
+  const value = useMemo(
+    () => ({ statusKind, setStatusKind }),
+    [statusKind],
+  );
+
+  return (
+    <FeedStatusIndicatorContext.Provider value={value}>
+      {children}
+    </FeedStatusIndicatorContext.Provider>
+  );
+}

--- a/src/app/feedStatusIndicator.ts
+++ b/src/app/feedStatusIndicator.ts
@@ -1,0 +1,26 @@
+import { createContext, useContext, useEffect } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import type { FeedStatusKind } from "../hooks/useFeed";
+
+export type FeedStatusIndicatorContextValue = {
+  statusKind?: FeedStatusKind;
+  setStatusKind: Dispatch<SetStateAction<FeedStatusKind | undefined>>;
+};
+
+export const FeedStatusIndicatorContext = createContext<FeedStatusIndicatorContextValue>({
+  statusKind: undefined,
+  setStatusKind: () => {},
+});
+
+export function useFeedStatusIndicator(): FeedStatusIndicatorContextValue {
+  return useContext(FeedStatusIndicatorContext);
+}
+
+export function useHeaderFeedStatus(statusKind: FeedStatusKind) {
+  const { setStatusKind } = useFeedStatusIndicator();
+
+  useEffect(() => {
+    setStatusKind(statusKind);
+    return () => setStatusKind(undefined);
+  }, [setStatusKind, statusKind]);
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 import { closeAllSubscriptions, initNostr, isNostrReady } from "../nostr/client";
+import { FeedStatusIndicatorProvider } from "./FeedStatusIndicatorProvider";
 import { SettingsProvider } from "./settings";
 
 type NostrContextValue = {
@@ -40,7 +41,9 @@ export function useNostrReady(): boolean {
 export function AppProviders({ children }: { children: ReactNode }) {
   return (
     <SettingsProvider>
-      <NostrProvider>{children}</NostrProvider>
+      <FeedStatusIndicatorProvider>
+        <NostrProvider>{children}</NostrProvider>
+      </FeedStatusIndicatorProvider>
     </SettingsProvider>
   );
 }

--- a/src/features/feed/FeedPage.tsx
+++ b/src/features/feed/FeedPage.tsx
@@ -7,6 +7,8 @@ import { PostCard } from "../../shared/ui/PostCard";
 import { FeedSortToggle } from "./FeedSortToggle";
 import { ContentColumn, PageShell } from "../../shared/ui/PageShell";
 import { useThreadNavigation } from "../thread/useThreadNavigation";
+import { Placeholder } from "../../shared/ui/Placeholder";
+import type { FeedStatus, FeedStatusKind } from "../../hooks/useFeed";
 
 const SKIP_RESOLVE_COUNT = 3;
 const INITIAL_RESOLVE_COUNT = 20;
@@ -17,9 +19,37 @@ type FeedPageProps = {
   mode?: "default" | "raw";
 };
 
+const statusToneClass: Record<FeedStatusKind, string> = {
+  snapshot: "border-ghost text-secondary",
+  live: "border-signal-ghost text-signal",
+  syncing: "border-ghost text-secondary",
+  degraded: "border-danger-dim text-danger",
+  empty: "border-ghost text-muted",
+};
+
+function FeedStatusBanner({ status }: { status: FeedStatus }) {
+  return (
+    <div
+      className={[
+        "mb-3 flex min-h-9 items-center justify-between gap-3 border px-3 py-2 text-meta",
+        statusToneClass[status.kind],
+      ].join(" ")}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="uppercase [letter-spacing:var(--letter-spacing-meta)]">
+        {status.label}
+      </span>
+      <span className="min-w-0 truncate text-right text-muted">
+        {status.detail}
+      </span>
+    </div>
+  );
+}
+
 export default function FeedPage({ mode = "default" }: FeedPageProps) {
   const { settings, updateSettings } = useSettings();
-  const { processedEvents } = useFeed({ mode });
+  const { processedEvents, feedStatus } = useFeed({ mode });
   const visibleCount = useInfiniteScroll();
   const openThread = useThreadNavigation();
   const [resolveWindowOpen, setResolveWindowOpen] = useState(true);
@@ -55,7 +85,10 @@ export default function FeedPage({ mode = "default" }: FeedPageProps) {
         </div>
       </div>
       <ContentColumn>
-        {sortedEvents.slice(0, visibleCount).map((event, index) => {
+        <FeedStatusBanner status={feedStatus} />
+        {sortedEvents.length === 0 ? (
+          <Placeholder message={feedStatus.detail} />
+        ) : sortedEvents.slice(0, visibleCount).map((event, index) => {
           const shouldResolve =
             resolveWindowOpen &&
             index >= SKIP_RESOLVE_COUNT &&

--- a/src/features/feed/FeedPage.tsx
+++ b/src/features/feed/FeedPage.tsx
@@ -8,7 +8,7 @@ import { FeedSortToggle } from "./FeedSortToggle";
 import { ContentColumn, PageShell } from "../../shared/ui/PageShell";
 import { useThreadNavigation } from "../thread/useThreadNavigation";
 import { Placeholder } from "../../shared/ui/Placeholder";
-import type { FeedStatus, FeedStatusKind } from "../../hooks/useFeed";
+import { useHeaderFeedStatus } from "../../app/feedStatusIndicator";
 
 const SKIP_RESOLVE_COUNT = 3;
 const INITIAL_RESOLVE_COUNT = 20;
@@ -19,40 +19,13 @@ type FeedPageProps = {
   mode?: "default" | "raw";
 };
 
-const statusToneClass: Record<FeedStatusKind, string> = {
-  snapshot: "border-ghost text-secondary",
-  live: "border-signal-ghost text-signal",
-  syncing: "border-ghost text-secondary",
-  degraded: "border-danger-dim text-danger",
-  empty: "border-ghost text-muted",
-};
-
-function FeedStatusBanner({ status }: { status: FeedStatus }) {
-  return (
-    <div
-      className={[
-        "mb-3 flex min-h-9 items-center justify-between gap-3 border px-3 py-2 text-meta",
-        statusToneClass[status.kind],
-      ].join(" ")}
-      role="status"
-      aria-live="polite"
-    >
-      <span className="uppercase [letter-spacing:var(--letter-spacing-meta)]">
-        {status.label}
-      </span>
-      <span className="min-w-0 truncate text-right text-muted">
-        {status.detail}
-      </span>
-    </div>
-  );
-}
-
 export default function FeedPage({ mode = "default" }: FeedPageProps) {
   const { settings, updateSettings } = useSettings();
   const { processedEvents, feedStatus } = useFeed({ mode });
   const visibleCount = useInfiniteScroll();
   const openThread = useThreadNavigation();
   const [resolveWindowOpen, setResolveWindowOpen] = useState(true);
+  useHeaderFeedStatus(feedStatus.kind);
 
   useEffect(() => {
     const timer = setTimeout(
@@ -85,7 +58,6 @@ export default function FeedPage({ mode = "default" }: FeedPageProps) {
         </div>
       </div>
       <ContentColumn>
-        <FeedStatusBanner status={feedStatus} />
         {sortedEvents.length === 0 ? (
           <Placeholder message={feedStatus.detail} />
         ) : sortedEvents.slice(0, visibleCount).map((event, index) => {

--- a/src/hooks/useFeed.test.ts
+++ b/src/hooks/useFeed.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Event } from "nostr-tools";
 import type { ProcessedEvent } from "../nostr/types";
-import { mergeProcessedFeedEvents } from "./useFeed";
+import { deriveFeedStatus, mergeProcessedFeedEvents } from "./useFeed";
 
 vi.mock("../shared/pow/core", () => ({
   verifyPow: (event: Event) =>
@@ -169,5 +169,77 @@ describe("mergeProcessedFeedEvents", () => {
       totalWork: Math.pow(2, 20) + 1,
     });
     expect(result[1]).toEqual(newLiveRow);
+  });
+});
+
+describe("deriveFeedStatus", () => {
+  it("reports syncing before relays or snapshots have resolved", () => {
+    expect(
+      deriveFeedStatus({
+        processedCount: 0,
+        bootstrapEligible: true,
+        bootstrapLoadState: "loading",
+        bootstrapProcessedCount: 0,
+        liveEventCount: 0,
+        liveInitialEose: false,
+        relayWaitElapsed: false,
+      }).kind,
+    ).toBe("syncing");
+  });
+
+  it("reports snapshot while bootstrap rows are visible before live updates", () => {
+    expect(
+      deriveFeedStatus({
+        processedCount: 4,
+        bootstrapEligible: true,
+        bootstrapLoadState: "loaded",
+        bootstrapProcessedCount: 4,
+        liveEventCount: 0,
+        liveInitialEose: false,
+        relayWaitElapsed: false,
+      }).kind,
+    ).toBe("snapshot");
+  });
+
+  it("reports live once relay events arrive", () => {
+    expect(
+      deriveFeedStatus({
+        processedCount: 4,
+        bootstrapEligible: true,
+        bootstrapLoadState: "loaded",
+        bootstrapProcessedCount: 4,
+        liveEventCount: 1,
+        liveInitialEose: false,
+        relayWaitElapsed: false,
+      }).kind,
+    ).toBe("live");
+  });
+
+  it("reports degraded when visible snapshot rows outlive relay response", () => {
+    expect(
+      deriveFeedStatus({
+        processedCount: 4,
+        bootstrapEligible: true,
+        bootstrapLoadState: "loaded",
+        bootstrapProcessedCount: 4,
+        liveEventCount: 0,
+        liveInitialEose: false,
+        relayWaitElapsed: true,
+      }).kind,
+    ).toBe("degraded");
+  });
+
+  it("reports empty after the initial relay query completes without rows", () => {
+    expect(
+      deriveFeedStatus({
+        processedCount: 0,
+        bootstrapEligible: false,
+        bootstrapLoadState: "disabled",
+        bootstrapProcessedCount: 0,
+        liveEventCount: 0,
+        liveInitialEose: true,
+        relayWaitElapsed: false,
+      }).kind,
+    ).toBe("empty");
   });
 });

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -28,8 +28,33 @@ import {
 } from "../shared/lib/feedBootstrapClient";
 
 const FEED_REPLY_DEPTH = 3;
+const FEED_RELAY_DEGRADED_AFTER_MS = 8000;
 
 type FeedMode = "default" | "raw";
+type FeedBootstrapLoadState = "disabled" | "loading" | "loaded" | "error";
+
+export type FeedStatusKind =
+  | "snapshot"
+  | "live"
+  | "syncing"
+  | "degraded"
+  | "empty";
+
+export type FeedStatus = {
+  kind: FeedStatusKind;
+  label: string;
+  detail: string;
+};
+
+type FeedStatusInput = {
+  processedCount: number;
+  bootstrapEligible: boolean;
+  bootstrapLoadState: FeedBootstrapLoadState;
+  bootstrapProcessedCount: number;
+  liveEventCount: number;
+  liveInitialEose: boolean;
+  relayWaitElapsed: boolean;
+};
 
 function mergeNoteEvents(...eventGroups: Event[][]): Event[] {
   const merged = new Map<string, Event>();
@@ -67,6 +92,80 @@ function eventsFromProcessedFeedEvents(processedEvents: ProcessedEvent[]): Event
   });
 
   return events;
+}
+
+export function deriveFeedStatus({
+  processedCount,
+  bootstrapEligible,
+  bootstrapLoadState,
+  bootstrapProcessedCount,
+  liveEventCount,
+  liveInitialEose,
+  relayWaitElapsed,
+}: FeedStatusInput): FeedStatus {
+  if (liveEventCount > 0) {
+    return {
+      kind: "live",
+      label: "live",
+      detail: "relay updates are flowing",
+    };
+  }
+
+  if (processedCount === 0) {
+    if (liveInitialEose) {
+      return {
+        kind: "empty",
+        label: "empty",
+        detail: "no qualifying feed events found",
+      };
+    }
+
+    if (bootstrapLoadState === "error" || relayWaitElapsed) {
+      return {
+        kind: "degraded",
+        label: "degraded",
+        detail: "relays are slow or unavailable",
+      };
+    }
+
+    return {
+      kind: "syncing",
+      label: "syncing",
+      detail: "checking relays for recent work",
+    };
+  }
+
+  if (bootstrapEligible && bootstrapProcessedCount > 0) {
+    if (!liveInitialEose && relayWaitElapsed) {
+      return {
+        kind: "degraded",
+        label: "degraded",
+        detail: "showing snapshot while relays catch up",
+      };
+    }
+
+    return {
+      kind: "snapshot",
+      label: "snapshot",
+      detail: liveInitialEose
+        ? "latest relay check is complete"
+        : "checking relays for live updates",
+    };
+  }
+
+  if (!liveInitialEose && relayWaitElapsed) {
+    return {
+      kind: "degraded",
+      label: "degraded",
+      detail: "relays are slow or unavailable",
+    };
+  }
+
+  return {
+    kind: "syncing",
+    label: "syncing",
+    detail: "checking relays for recent work",
+  };
 }
 
 function isProcessedEventModerated(
@@ -137,6 +236,12 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
   const moderationManifest = useModerationManifest();
   const isRawMode = mode === "raw";
   const bootstrapEligible = !isRawMode && canUseFeedBootstrap(settings);
+  const [bootstrapLoadState, setBootstrapLoadState] =
+    useState<FeedBootstrapLoadState>(
+      bootstrapEligible ? "loading" : "disabled",
+    );
+  const [liveInitialEose, setLiveInitialEose] = useState(false);
+  const [relayWaitElapsed, setRelayWaitElapsed] = useState(false);
   const [bootstrapProcessedEvents, setBootstrapProcessedEvents] = useState<ProcessedEvent[]>([]);
   const [bootstrapEvents, setBootstrapEvents] = useState<Event[]>([]);
   const [bootstrapRootIds, setBootstrapRootIds] = useState<string[]>([]);
@@ -145,6 +250,7 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
 
   useEffect(() => {
     if (!bootstrapEligible) {
+      setBootstrapLoadState("disabled");
       setBootstrapProcessedEvents([]);
       setBootstrapEvents([]);
       setBootstrapRootIds([]);
@@ -153,11 +259,13 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
     }
 
     let cancelled = false;
+    setBootstrapLoadState("loading");
 
     void loadFeedBootstrapSnapshot()
       .then((snapshot) => {
         if (cancelled) return;
         if (!snapshot) {
+          setBootstrapLoadState("loaded");
           setBootstrapProcessedEvents([]);
           setBootstrapEvents([]);
           setBootstrapRootIds([]);
@@ -173,10 +281,12 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
         setBootstrapRootIds(
           processedEvents.map((event) => event.postEvent.id),
         );
+        setBootstrapLoadState("loaded");
         seedProfiles(snapshot.profiles);
       })
       .catch(() => {
         // Fall back to live relay subscription only.
+        setBootstrapLoadState("error");
         setBootstrapProcessedEvents([]);
         setBootstrapEvents([]);
         setBootstrapRootIds([]);
@@ -188,6 +298,18 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
     };
   }, [bootstrapEligible, settings.ageHours, settings.filterDifficulty]);
 
+  useEffect(() => {
+    setLiveInitialEose(false);
+    setRelayWaitElapsed(false);
+
+    const timer = window.setTimeout(
+      () => setRelayWaitElapsed(true),
+      FEED_RELAY_DEGRADED_AFTER_MS,
+    );
+
+    return () => window.clearTimeout(timer);
+  }, [mode, settings.ageHours, settings.filterDifficulty]);
+
   const subscribe = useCallback(
     (onEvent: Parameters<typeof subGlobalFeed>[0]) =>
       subGlobalFeed(
@@ -198,6 +320,7 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
           replyRelayUrls: THREAD_RELAYS,
           rootFilterDifficulty: settings.filterDifficulty,
           replyDepth: FEED_REPLY_DEPTH,
+          onInitialEose: () => setLiveInitialEose(true),
         },
       ),
     [settings.ageHours, settings.filterDifficulty],
@@ -300,6 +423,27 @@ export function useFeed({ mode = "default" }: { mode?: FeedMode } = {}) {
       liveProcessedEvents,
     ],
   );
+  const feedStatus = useMemo(
+    () =>
+      deriveFeedStatus({
+        processedCount: processedEvents.length,
+        bootstrapEligible,
+        bootstrapLoadState,
+        bootstrapProcessedCount: visibleBootstrapProcessedEvents.length,
+        liveEventCount: liveEvents.length,
+        liveInitialEose,
+        relayWaitElapsed,
+      }),
+    [
+      processedEvents.length,
+      bootstrapEligible,
+      bootstrapLoadState,
+      visibleBootstrapProcessedEvents.length,
+      liveEvents.length,
+      liveInitialEose,
+      relayWaitElapsed,
+    ],
+  );
 
-  return { processedEvents, noteEvents: visibleNoteEvents };
+  return { processedEvents, noteEvents: visibleNoteEvents, feedStatus };
 }

--- a/src/nostr/subscriptions/global-feed.test.ts
+++ b/src/nostr/subscriptions/global-feed.test.ts
@@ -15,7 +15,12 @@ vi.mock("../client", () => ({
   }),
 }));
 
-import { subGlobalFeed, subRepliesForRootIds } from "./global-feed";
+import {
+  FEED_REPLY_PARENT_CHUNK_SIZE,
+  FEED_ROOT_FETCH_CHUNK_SIZE,
+  subGlobalFeed,
+  subRepliesForRootIds,
+} from "./global-feed";
 
 const rootNote = (id: string): Event => ({
   id,
@@ -387,9 +392,13 @@ describe("subGlobalFeed", () => {
       String(index).padStart(64, "0"),
     );
 
+    const firstLevelChunkCount = Math.ceil(
+      MAX_REPLY_PARENT_IDS / FEED_REPLY_PARENT_CHUNK_SIZE,
+    );
+
     subscribeMock.mockImplementation((requests) => {
       const id = String(subscribeMock.mock.calls.length);
-      if (Number(id) <= MAX_REPLY_FETCH_DEPTH) {
+      if (Number(id) <= firstLevelChunkCount + 1) {
         const { cb, onEose } = requests[0];
         cb(rootNote(String(Number(id)).repeat(64)), "wss://relay.damus.io");
         onEose?.();
@@ -399,14 +408,75 @@ describe("subGlobalFeed", () => {
 
     subRepliesForRootIds(rootIds, vi.fn(), { depth: MAX_REPLY_FETCH_DEPTH + 3 });
 
-    expect(subscribeMock).toHaveBeenCalledTimes(MAX_REPLY_FETCH_DEPTH);
+    expect(subscribeMock).toHaveBeenCalledTimes(firstLevelChunkCount + 1);
     const firstReplyRequest = subscribeMock.mock.calls[0][0][0];
-    expect(firstReplyRequest.filter["#e"]).toHaveLength(MAX_REPLY_PARENT_IDS);
+    expect(firstReplyRequest.filter["#e"]).toHaveLength(
+      FEED_REPLY_PARENT_CHUNK_SIZE,
+    );
     expect(firstReplyRequest.filter).toMatchObject({
       kinds: [1],
       limit: REPLY_QUERY_LIMIT,
       since: expect.any(Number),
     });
+  });
+
+  it("opens reply parent chunks sequentially", () => {
+    const rootIds = Array.from(
+      { length: FEED_REPLY_PARENT_CHUNK_SIZE + 5 },
+      (_, index) => String(index).padStart(64, "0"),
+    );
+
+    subscribeMock.mockImplementation(() => {
+      const id = String(subscribeMock.mock.calls.length);
+      return { id, close: vi.fn() };
+    });
+
+    subRepliesForRootIds(rootIds, vi.fn());
+
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+    expect(subscribeMock.mock.calls[0][0][0].filter["#e"]).toHaveLength(
+      FEED_REPLY_PARENT_CHUNK_SIZE,
+    );
+
+    subscribeMock.mock.calls[0][0][0].onEose?.();
+
+    expect(subscribeMock).toHaveBeenCalledTimes(2);
+    expect(subscribeMock.mock.calls[1][0][0].filter["#e"]).toHaveLength(5);
+  });
+
+  it("fetches missing root ids in sequential chunks", () => {
+    const rootIds = Array.from(
+      { length: FEED_ROOT_FETCH_CHUNK_SIZE + 3 },
+      (_, index) => String(index + 1).padStart(64, "0"),
+    );
+    const replies = rootIds.map((rootId, index) => ({
+      ...rootNote(String(index + 100).padStart(64, "0")),
+      tags: [["e", rootId, "wss://relay.example", "root"]],
+    }));
+
+    subscribeMock.mockImplementation((requests) => {
+      const id = String(subscribeMock.mock.calls.length);
+
+      if (id === "1") {
+        const { cb, onEose } = requests[0];
+        replies.forEach((reply) => cb(reply, "wss://powrelay.xyz"));
+        onEose?.();
+      }
+
+      return { id, close: vi.fn() };
+    });
+
+    subGlobalFeed(vi.fn(), 24, { rootFilterDifficulty: 0 });
+
+    expect(subscribeMock).toHaveBeenCalledTimes(2);
+    expect(subscribeMock.mock.calls[1][0][0].filter.ids).toHaveLength(
+      FEED_ROOT_FETCH_CHUNK_SIZE,
+    );
+
+    subscribeMock.mock.calls[1][0][0].onEose?.();
+
+    expect(subscribeMock).toHaveBeenCalledTimes(3);
+    expect(subscribeMock.mock.calls[2][0][0].filter.ids).toHaveLength(3);
   });
 
   it("closes reply traversal children that are added after the parent closes", () => {

--- a/src/nostr/subscriptions/global-feed.ts
+++ b/src/nostr/subscriptions/global-feed.ts
@@ -14,14 +14,19 @@ import { createSubHandleOwner } from "./utils";
 import {
   buildReplyFilter,
   clampReplyDepth,
+  limitReplyParentIds,
   sinceFromAgeHours,
 } from "./query-limits";
+
+export const FEED_REPLY_PARENT_CHUNK_SIZE = 20;
+export const FEED_ROOT_FETCH_CHUNK_SIZE = 20;
 
 type GlobalFeedOptions = {
   rootRelayUrls?: readonly string[];
   replyRelayUrls?: readonly string[];
   rootFilterDifficulty?: number;
   replyDepth?: number;
+  onInitialEose?: () => void;
 };
 
 function uniqueRelays(relays: readonly string[]): string[] {
@@ -38,6 +43,14 @@ function rootRelayUrls(
   ]);
 
   return relays.length > 0 ? relays : undefined;
+}
+
+function chunkItems<T>(items: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
 }
 
 class FeedReplyTraversal {
@@ -61,9 +74,31 @@ class FeedReplyTraversal {
   private subscribeParents(parentIds: string[], depth: number) {
     if (parentIds.length === 0 || depth <= 0) return;
 
+    const chunks = chunkItems(
+      limitReplyParentIds(parentIds),
+      FEED_REPLY_PARENT_CHUNK_SIZE,
+    );
     const childReplyIds = new Set<string>();
+    this.subscribeParentChunk(chunks, 0, childReplyIds, depth);
+  }
+
+  private subscribeParentChunk(
+    parentChunks: string[][],
+    index: number,
+    childReplyIds: Set<string>,
+    depth: number,
+  ) {
+    const parentIds = parentChunks[index];
+    if (!parentIds) {
+      this.subscribeParents(Array.from(childReplyIds), depth - 1);
+      return;
+    }
+
     const filter = buildReplyFilter(parentIds, this.since);
-    if (!filter) return;
+    if (!filter) {
+      this.subscribeParentChunk(parentChunks, index + 1, childReplyIds, depth);
+      return;
+    }
 
     this.owner.add(getRegistry().subscribe([
       {
@@ -75,7 +110,12 @@ class FeedReplyTraversal {
         },
         closeOnEose: true,
         onEose: () => {
-          this.subscribeParents(Array.from(childReplyIds), depth - 1);
+          this.subscribeParentChunk(
+            parentChunks,
+            index + 1,
+            childReplyIds,
+            depth,
+          );
         },
       },
     ]));
@@ -114,47 +154,65 @@ class FeedRootFetch {
 
     refsToFetch.forEach((ref) => this.requestedIds.add(ref.id));
 
-    {
-      const chunk = mergeFeedRootRefs(refsToFetch);
-      const ids = chunk.map((ref) => ref.id);
-      if (ids.length > 0) {
-        const nextRefs = new Map<string, FeedRootRef>();
-        const addNextRef = (ref: FeedRootRef) => {
-          const [merged] = mergeFeedRootRefs([
-            ...(nextRefs.get(ref.id) ? [nextRefs.get(ref.id)!] : []),
-            ref,
-          ]);
-          nextRefs.set(ref.id, merged);
-        };
+    const chunks = chunkItems(
+      mergeFeedRootRefs(refsToFetch),
+      FEED_ROOT_FETCH_CHUNK_SIZE,
+    );
+    this.subscribeRootChunk(chunks, 0, new Map(), depth);
+  }
 
-        this.owner.add(getRegistry().subscribe([
-          {
-            filter: {
-              ids,
-              kinds: [1],
-              limit: ids.length,
-            },
-            relayUrls: rootRelayUrls(chunk, this.fallbackRelayUrls),
-            cb: (evt, relay) => {
-              this.eventsById.set(evt.id.toLowerCase(), evt);
-              this.onEvent(evt, relay);
-
-              const nextRef = resolveFeedRootRef(evt, this.eventsById);
-              if (nextRef?.id === evt.id.toLowerCase()) {
-                this.onRootEvents([evt]);
-                return;
-              }
-
-              if (nextRef) addNextRef(nextRef);
-            },
-            closeOnEose: true,
-            onEose: () => {
-              this.start([...nextRefs.values()], depth - 1);
-            },
-          },
-        ]));
-      }
+  private subscribeRootChunk(
+    rootChunks: FeedRootRef[][],
+    index: number,
+    nextRefs: Map<string, FeedRootRef>,
+    depth: number,
+  ) {
+    const chunk = rootChunks[index];
+    if (!chunk) {
+      this.start([...nextRefs.values()], depth - 1);
+      return;
     }
+
+    const ids = chunk.map((ref) => ref.id);
+    if (ids.length === 0) {
+      this.subscribeRootChunk(rootChunks, index + 1, nextRefs, depth);
+      return;
+    }
+
+    const addNextRef = (ref: FeedRootRef) => {
+      const [merged] = mergeFeedRootRefs([
+        ...(nextRefs.get(ref.id) ? [nextRefs.get(ref.id)!] : []),
+        ref,
+      ]);
+      nextRefs.set(ref.id, merged);
+    };
+
+    this.owner.add(getRegistry().subscribe([
+      {
+        filter: {
+          ids,
+          kinds: [1],
+          limit: ids.length,
+        },
+        relayUrls: rootRelayUrls(chunk, this.fallbackRelayUrls),
+        cb: (evt, relay) => {
+          this.eventsById.set(evt.id.toLowerCase(), evt);
+          this.onEvent(evt, relay);
+
+          const nextRef = resolveFeedRootRef(evt, this.eventsById);
+          if (nextRef?.id === evt.id.toLowerCase()) {
+            this.onRootEvents([evt]);
+            return;
+          }
+
+          if (nextRef) addNextRef(nextRef);
+        },
+        closeOnEose: true,
+        onEose: () => {
+          this.subscribeRootChunk(rootChunks, index + 1, nextRefs, depth);
+        },
+      },
+    ]));
   }
 }
 
@@ -236,6 +294,7 @@ export const subGlobalFeed = (
         },
         closeOnEose: true,
         onEose: () => {
+          options.onInitialEose?.();
           const rootRefs = feedRootRefsFromQualifyingActivity(
             activityEvents,
             options.rootFilterDifficulty ?? 0,

--- a/src/shared/ui/Header.test.tsx
+++ b/src/shared/ui/Header.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { Header } from "./Header";
+
+type ReactActGlobal = typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+function LocationProbe() {
+  const { pathname } = useLocation();
+  return <span data-testid="pathname">{pathname}</span>;
+}
+
+describe("Header", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("takes users back to the main feed when signal path is clicked", () => {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={["/thread/abc"]}>
+          <Header />
+          <LocationProbe />
+        </MemoryRouter>,
+      );
+    });
+
+    const homeLink = container.querySelector<HTMLAnchorElement>(
+      "a[aria-label='go to main feed']",
+    );
+    expect(homeLink?.getAttribute("href")).toBe("/");
+    expect(container.querySelector("[data-testid='pathname']")?.textContent).toBe("/thread/abc");
+
+    act(() => {
+      homeLink?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }),
+      );
+    });
+
+    expect(container.querySelector("[data-testid='pathname']")?.textContent).toBe("/");
+  });
+});

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -1,5 +1,38 @@
 import { Link, useLocation } from "react-router-dom";
+import { useFeedStatusIndicator } from "../../app/feedStatusIndicator";
+import type { FeedStatusKind } from "../../hooks/useFeed";
 import { getPathDisplay } from "./routeLabelMap";
+
+const feedStatusIndicatorClass: Record<FeedStatusKind, string> = {
+  live: "bg-signal shadow-[0_0_8px_var(--signal-dim)]",
+  degraded: "bg-danger shadow-[0_0_8px_var(--danger-dim)]",
+  syncing: "bg-[var(--text-secondary)]",
+  snapshot: "bg-[var(--text-muted)]",
+  empty: "bg-[var(--text-ghost)]",
+};
+
+const feedStatusLabel: Record<FeedStatusKind, string> = {
+  live: "feed live",
+  degraded: "feed degraded",
+  syncing: "feed syncing",
+  snapshot: "feed snapshot",
+  empty: "feed empty",
+};
+
+function FeedStatusLed({ statusKind }: { statusKind?: FeedStatusKind }) {
+  if (!statusKind) return null;
+
+  return (
+    <span
+      className={[
+        "h-2 w-2 shrink-0 rounded-full",
+        feedStatusIndicatorClass[statusKind],
+      ].join(" ")}
+      role="status"
+      aria-label={feedStatusLabel[statusKind]}
+    />
+  );
+}
 
 function NavLink({
   to,
@@ -33,6 +66,7 @@ function NavLink({
 export function Header() {
   const { pathname } = useLocation();
   const pathDisplay = getPathDisplay(pathname);
+  const { statusKind } = useFeedStatusIndicator();
 
   return (
     <header className="mx-auto px-4 sm:px-6 lg:px-8 h-[var(--header-height)] flex items-center border-b border-ghost">
@@ -45,9 +79,10 @@ export function Header() {
       <div className="flex w-full items-center justify-between gap-4">
         <Link
           to="/"
-          className="flex min-w-0 items-center gap-1 truncate focus-visible:outline-none"
+          className="flex min-w-0 items-center gap-1.5 truncate focus-visible:outline-none"
           title={`signal ${pathDisplay}`}
         >
+          <FeedStatusLed statusKind={statusKind} />
           <span className="text-meta text-secondary shrink-0">signal</span>
           <span className="text-meta text-signal font-medium truncate border-b-2 border-signal pb-0.5">
             {pathDisplay}

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -79,6 +79,7 @@ export function Header() {
       <div className="flex w-full items-center justify-between gap-4">
         <Link
           to="/"
+          aria-label="go to main feed"
           className="flex min-w-0 items-center gap-1.5 truncate focus-visible:outline-none"
           title={`signal ${pathDisplay}`}
         >

--- a/src/shared/ui/Placeholder.tsx
+++ b/src/shared/ui/Placeholder.tsx
@@ -1,7 +1,11 @@
-export function Placeholder() {
+type PlaceholderProps = {
+  message?: string;
+};
+
+export function Placeholder({ message = "acquiring signal…" }: PlaceholderProps) {
   return (
     <p className="text-meta text-muted text-center py-8" role="status">
-      acquiring signal…
+      {message}
     </p>
   );
 }


### PR DESCRIPTION
## Summary
- expose feed status for syncing, snapshot, live, degraded, and empty states
- render the current status above the feed and show explicit empty/degraded placeholder copy
- chunk reply/root relay follow-up subscriptions sequentially to reduce concurrent REQ pressure

## Tests
- npm test -- src/hooks/useFeed.test.ts src/nostr/subscriptions/global-feed.test.ts
- npm run typecheck
- npm run lint
- npm run build