### PR TITLE
Improve settings guidance and validation

### DIFF
--- a/src/features/settings/SettingsPage.test.tsx
+++ b/src/features/settings/SettingsPage.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import SettingsPage from "./SettingsPage";
+
+type ReactActGlobal = typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+const settingsMock = vi.hoisted(() => ({
+  settings: {
+    difficulty: 20,
+    filterDifficulty: 16,
+    ageHours: 24,
+    sortByPow: true,
+  },
+  updateSettings: vi.fn(),
+}));
+
+vi.mock("../../app/settings", () => ({
+  useSettings: () => ({
+    settings: settingsMock.settings,
+    updateSettings: settingsMock.updateSettings,
+  }),
+}));
+
+describe("SettingsPage", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    settingsMock.updateSettings.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function renderPage() {
+    act(() => {
+      root.render(
+        <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+          <SettingsPage />
+        </MemoryRouter>,
+      );
+    });
+  }
+
+  function changeInput(id: string, value: string) {
+    const input = container.querySelector<HTMLInputElement>(`#${id}`);
+    const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+
+    if (!input || !valueSetter) {
+      throw new Error(`Missing input ${id}`);
+    }
+
+    act(() => {
+      valueSetter.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  function submitSettings() {
+    const form = container.querySelector("form");
+
+    if (!form) {
+      throw new Error("Missing settings form");
+    }
+
+    act(() => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+  }
+
+  it("explains each numeric setting inline", () => {
+    renderPage();
+
+    expect(container.textContent).toContain("Feed minimum");
+    expect(container.textContent).toContain("Proof mined for new posts");
+    expect(container.textContent).toContain("Feed lookback");
+  });
+
+  it("blocks invalid settings without persisting them", () => {
+    renderPage();
+
+    changeInput("filterDifficulty", "15");
+    submitSettings();
+
+    expect(container.textContent).toContain("use 16 or higher");
+    expect(container.querySelector<HTMLButtonElement>('button[type="submit"]')?.disabled).toBe(true);
+    expect(settingsMock.updateSettings).not.toHaveBeenCalled();
+  });
+
+  it("persists valid settings and confirms the save", () => {
+    renderPage();
+
+    changeInput("filterDifficulty", "18");
+    changeInput("difficulty", "21");
+    changeInput("age", "48");
+    submitSettings();
+
+    expect(settingsMock.updateSettings).toHaveBeenCalledWith({
+      filterDifficulty: 18,
+      difficulty: 21,
+      ageHours: 48,
+    });
+    expect(container.textContent).toContain("settings saved");
+  });
+});

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -5,40 +5,86 @@ import { Button } from "../../shared/ui/Button";
 import { Input } from "../../shared/ui/Input";
 import { PageShell } from "../../shared/ui/PageShell";
 
+const MIN_SIGNAL = 16;
+const MIN_THREAD_AGE_HOURS = 1;
+const MAX_THREAD_AGE_HOURS = 168;
+
+function integerError(value: string, min: number, max?: number, unit?: string) {
+  const trimmed = value.trim();
+  const parsed = Number(trimmed);
+  const range = `${min}-${max}${unit ? ` ${unit}` : ""}`;
+
+  if (trimmed === "") {
+    return "required";
+  }
+
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+    return "enter a whole number";
+  }
+
+  if (parsed < min) {
+    return max ? `use ${range}` : `use ${min} or higher`;
+  }
+
+  if (max !== undefined && parsed > max) {
+    return `use ${range}`;
+  }
+
+  return undefined;
+}
+
 export default function SettingsPage() {
   const { settings, updateSettings } = useSettings();
   const [filterDifficulty, setFilterDifficulty] = useState(String(settings.filterDifficulty));
   const [difficulty, setDifficulty] = useState(String(settings.difficulty));
   const [age, setAge] = useState(String(settings.ageHours));
   const [threadRef, setThreadRef] = useState("");
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saved">("idle");
   const navigate = useNavigate();
-  const filterDifficultyValue = Number(filterDifficulty);
-  const filterDifficultyError =
-    filterDifficulty !== "" && (Number.isNaN(filterDifficultyValue) || filterDifficultyValue < 16)
-      ? "minimum signal is 16"
-      : undefined;
+  const filterDifficultyError = integerError(filterDifficulty, MIN_SIGNAL);
+  const difficultyError = integerError(difficulty, MIN_SIGNAL);
+  const ageError = integerError(age, MIN_THREAD_AGE_HOURS, MAX_THREAD_AGE_HOURS, "hours");
+  const hasSettingsError = Boolean(filterDifficultyError || difficultyError || ageError);
+
+  const handleSettingsChange = (
+    setter: React.Dispatch<React.SetStateAction<string>>,
+    value: string,
+  ) => {
+    setSaveStatus("idle");
+    setter(value);
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (hasSettingsError) {
+      setSaveStatus("idle");
+      return;
+    }
+
     updateSettings({
       filterDifficulty: Number(filterDifficulty),
       difficulty: Number(difficulty),
       ageHours: Number(age),
     });
+    setSaveStatus("saved");
   };
 
   return (
     <PageShell className="settings-page bg-void p-8 flex flex-col h-full max-w-content mx-auto">
       <h1 className="text-display font-medium mb-4">settings</h1>
-      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Input
             id="filterDifficulty"
             label="proof filter"
             type="number"
             value={filterDifficulty}
-            onChange={(e) => setFilterDifficulty(e.target.value)}
-            min={16}
+            onChange={(e) => handleSettingsChange(setFilterDifficulty, e.target.value)}
+            min={MIN_SIGNAL}
+            step={1}
+            inputMode="numeric"
+            hint="Feed minimum; higher hides more low-proof roots. 16+."
             error={filterDifficultyError}
           />
           <Input
@@ -46,20 +92,37 @@ export default function SettingsPage() {
             label="post signal"
             type="number"
             value={difficulty}
-            onChange={(e) => setDifficulty(e.target.value)}
-            min={16}
+            onChange={(e) => handleSettingsChange(setDifficulty, e.target.value)}
+            min={MIN_SIGNAL}
+            step={1}
+            inputMode="numeric"
+            hint="Proof mined for new posts; higher carries more weight and takes longer. 16+."
+            error={difficultyError}
           />
           <Input
             id="age"
             label="thread age (hrs)"
             type="number"
             value={age}
-            onChange={(e) => setAge(e.target.value)}
+            onChange={(e) => handleSettingsChange(setAge, e.target.value)}
+            min={MIN_THREAD_AGE_HOURS}
+            max={MAX_THREAD_AGE_HOURS}
+            step={1}
+            inputMode="numeric"
+            hint="Feed lookback; shorter loads faster, longer reaches older threads. 1-168."
+            error={ageError}
           />
         </div>
-        <Button type="submit" variant="primary">
-          save
-        </Button>
+        <div className="flex items-center gap-3">
+          <Button type="submit" variant="primary" disabled={hasSettingsError}>
+            {saveStatus === "saved" ? "saved" : "save"}
+          </Button>
+          {saveStatus === "saved" && (
+            <p role="status" className="text-meta text-secondary">
+              settings saved
+            </p>
+          )}
+        </div>
       </form>
       <div className="pt-10">
         <h2 className="text-body font-medium mb-4">open thread</h2>


### PR DESCRIPTION
## Summary
- add compact inline guidance for proof filter, post signal, and thread age settings
- validate settings as whole numbers before saving, including a 1-168 hour thread age range
- show saved feedback after a successful settings update

## Tests
- npm test -- src/features/settings/SettingsPage.test.tsx
- npm run typecheck
- npm run lint
- npm test