### PR TITLE
Improve feed startup performance

### DIFF
--- a/api/_shared/handlers.test.ts
+++ b/api/_shared/handlers.test.ts
@@ -79,6 +79,26 @@ describe("shared API handlers", () => {
     });
   });
 
+  it("explains bootstrap cache misses when refresh-on-read is disabled", async () => {
+    const service = new FeedBootstrapCacheService({
+      store: new MemoryFeedBootstrapStore(),
+      allowRefreshOnRead: () => false,
+    });
+
+    await expect(handleFeedBootstrapApi({ method: "GET" }, { service })).resolves.toMatchObject({
+      status: 503,
+      body: {
+        error: "bootstrap unavailable",
+        cache: {
+          hit: false,
+          refreshOnRead: false,
+          refreshing: false,
+        },
+        lastRefreshError: null,
+      },
+    });
+  });
+
   it("returns a refresh summary from the shared cache service", async () => {
     delete process.env.CRON_SECRET;
     process.env.NODE_ENV = "test";

--- a/api/_shared/handlers.ts
+++ b/api/_shared/handlers.ts
@@ -120,6 +120,11 @@ export async function handleFeedBootstrapApi(
   if (!snapshot) {
     return json(503, {
       error: "bootstrap unavailable",
+      cache: {
+        hit: false,
+        refreshOnRead: service.canRefreshOnRead(),
+        refreshing: service.isRefreshing(),
+      },
       lastRefreshError: service.getLastRefreshError(),
     });
   }

--- a/lib/feedBootstrapCache.ts
+++ b/lib/feedBootstrapCache.ts
@@ -126,6 +126,10 @@ export class FeedBootstrapCacheService {
     return this.lastRefreshError;
   }
 
+  canRefreshOnRead(): boolean {
+    return this.allowRefreshOnRead();
+  }
+
   read(): Promise<FeedBootstrapSnapshot | null> {
     return this.store.read();
   }

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,18 +1,39 @@
+import { lazy, Suspense } from "react";
+import type { ReactNode } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import FeedPage from "../features/feed/FeedPage";
-import SettingsPage from "../features/settings/SettingsPage";
 import ThreadPage from "../features/thread/ThreadPage";
-import NotificationsPage from "../features/notifications/NotificationsPage";
+
+const SettingsPage = lazy(() => import("../features/settings/SettingsPage"));
+const NotificationsPage = lazy(() => import("../features/notifications/NotificationsPage"));
+
+function LazyRoute({ children }: { children: ReactNode }) {
+  return <Suspense fallback={null}>{children}</Suspense>;
+}
 
 export function AppRoutes() {
   return (
     <Routes>
-      <Route path="/settings" element={<SettingsPage />} />
+      <Route
+        path="/settings"
+        element={
+          <LazyRoute>
+            <SettingsPage />
+          </LazyRoute>
+        }
+      />
       <Route path="/" element={<FeedPage />} />
       <Route path="/raw" element={<FeedPage mode="raw" />} />
       <Route path="/confess" element={<Navigate to="/" replace />} />
       <Route path="/thread/:id" element={<ThreadPage />} />
-      <Route path="/notifications" element={<NotificationsPage />} />
+      <Route
+        path="/notifications"
+        element={
+          <LazyRoute>
+            <NotificationsPage />
+          </LazyRoute>
+        }
+      />
     </Routes>
   );
 }

--- a/src/features/compose/ThreadComposer.tsx
+++ b/src/features/compose/ThreadComposer.tsx
@@ -1,10 +1,13 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import { Event } from "nostr-tools";
-import { PostForm } from "./PostForm";
 import { Button } from "../../shared/ui/Button";
 import { ContentColumn } from "../../shared/ui/PageShell";
 
 type PostType = "" | "Reply" | "Quote" | undefined;
+
+const LazyPostForm = lazy(() =>
+  import("./PostForm").then((module) => ({ default: module.PostForm })),
+);
 
 export function ThreadComposer({ OPEvent }: { OPEvent: Event }) {
   const [showForm, setShowForm] = useState(false);
@@ -39,7 +42,9 @@ export function ThreadComposer({ OPEvent }: { OPEvent: Event }) {
       {showForm && postType && (
         <ContentColumn className="my-2">
           <p className="text-meta text-muted text-center mb-2">{postType.toLowerCase()}</p>
-          <PostForm refEvent={OPEvent} tagType={postType} />
+          <Suspense fallback={null}>
+            <LazyPostForm refEvent={OPEvent} tagType={postType} />
+          </Suspense>
         </ContentColumn>
       )}
     </>

--- a/src/features/feed/FeedPage.tsx
+++ b/src/features/feed/FeedPage.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { useFeed } from "../../hooks/useFeed";
 import { useSettings } from "../../app/settings";
 import { useInfiniteScroll } from "../../shared/hooks/useInfiniteScroll";
-import { PostForm } from "../compose/PostForm";
 import { PostCard } from "../../shared/ui/PostCard";
 import { FeedSortToggle } from "./FeedSortToggle";
 import { ContentColumn, PageShell } from "../../shared/ui/PageShell";
@@ -15,6 +14,10 @@ const INITIAL_RESOLVE_COUNT = 20;
 const RESOLVE_DURATION_MS = 600;
 const STAGGER_MS = 40;
 
+const LazyPostForm = lazy(() =>
+  import("../compose/PostForm").then((module) => ({ default: module.PostForm })),
+);
+
 type FeedPageProps = {
   mode?: "default" | "raw";
 };
@@ -25,6 +28,7 @@ export default function FeedPage({ mode = "default" }: FeedPageProps) {
   const visibleCount = useInfiniteScroll();
   const openThread = useThreadNavigation();
   const [resolveWindowOpen, setResolveWindowOpen] = useState(true);
+  const [showComposer, setShowComposer] = useState(false);
   useHeaderFeedStatus(feedStatus.kind);
 
   useEffect(() => {
@@ -33,6 +37,11 @@ export default function FeedPage({ mode = "default" }: FeedPageProps) {
       RESOLVE_DURATION_MS + INITIAL_RESOLVE_COUNT * STAGGER_MS,
     );
     return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setShowComposer(true), 0);
+    return () => window.clearTimeout(timer);
   }, []);
 
   const sortedEvents = useMemo(() => {
@@ -52,8 +61,12 @@ export default function FeedPage({ mode = "default" }: FeedPageProps) {
             sortByPow={settings.sortByPow}
             onToggle={() => updateSettings({ sortByPow: !settings.sortByPow })}
           />
-          <div className="min-w-0 flex-1">
-            <PostForm />
+          <div className="min-h-[8.5rem] min-w-0 flex-1">
+            {showComposer && (
+              <Suspense fallback={null}>
+                <LazyPostForm />
+              </Suspense>
+            )}
           </div>
         </div>
       </div>

--- a/src/shared/lib/feedBootstrapClient.test.ts
+++ b/src/shared/lib/feedBootstrapClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Event } from "nostr-tools";
 import {
   eventsFromSnapshot,
@@ -11,6 +11,10 @@ import {
   VERCEL_FEED_BOOTSTRAP_URL,
 } from "./feedBootstrapClient";
 import type { FeedBootstrapResponse } from "./feedBootstrapClient";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 const event = (overrides: Partial<Event> = {}): Event => ({
   id: "f".repeat(64),
@@ -241,6 +245,41 @@ describe("fetchFeedBootstrapSnapshot", () => {
     );
 
     expect(result).toEqual(snapshot());
+    expect(calls).toEqual([
+      "https://snapshot.example/feed.json",
+      VERCEL_FEED_BOOTSTRAP_URL,
+    ]);
+  });
+
+  it("keeps the Vercel fallback cheap when the external snapshot misses", async () => {
+    vi.useFakeTimers();
+    resetFeedBootstrapSnapshotCache();
+    const calls: string[] = [];
+    const fetcher = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push(String(input));
+      if (String(input).startsWith("https://snapshot.example")) {
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }
+
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("aborted", "AbortError")),
+          { once: true },
+        );
+      });
+    });
+
+    const result = fetchFeedBootstrapSnapshot(
+      fetcher,
+      "https://snapshot.example/feed.json",
+      { timeoutMs: 1_000, fallbackTimeoutMs: 25 },
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(result).resolves.toBeNull();
     expect(calls).toEqual([
       "https://snapshot.example/feed.json",
       VERCEL_FEED_BOOTSTRAP_URL,

--- a/src/shared/lib/feedBootstrapClient.ts
+++ b/src/shared/lib/feedBootstrapClient.ts
@@ -9,11 +9,18 @@ export type FeedBootstrapResponse = FeedBootstrapSnapshot;
 
 export const VERCEL_FEED_BOOTSTRAP_URL = "/api/feed/bootstrap";
 export const FEED_SNAPSHOT_URL_ENV = "VITE_FEED_SNAPSHOT_URL";
+export const FEED_BOOTSTRAP_FETCH_TIMEOUT_MS = 3_000;
+export const FEED_BOOTSTRAP_FALLBACK_TIMEOUT_MS = 800;
 
 type FetchLike = (
   input: RequestInfo | URL,
   init?: RequestInit,
 ) => Promise<Response>;
+
+type FeedBootstrapFetchOptions = {
+  timeoutMs?: number;
+  fallbackTimeoutMs?: number;
+};
 
 let cachedSnapshot: FeedBootstrapResponse | null = null;
 let snapshotPromise: Promise<FeedBootstrapResponse | null> | null = null;
@@ -31,19 +38,63 @@ export function feedBootstrapUrls(
     : [VERCEL_FEED_BOOTSTRAP_URL];
 }
 
+function timeoutSignal(timeoutMs: number): { signal?: AbortSignal; cleanup(): void } {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return { cleanup: () => undefined };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+
+  return {
+    signal: controller.signal,
+    cleanup: () => globalThis.clearTimeout(timeoutId),
+  };
+}
+
+function timeoutForBootstrapUrl(
+  url: string,
+  externalSnapshotUrl: string | null,
+  { timeoutMs, fallbackTimeoutMs }: FeedBootstrapFetchOptions,
+): number {
+  if (externalSnapshotUrl && url === VERCEL_FEED_BOOTSTRAP_URL) {
+    return fallbackTimeoutMs ?? FEED_BOOTSTRAP_FALLBACK_TIMEOUT_MS;
+  }
+
+  return timeoutMs ?? FEED_BOOTSTRAP_FETCH_TIMEOUT_MS;
+}
+
+async function fetchSnapshotFromUrl(
+  fetcher: FetchLike,
+  url: string,
+  timeoutMs: number,
+): Promise<FeedBootstrapResponse | null> {
+  const timeout = timeoutSignal(timeoutMs);
+
+  try {
+    const response = await fetcher(url, { signal: timeout.signal });
+    if (!response.ok) return null;
+
+    const snapshot = (await response.json()) as unknown;
+    return isFeedBootstrapSnapshot(snapshot) ? snapshot : null;
+  } finally {
+    timeout.cleanup();
+  }
+}
+
 export async function fetchFeedBootstrapSnapshot(
   fetcher: FetchLike = fetch,
   externalSnapshotUrl: string | null = configuredFeedSnapshotUrl(),
+  options: FeedBootstrapFetchOptions = {},
 ): Promise<FeedBootstrapResponse | null> {
   for (const url of feedBootstrapUrls(externalSnapshotUrl)) {
     try {
-      const response = await fetcher(url);
-      if (!response.ok) continue;
-
-      const snapshot = (await response.json()) as unknown;
-      if (isFeedBootstrapSnapshot(snapshot)) {
-        return snapshot;
-      }
+      const snapshot = await fetchSnapshotFromUrl(
+        fetcher,
+        url,
+        timeoutForBootstrapUrl(url, externalSnapshotUrl, options),
+      );
+      if (snapshot) return snapshot;
     } catch {
       // Try the next bootstrap source.
     }

--- a/src/shared/ui/NoteMedia.test.tsx
+++ b/src/shared/ui/NoteMedia.test.tsx
@@ -3,7 +3,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MediaAttachment, NoteMedia } from "./NoteMedia";
+import { MediaAttachment, MediaGrid, NoteMedia } from "./NoteMedia";
 
 (
   globalThis as typeof globalThis & {
@@ -71,6 +71,8 @@ describe("NoteMedia video previews", () => {
     expect(video?.getAttribute("preload")).toBe("metadata");
     expect(video?.hasAttribute("controls")).toBe(true);
     expect(video?.getAttribute("poster")).toBeNull();
+    expect(video?.getAttribute("width")).toBe("640");
+    expect(video?.getAttribute("height")).toBe("360");
     expect(video?.parentElement?.style.aspectRatio).toBe("640 / 360");
     expect(container.textContent).toContain("video preview");
     expect(loadMock).not.toHaveBeenCalled();
@@ -167,6 +169,8 @@ describe("NoteMedia video previews", () => {
     });
 
     const image = container.querySelector("img");
+    expect(image?.getAttribute("width")).toBe("1200");
+    expect(image?.getAttribute("height")).toBe("400");
     expect(image?.className).toContain("mx-auto");
     expect(image?.className).toContain("max-h-[12rem]");
     expect(image?.className.split(/\s+/)).not.toContain("w-full");
@@ -190,11 +194,59 @@ describe("NoteMedia video previews", () => {
     });
 
     const image = container.querySelector("img");
+    expect(image?.getAttribute("width")).toBe("800");
+    expect(image?.getAttribute("height")).toBe("1400");
     expect(image?.className).toContain("mx-auto");
     expect(image?.className).toContain("max-w-[min(100%,12rem)]");
     expect(image?.className).toContain("max-h-[16rem]");
     expect(image?.className.split(/\s+/)).not.toContain("w-full");
     expect(image?.style.aspectRatio).toBe("800 / 1400");
+  });
+
+  it("sets dimensions on grid images when imeta dimensions are present", () => {
+    act(() => {
+      root.render(
+        <MediaGrid
+          items={[
+            {
+              url: "https://example.com/one.jpg",
+              type: "image",
+              width: 1600,
+              height: 900,
+            },
+            {
+              url: "https://example.com/two.jpg",
+              type: "image",
+              width: 900,
+              height: 1600,
+            },
+          ]}
+        />,
+      );
+    });
+
+    const images = container.querySelectorAll("img");
+    expect(images[0]?.getAttribute("width")).toBe("1600");
+    expect(images[0]?.getAttribute("height")).toBe("900");
+    expect(images[1]?.getAttribute("width")).toBe("900");
+    expect(images[1]?.getAttribute("height")).toBe("1600");
+  });
+
+  it("omits image dimensions when imeta dimensions are missing", () => {
+    act(() => {
+      root.render(
+        <MediaAttachment
+          item={{
+            url: "https://example.com/photo.jpg",
+            type: "image",
+          }}
+        />,
+      );
+    });
+
+    const image = container.querySelector("img");
+    expect(image?.hasAttribute("width")).toBe(false);
+    expect(image?.hasAttribute("height")).toBe(false);
   });
 
   it("uses orientation-aware compact classes for quoted landscape video", () => {
@@ -271,6 +323,8 @@ describe("NoteMedia video previews", () => {
 
     expect(wrapper?.style.aspectRatio).toBe("720 / 1280");
     expect(wrapper?.className).toContain("max-w-[min(100%,18rem)]");
+    expect(video?.getAttribute("width")).toBe("720");
+    expect(video?.getAttribute("height")).toBe("1280");
   });
 
   it("keeps the media fallback on video errors", () => {

--- a/src/shared/ui/NoteMedia.tsx
+++ b/src/shared/ui/NoteMedia.tsx
@@ -30,6 +30,14 @@ function aspectRatioFromDimensions(width?: number, height?: number): string {
   return "16 / 9";
 }
 
+function dimensionAttrs(
+  width?: number,
+  height?: number,
+): { width?: number; height?: number } {
+  if (!width || !height) return {};
+  return { width, height };
+}
+
 function imageClasses(orientation: MediaOrientation, compact?: boolean): string {
   const base = "rounded border border-ghost object-contain";
 
@@ -78,14 +86,29 @@ function useOptimizedImage(
 ) {
   const [useRaw, setUseRaw] = useState(false);
 
+  useEffect(() => {
+    setUseRaw(false);
+  }, [url]);
+
+  const optimizedSrc = optimizedImageUrl(url, width);
+  const isOptimized = optimizedSrc !== url;
+
   if (useRaw) {
-    return { src: url, srcSet: undefined, onError: () => setUseRaw(true) };
+    return {
+      src: url,
+      srcSet: undefined,
+      isOptimized: false,
+      onError: () => undefined,
+    };
   }
 
   return {
-    src: optimizedImageUrl(url, width),
-    srcSet: optimizedImageSrcSet(url, srcSetWidths),
-    onError: () => setUseRaw(true),
+    src: optimizedSrc,
+    srcSet: isOptimized ? optimizedImageSrcSet(url, srcSetWidths) : undefined,
+    isOptimized,
+    onError: () => {
+      if (isOptimized) setUseRaw(true);
+    },
   };
 }
 
@@ -102,7 +125,11 @@ function MediaImage({
   const maxWidth = compact ? 384 : 828;
   const width = pickOptimizedWidth(item.width, maxWidth);
   const srcSetWidths = compact ? [384, 640] : [640, 828, 1200];
-  const { src, srcSet, onError } = useOptimizedImage(item.url, width, srcSetWidths);
+  const { src, srcSet, isOptimized, onError } = useOptimizedImage(
+    item.url,
+    width,
+    srcSetWidths,
+  );
 
   if (failed) return <MediaFallback />;
 
@@ -114,13 +141,14 @@ function MediaImage({
       src={src}
       srcSet={srcSet}
       sizes={compact ? "384px" : "(max-width: 768px) 100vw, 828px"}
+      {...dimensionAttrs(item.width, item.height)}
       alt=""
       loading={priority ? "eager" : "lazy"}
-      fetchPriority={priority ? "high" : undefined}
+      {...(priority ? { fetchpriority: "high" } : {})}
       decoding="async"
       onError={() => {
         onError();
-        if (src === item.url) setFailed(true);
+        if (!isOptimized) setFailed(true);
       }}
       className={imageClasses(orientation, compact)}
       style={
@@ -149,7 +177,11 @@ function GridImage({
   const maxWidth = compact ? 384 : 640;
   const width = pickOptimizedWidth(item.width, maxWidth);
   const srcSetWidths = compact ? [384, 640] : [384, 640, 828];
-  const { src, srcSet, onError } = useOptimizedImage(item.url, width, srcSetWidths);
+  const { src, srcSet, isOptimized, onError } = useOptimizedImage(
+    item.url,
+    width,
+    srcSetWidths,
+  );
 
   if (failed) return <MediaFallback />;
 
@@ -165,13 +197,14 @@ function GridImage({
         src={src}
         srcSet={srcSet}
         sizes={compact ? "384px" : "(max-width: 768px) 50vw, 640px"}
+        {...dimensionAttrs(item.width, item.height)}
         alt=""
         loading={priority ? "eager" : "lazy"}
-        fetchPriority={priority ? "high" : undefined}
+        {...(priority ? { fetchpriority: "high" } : {})}
         decoding="async"
         onError={() => {
           onError();
-          if (src === item.url) setFailed(true);
+          if (!isOptimized) setFailed(true);
         }}
         className={[
           "h-full w-full object-cover",
@@ -278,6 +311,7 @@ function MediaVideo({
         ref={videoRef}
         src={item.url}
         poster={item.posterUrl}
+        {...dimensionAttrs(resolvedDimensions.width, resolvedDimensions.height)}
         controls
         preload={hasPoster || !shouldPrimePreview ? "metadata" : "auto"}
         playsInline

--- a/src/shared/ui/SignalAvatar.test.tsx
+++ b/src/shared/ui/SignalAvatar.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SignalAvatar } from "./SignalAvatar";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("SignalAvatar", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllEnvs();
+  });
+
+  it("renders fixed image dimensions and keeps priority loading for visible avatars", () => {
+    vi.stubEnv("DEV", false);
+
+    act(() => {
+      root.render(
+        <SignalAvatar
+          pubkey="abcdef1234567890"
+          pictureUrl="https://image.nostr.build/avatar.jpg"
+          priority
+        />,
+      );
+    });
+
+    const image = container.querySelector("img");
+    expect(image?.getAttribute("src")).toBe(
+      "/_vercel/image?url=https%3A%2F%2Fimage.nostr.build%2Favatar.jpg&w=48&q=75",
+    );
+    expect(image?.getAttribute("width")).toBe("20");
+    expect(image?.getAttribute("height")).toBe("20");
+    expect(image?.getAttribute("loading")).toBe("eager");
+    expect(image?.getAttribute("fetchpriority")).toBe("high");
+  });
+
+  it("falls back from an optimized avatar URL to the raw image URL", () => {
+    vi.stubEnv("DEV", false);
+
+    act(() => {
+      root.render(
+        <SignalAvatar
+          pubkey="abcdef1234567890"
+          pictureUrl="https://image.nostr.build/avatar.jpg"
+        />,
+      );
+    });
+
+    act(() => {
+      container.querySelector("img")?.dispatchEvent(new Event("error", { bubbles: true }));
+    });
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      "https://image.nostr.build/avatar.jpg",
+    );
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("uses the grid fallback after one raw avatar error", () => {
+    vi.stubEnv("DEV", false);
+
+    act(() => {
+      root.render(
+        <SignalAvatar
+          pubkey="abcdef1234567890"
+          pictureUrl="https://unknown.example/avatar.jpg"
+        />,
+      );
+    });
+
+    const image = container.querySelector("img");
+    expect(image?.getAttribute("src")).toBe("https://unknown.example/avatar.jpg");
+
+    act(() => {
+      image?.dispatchEvent(new Event("error", { bubbles: true }));
+    });
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/src/shared/ui/SignalAvatar.tsx
+++ b/src/shared/ui/SignalAvatar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { pubkeyToGrid } from "@lib/pubkeyToGrid";
 import { optimizedAvatarUrl } from "@lib/optimizedImageUrl";
 
@@ -71,10 +71,15 @@ export function SignalAvatar({
   const pixels = sizePixels[size];
   const ariaLabel = label ?? `author ${pubkey.slice(0, 8)}`;
 
+  useEffect(() => {
+    setImageFailed(false);
+    setUseRawUrl(false);
+  }, [pictureUrl]);
+
   if (pictureUrl && !imageFailed) {
-    const src = useRawUrl
-      ? pictureUrl
-      : optimizedAvatarUrl(pictureUrl, pixels);
+    const optimizedSrc = optimizedAvatarUrl(pictureUrl, pixels);
+    const isOptimized = optimizedSrc !== pictureUrl;
+    const src = useRawUrl ? pictureUrl : optimizedSrc;
 
     return (
       <img
@@ -83,11 +88,11 @@ export function SignalAvatar({
         width={pixels}
         height={pixels}
         loading={priority ? "eager" : "lazy"}
-        fetchPriority={priority ? "high" : undefined}
+        {...(priority ? { fetchpriority: "high" } : {})}
         decoding="async"
         aria-label={ariaLabel}
         onError={() => {
-          if (!useRawUrl) {
+          if (!useRawUrl && isOptimized) {
             setUseRawUrl(true);
             return;
           }

--- a/vercel.json
+++ b/vercel.json
@@ -52,6 +52,42 @@
           "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), browsing-topics=()"
         }
       ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/fonts/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/favicon.svg",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/noise.png",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary
- add immutable Vercel cache headers for hashed/static assets
- bound bootstrap snapshot fetches and expose cache diagnostics on fallback misses
- defer composer/noncritical route code while keeping feed and thread LCP paths eager
- add media dimensions, priority hints, and safer optimized-image fallback behavior

## Verification
- npm test
- npm run typecheck
- npm run lint (passes with existing Fast Refresh warnings)
- npm run build

## Speed signals
- main app chunk reduced from prior baseline 350.87 kB / 114.21 kB gzip to 326.00 kB / 106.59 kB gzip
- Vercel header config parses with immutable rules for /assets, /fonts, /favicon.svg, and /noise.png
