### PR TITLE
Simplify compose density

### DIFF
--- a/src/features/compose/CustomEmojiPicker.tsx
+++ b/src/features/compose/CustomEmojiPicker.tsx
@@ -271,10 +271,10 @@ export function CustomEmojiPicker({ onSelect }: CustomEmojiPickerProps) {
         aria-label="open custom emoji picker"
         aria-expanded={isOpen}
         title="custom emoji"
-        className="px-2"
+        className="h-8 w-8 p-0 text-muted hover:text-secondary"
         onClick={togglePicker}
       >
-        <SmilePlus className="h-4 w-4" aria-hidden="true" />
+        <SmilePlus className="h-4 w-4" aria-hidden="true" strokeWidth={1.8} />
       </Button>
 
       {isOpen && (

--- a/src/features/compose/PostForm.test.tsx
+++ b/src/features/compose/PostForm.test.tsx
@@ -84,7 +84,7 @@ describe("PostForm", () => {
     });
 
     expect(container.textContent).toContain("signal");
-    expect(container.textContent).toContain("estimated mine time ~12s");
+    expect(container.textContent).toContain("ETA ~12s");
   });
 
   it("does not duplicate the PoW ETA while mining", () => {
@@ -111,7 +111,7 @@ describe("PostForm", () => {
     expect(container.textContent).toContain("best signal 17");
   });
 
-  it("shows a visible first-use compose affordance", () => {
+  it("keeps the composer labelled with a quieter visible affordance", () => {
     act(() => {
       root.render(<PostForm />);
     });
@@ -120,7 +120,8 @@ describe("PostForm", () => {
     const textarea = container.querySelector("textarea");
 
     expect(label?.textContent).toBe("Write a note");
-    expect(textarea?.getAttribute("placeholder")).toBe("Share a note with the network");
+    expect(label?.className).toContain("sr-only");
+    expect(textarea?.getAttribute("placeholder")).toBe("write something...");
     expect(textarea?.id).toBe(label?.getAttribute("for"));
   });
 

--- a/src/features/compose/PostForm.tsx
+++ b/src/features/compose/PostForm.tsx
@@ -110,7 +110,8 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
           name="com"
           variant="compose"
           label={composerLabel}
-          placeholder="Share a note with the network"
+          labelHidden
+          placeholder="write something..."
           value={comment}
           aria-invalid={emptySubmitMessage ? true : undefined}
           aria-describedby={emptySubmitMessage ? emptySubmitMessageId : undefined}
@@ -125,19 +126,17 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
           rows={comment.split("\n").length || 1}
         />
         {tagType === "Quote" && refEvent && <QuotePreview event={refEvent} />}
-        <div className="min-h-14 flex items-start justify-between gap-4 mt-2">
-          <div className="flex flex-col items-start gap-1">
+        <div className="mt-2 flex min-h-20 flex-col gap-2">
+          <div className="min-w-0">
             <SignalStepper
               value={difficulty}
               onChange={setDifficulty}
               min={16}
               active={willUseWiredAccount}
+              meta={showPowEta ? `ETA ~${powEta}` : undefined}
             />
-            {showPowEta && (
-              <p className="text-meta text-secondary">estimated mine time ~{powEta}</p>
-            )}
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center justify-between gap-3">
             <CustomEmojiPicker onSelect={handleEmojiSelect} />
             <Button type="submit" variant="primary" size="sm" disabled={doingWorkProp} loading={doingWorkProp}>
               transmit

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -50,12 +50,12 @@ function NavLink({
       to={to}
       aria-current={isActive ? "page" : undefined}
       className={[
-        "text-meta transition-colors duration-hover border-b-2 pb-0.5",
+        "text-micro sm:text-meta transition-colors duration-hover border-b-2 pb-0.5",
         isActive
           ? "text-signal font-medium border-signal"
           : signalGlow
             ? "text-signal border-transparent drop-shadow-[0_0_6px_var(--signal-dim)] hover:text-primary"
-            : "text-secondary border-transparent hover:text-primary",
+            : "text-muted border-transparent hover:text-secondary",
       ].join(" ")}
     >
       {label}
@@ -89,7 +89,7 @@ export function Header() {
             {pathDisplay}
           </span>
         </Link>
-        <nav className="flex shrink-0 gap-4" aria-label="Primary navigation">
+        <nav className="flex shrink-0 gap-3 sm:gap-4" aria-label="Primary navigation">
           <NavLink
             to="/notifications"
             label="activity"

--- a/src/shared/ui/SignalStepper.tsx
+++ b/src/shared/ui/SignalStepper.tsx
@@ -7,6 +7,7 @@ type SignalStepperProps = {
   min?: number | string;
   label?: string;
   active?: boolean;
+  meta?: string;
 };
 
 export function SignalStepper({
@@ -15,6 +16,7 @@ export function SignalStepper({
   min = 16,
   label = "signal",
   active = false,
+  meta,
 }: SignalStepperProps) {
   const numericValue = parseInt(value, 10) || 0;
   const minValue = typeof min === "string" ? parseInt(min, 10) || 0 : min;
@@ -25,7 +27,7 @@ export function SignalStepper({
   return (
     <div
       className={[
-        "inline-flex items-center gap-0.5 bg-surface border rounded-sm px-1 py-0.5 transition-colors",
+        "flex w-full max-w-full items-center gap-0.5 bg-surface border rounded-sm px-1 py-0.5 transition-colors",
         active
           ? "border-signal drop-shadow-[0_0_6px_var(--signal-dim)]"
           : "border-ghost",
@@ -62,6 +64,11 @@ export function SignalStepper({
       >
         +
       </Button>
+      {meta && (
+        <span className="ml-auto w-[13ch] shrink-0 truncate border-l border-ghost pl-2 pr-1 text-right text-micro text-muted">
+          {meta}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/shared/ui/Textarea.tsx
+++ b/src/shared/ui/Textarea.tsx
@@ -4,19 +4,21 @@ import { forwardRef, useId } from "react";
 export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   variant?: "default" | "compose";
   label?: string;
+  labelHidden?: boolean;
 }
 
 const variantClasses: Record<NonNullable<TextareaProps["variant"]>, string> = {
   default:
     "rounded-sm bg-surface border border-ghost px-3 py-2 resize-y",
   compose:
-    "min-h-[var(--compose-min-height)] resize-none bg-surface border-0 border-b border-ghost rounded-none px-3 py-2",
+    "min-h-[var(--compose-min-height)] resize-none bg-surface border-0 border-b border-ghost rounded-none px-3 py-2 placeholder:text-muted placeholder:opacity-60",
 };
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
   {
     variant = "default",
     label,
+    labelHidden = false,
     id: idProp,
     className = "",
     ...props
@@ -29,7 +31,14 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
   return (
     <div className="w-full">
       {label && (
-        <label htmlFor={id} className="block text-meta text-secondary mb-1">
+        <label
+          htmlFor={id}
+          className={
+            labelHidden
+              ? "sr-only"
+              : "block text-meta text-secondary mb-1"
+          }
+        >
           {label}
         </label>
       )}


### PR DESCRIPTION
## Summary
- quiet the header secondary nav and composer placeholder
- move the idle ETA into a fixed-width signal stepper slot
- stack emoji/transmit under the stepper with transmit pinned right
- visually hide the composer label while keeping it accessible

Preview: https://wired-4wwfu7p2u-smolgrrrs-projects.vercel.app

## Tests
- npm test -- src/features/compose/PostForm.test.tsx src/features/compose/CustomEmojiPicker.test.tsx src/shared/ui/Header.test.tsx
- npm run typecheck
- npm run lint (passes with existing 3 Fast Refresh warnings)