### PR TITLE
Add Blossom media uploads to composer

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_DIFFICULTY,
+  DEFAULT_BLOSSOM_SERVERS,
   DEFAULT_FILTER_DIFFICULTY,
   DEFAULT_POST_DIFFICULTY,
   DEFAULT_RELAYS,
+  configuredHttpUrls,
   configuredRelays,
 } from "./config";
 
@@ -21,6 +23,12 @@ describe("DEFAULT_DIFFICULTY", () => {
 describe("DEFAULT_RELAYS", () => {
   it("includes the Wired relay in the main feed relay list", () => {
     expect(DEFAULT_RELAYS).toContain("wss://relay.wiredsignal.online");
+  });
+});
+
+describe("DEFAULT_BLOSSOM_SERVERS", () => {
+  it("provides a default media upload server", () => {
+    expect(DEFAULT_BLOSSOM_SERVERS[0]).toMatch(/^https:\/\//);
   });
 });
 
@@ -42,6 +50,28 @@ describe("configuredRelays", () => {
   it("uses fallback relays when env contains no wss URLs", () => {
     expect(configuredRelays("https://bad.example", ["wss://fallback.example"])).toEqual([
       "wss://fallback.example",
+    ]);
+  });
+});
+
+describe("configuredHttpUrls", () => {
+  it("uses fallback URLs when env is unset", () => {
+    expect(configuredHttpUrls(undefined, ["https://fallback.example"])).toEqual([
+      "https://fallback.example",
+    ]);
+  });
+
+  it("parses comma-separated HTTPS URLs and strips trailing slashes", () => {
+    expect(
+      configuredHttpUrls(" https://one.example/,http://bad.example,https://two.example/path/ ", [
+        "https://fallback.example",
+      ]),
+    ).toEqual(["https://one.example", "https://two.example/path"]);
+  });
+
+  it("uses fallback URLs when env contains no HTTPS URLs", () => {
+    expect(configuredHttpUrls("wss://bad.example", ["https://fallback.example"])).toEqual([
+      "https://fallback.example",
     ]);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,10 @@ export const DEFAULT_RELAYS = [
   "wss://pow.relays.land",
 ] as const;
 
+export const DEFAULT_BLOSSOM_SERVERS = [
+  "https://blossom.primal.net",
+] as const;
+
 export const DEFAULT_ENRICHMENT_RELAYS = [
   "wss://relay.damus.io",
   "wss://offchain.pub",
@@ -30,6 +34,27 @@ export function configuredRelays(
     .filter((relay) => relay.startsWith("wss://"));
 
   return relays.length > 0 ? relays : fallback;
+}
+
+export function configuredHttpUrls(
+  envValue: string | undefined,
+  fallback: readonly string[],
+) {
+  if (!envValue?.trim()) return fallback;
+
+  const urls = envValue
+    .split(",")
+    .map((url) => url.trim().replace(/\/+$/, ""))
+    .filter((url) => {
+      try {
+        const parsed = new URL(url);
+        return parsed.protocol === "https:";
+      } catch {
+        return false;
+      }
+    });
+
+  return urls.length > 0 ? urls : fallback;
 }
 
 function configuredEnv(key: string): string | undefined {
@@ -60,6 +85,11 @@ export const QUOTE_FALLBACK_RELAYS = [
 export const THREAD_RELAYS = [
   ...new Set([...POW_RELAYS, ...ENRICHMENT_RELAYS]),
 ] as const;
+
+export const BLOSSOM_SERVERS = configuredHttpUrls(
+  configuredEnv("VITE_BLOSSOM_SERVERS"),
+  DEFAULT_BLOSSOM_SERVERS,
+);
 
 export const WIRED_ACCOUNT_API_BASE = (
   configuredEnv("VITE_WIRED_ACCOUNT_API_BASE") ||

--- a/src/features/compose/MediaUploadPicker.tsx
+++ b/src/features/compose/MediaUploadPicker.tsx
@@ -1,0 +1,137 @@
+import { useRef } from "react";
+import { File, ImagePlus, RotateCcw, X } from "lucide-react";
+import { Button } from "../../shared/ui/Button";
+import type { MediaUpload } from "./useMediaUploads";
+
+const accept = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+  "audio/mpeg",
+  "audio/wav",
+  "audio/ogg",
+  "audio/mp4",
+].join(",");
+
+type MediaUploadPickerProps = {
+  uploads: MediaUpload[];
+  disabled?: boolean;
+  onAddFiles: (files: FileList) => void;
+  onRemove: (id: string) => void;
+  onRetry: (id: string) => void;
+};
+
+function UploadPreview({ upload }: { upload: MediaUpload }) {
+  if (upload.previewUrl && upload.file.type.startsWith("image/")) {
+    return (
+      <img
+        src={upload.previewUrl}
+        alt=""
+        className="h-10 w-10 rounded-sm border border-ghost object-cover"
+      />
+    );
+  }
+
+  if (upload.previewUrl && upload.file.type.startsWith("video/")) {
+    return (
+      <video
+        src={upload.previewUrl}
+        muted
+        playsInline
+        className="h-10 w-10 rounded-sm border border-ghost object-cover"
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-10 w-10 items-center justify-center rounded-sm border border-ghost text-meta text-muted">
+      <File aria-hidden="true" size={16} />
+    </div>
+  );
+}
+
+export function MediaUploadPicker({
+  uploads,
+  disabled = false,
+  onAddFiles,
+  onRemove,
+  onRetry,
+}: MediaUploadPickerProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        multiple
+        className="sr-only"
+        onChange={(event) => {
+          const files = event.currentTarget.files;
+          if (files && files.length > 0) onAddFiles(files);
+          event.currentTarget.value = "";
+        }}
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        disabled={disabled}
+        title="attach media"
+        aria-label="attach media"
+        onClick={() => inputRef.current?.click()}
+      >
+        <ImagePlus aria-hidden="true" size={16} />
+      </Button>
+      {uploads.length > 0 && (
+        <div className="grid grid-cols-1 gap-2" aria-label="media uploads">
+          {uploads.map((upload) => (
+            <div
+              key={upload.id}
+              className="flex min-w-0 items-center gap-2 rounded-sm border border-ghost bg-surface px-2 py-1"
+            >
+              <UploadPreview upload={upload} />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-meta text-primary">{upload.name || "media"}</p>
+                <p className={upload.status === "failed" ? "text-meta text-danger" : "text-meta text-muted"}>
+                  {upload.status === "uploading"
+                    ? "uploading..."
+                    : upload.status === "uploaded"
+                      ? "uploaded"
+                      : upload.error || "upload failed"}
+                </p>
+              </div>
+              {upload.status === "failed" && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  title="retry upload"
+                  aria-label={`retry ${upload.name || "media"} upload`}
+                  onClick={() => onRetry(upload.id)}
+                >
+                  <RotateCcw aria-hidden="true" size={14} />
+                </Button>
+              )}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                title="remove media"
+                aria-label={`remove ${upload.name || "media"}`}
+                onClick={() => onRemove(upload.id)}
+              >
+                <X aria-hidden="true" size={14} />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/compose/MediaUploadPicker.tsx
+++ b/src/features/compose/MediaUploadPicker.tsx
@@ -20,6 +20,8 @@ const accept = [
 type MediaUploadPickerProps = {
   uploads: MediaUpload[];
   disabled?: boolean;
+  showButton?: boolean;
+  showUploads?: boolean;
   onAddFiles: (files: FileList) => void;
   onRemove: (id: string) => void;
   onRetry: (id: string) => void;
@@ -57,6 +59,8 @@ function UploadPreview({ upload }: { upload: MediaUpload }) {
 export function MediaUploadPicker({
   uploads,
   disabled = false,
+  showButton = true,
+  showUploads = true,
   onAddFiles,
   onRemove,
   onRetry,
@@ -77,18 +81,20 @@ export function MediaUploadPicker({
           event.currentTarget.value = "";
         }}
       />
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        disabled={disabled}
-        title="attach media"
-        aria-label="attach media"
-        onClick={() => inputRef.current?.click()}
-      >
-        <ImagePlus aria-hidden="true" size={16} />
-      </Button>
-      {uploads.length > 0 && (
+      {showButton && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={disabled}
+          title="attach media"
+          aria-label="attach media"
+          onClick={() => inputRef.current?.click()}
+        >
+          <ImagePlus aria-hidden="true" size={16} />
+        </Button>
+      )}
+      {showUploads && uploads.length > 0 && (
         <div className="grid grid-cols-1 gap-2" aria-label="media uploads">
           {uploads.map((upload) => (
             <div

--- a/src/features/compose/PostForm.test.tsx
+++ b/src/features/compose/PostForm.test.tsx
@@ -10,6 +10,7 @@ type ReactActGlobal = typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
 const mocks = vi.hoisted(() => ({
   handleSubmit: vi.fn(),
   useSubmitForm: vi.fn(),
+  useMediaUploads: vi.fn(),
 }));
 
 vi.mock("../../app/settings", () => ({
@@ -38,6 +39,14 @@ vi.mock("./CustomEmojiPicker", () => ({
   CustomEmojiPicker: () => <button type="button">emoji</button>,
 }));
 
+vi.mock("./MediaUploadPicker", () => ({
+  MediaUploadPicker: () => <button type="button">media</button>,
+}));
+
+vi.mock("./useMediaUploads", () => ({
+  useMediaUploads: mocks.useMediaUploads,
+}));
+
 describe("PostForm", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -56,6 +65,16 @@ describe("PostForm", () => {
     root = createRoot(container);
     mocks.handleSubmit.mockReset();
     mocks.handleSubmit.mockResolvedValue(undefined);
+    mocks.useMediaUploads.mockReturnValue({
+      uploads: [],
+      uploadedMedia: [],
+      hasUploading: false,
+      hasFailed: false,
+      addFiles: vi.fn(),
+      removeUpload: vi.fn(),
+      retryUpload: vi.fn(),
+      clearUploads: vi.fn(),
+    });
     mocks.useSubmitForm.mockReturnValue({
       handleSubmit: mocks.handleSubmit,
       doingWorkProp: false,
@@ -139,10 +158,91 @@ describe("PostForm", () => {
     const message = container.querySelector("[role='status']");
 
     expect(mocks.handleSubmit).not.toHaveBeenCalled();
-    expect(message?.textContent).toBe("Write something before transmitting.");
+    expect(message?.textContent).toBe("Write something or attach media before transmitting.");
     expect(textarea?.getAttribute("aria-invalid")).toBe("true");
     expect(textarea?.getAttribute("aria-describedby")).toBe(message?.id);
     expect(document.activeElement).toBe(textarea);
+  });
+
+  it("allows media-only transmits", async () => {
+    mocks.useMediaUploads.mockReturnValue({
+      uploads: [],
+      uploadedMedia: [
+        {
+          url: "https://cdn.example/image.png",
+          mime: "image/png",
+          sha256: "a".repeat(64),
+          size: 123,
+        },
+      ],
+      hasUploading: false,
+      hasFailed: false,
+      addFiles: vi.fn(),
+      removeUpload: vi.fn(),
+      retryUpload: vi.fn(),
+      clearUploads: vi.fn(),
+    });
+
+    act(() => {
+      root.render(<PostForm />);
+    });
+
+    await act(async () => {
+      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.handleSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks transmits while media is uploading", async () => {
+    mocks.useMediaUploads.mockReturnValue({
+      uploads: [],
+      uploadedMedia: [],
+      hasUploading: true,
+      hasFailed: false,
+      addFiles: vi.fn(),
+      removeUpload: vi.fn(),
+      retryUpload: vi.fn(),
+      clearUploads: vi.fn(),
+    });
+
+    act(() => {
+      root.render(<PostForm />);
+    });
+
+    await act(async () => {
+      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.handleSubmit).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Wait for media uploads to finish.");
+  });
+
+  it("blocks transmits when a media upload failed", async () => {
+    mocks.useMediaUploads.mockReturnValue({
+      uploads: [],
+      uploadedMedia: [],
+      hasUploading: false,
+      hasFailed: true,
+      addFiles: vi.fn(),
+      removeUpload: vi.fn(),
+      retryUpload: vi.fn(),
+      clearUploads: vi.fn(),
+    });
+
+    act(() => {
+      root.render(<PostForm />);
+    });
+
+    await act(async () => {
+      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.handleSubmit).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Remove or retry failed media uploads.");
   });
 
   it("delegates non-empty transmits to the submit hook", async () => {

--- a/src/features/compose/PostForm.test.tsx
+++ b/src/features/compose/PostForm.test.tsx
@@ -106,6 +106,21 @@ describe("PostForm", () => {
     expect(container.textContent).toContain("ETA ~12s");
   });
 
+  it("keeps media and emoji controls together below the signal selector", () => {
+    act(() => {
+      root.render(<PostForm />);
+    });
+
+    const emojiButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "emoji",
+    );
+    const mediaButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "media",
+    );
+
+    expect(emojiButton?.parentElement).toBe(mediaButton?.parentElement);
+  });
+
   it("does not duplicate the PoW ETA while mining", () => {
     mocks.useSubmitForm.mockReturnValue({
       handleSubmit: mocks.handleSubmit,

--- a/src/features/compose/PostForm.tsx
+++ b/src/features/compose/PostForm.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useId, useMemo, useRef } from "react";
-import { Event as NostrEvent } from "nostr-tools";
+import { useState, useEffect, useId, useMemo, useRef, useCallback } from "react";
+import { Event as NostrEvent, finalizeEvent, generateSecretKey, type EventTemplate } from "nostr-tools";
 import { useSubmitForm } from "../../shared/hooks/useSubmitForm";
 import { buildUnsignedEvent, type CustomEmojiTag } from "./buildUnsignedEvent";
 import { PostCard } from "../../shared/ui/PostCard";
@@ -12,6 +12,8 @@ import { SignalStepper } from "../../shared/ui/SignalStepper";
 import { useThreadNavigation } from "../thread/useThreadNavigation";
 import { CustomEmojiPicker } from "./CustomEmojiPicker";
 import type { CustomEmoji } from "./customEmojiCatalog";
+import { MediaUploadPicker } from "./MediaUploadPicker";
+import { useMediaUploads } from "./useMediaUploads";
 
 interface PostFormProps {
   refEvent?: NostrEvent;
@@ -25,6 +27,7 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
   const [difficulty, setDifficulty] = useState(String(settings.difficulty));
   const [emptySubmitMessage, setEmptySubmitMessage] = useState("");
   const [selectedEmojis, setSelectedEmojis] = useState<CustomEmojiTag[]>([]);
+  const [composeSecretKey, setComposeSecretKey] = useState(generateSecretKey);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const emptySubmitMessageId = useId();
   const composerLabel = tagType === "Reply" ? "Write a reply" : tagType === "Quote" ? "Add your quote" : "Write a note";
@@ -33,6 +36,20 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
     () => selectedEmojis.filter((emoji) => comment.includes(`:${emoji.shortcode}:`)),
     [comment, selectedEmojis],
   );
+  const signBlossomAuth = useCallback(
+    (template: EventTemplate) => finalizeEvent(template, composeSecretKey),
+    [composeSecretKey],
+  );
+  const {
+    uploads,
+    uploadedMedia,
+    hasUploading,
+    hasFailed,
+    addFiles,
+    removeUpload,
+    retryUpload,
+    clearUploads,
+  } = useMediaUploads(signBlossomAuth);
 
   const unsigned = useMemo(
     () =>
@@ -41,8 +58,9 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
         refEvent,
         tagType,
         customEmojis: activeEmojiTags,
+        media: uploadedMedia,
       }),
-    [activeEmojiTags, comment, refEvent, tagType],
+    [activeEmojiTags, comment, refEvent, tagType, uploadedMedia],
   );
 
   useEffect(() => {
@@ -61,14 +79,27 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
     powEta,
     willUseWiredAccount,
   } =
-    useSubmitForm(unsigned, difficulty);
+    useSubmitForm(unsigned, difficulty, {
+      secretKey: composeSecretKey,
+      onRotateSecretKey: setComposeSecretKey,
+    });
   const showPowEta = !doingWorkProp && submitStatus !== "published";
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
-    if (comment.trim() === "") {
-      setEmptySubmitMessage("Write something before transmitting.");
+    if (hasUploading) {
+      setEmptySubmitMessage("Wait for media uploads to finish.");
+      return;
+    }
+
+    if (hasFailed) {
+      setEmptySubmitMessage("Remove or retry failed media uploads.");
+      return;
+    }
+
+    if (comment.trim() === "" && uploadedMedia.length === 0) {
+      setEmptySubmitMessage("Write something or attach media before transmitting.");
       textareaRef.current?.focus();
       return;
     }
@@ -82,7 +113,8 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
 
     setComment("");
     setSelectedEmojis([]);
-  }, [signedPoWEvent]);
+    clearUploads();
+  }, [clearUploads, signedPoWEvent]);
 
   function handleEmojiSelect(emoji: CustomEmoji) {
     const token = `:${emoji.shortcode}:`;
@@ -126,6 +158,15 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
           rows={comment.split("\n").length || 1}
         />
         {tagType === "Quote" && refEvent && <QuotePreview event={refEvent} />}
+        <div className="mt-2">
+          <MediaUploadPicker
+            uploads={uploads}
+            disabled={doingWorkProp}
+            onAddFiles={addFiles}
+            onRemove={removeUpload}
+            onRetry={retryUpload}
+          />
+        </div>
         <div className="mt-2 flex min-h-20 flex-col gap-2">
           <div className="min-w-0">
             <SignalStepper
@@ -138,7 +179,7 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
           </div>
           <div className="flex items-center justify-between gap-3">
             <CustomEmojiPicker onSelect={handleEmojiSelect} />
-            <Button type="submit" variant="primary" size="sm" disabled={doingWorkProp} loading={doingWorkProp}>
+            <Button type="submit" variant="primary" size="sm" disabled={doingWorkProp || hasUploading} loading={doingWorkProp}>
               transmit
             </Button>
           </div>

--- a/src/features/compose/PostForm.tsx
+++ b/src/features/compose/PostForm.tsx
@@ -158,15 +158,18 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
           rows={comment.split("\n").length || 1}
         />
         {tagType === "Quote" && refEvent && <QuotePreview event={refEvent} />}
-        <div className="mt-2">
-          <MediaUploadPicker
-            uploads={uploads}
-            disabled={doingWorkProp}
-            onAddFiles={addFiles}
-            onRemove={removeUpload}
-            onRetry={retryUpload}
-          />
-        </div>
+        {uploads.length > 0 && (
+          <div className="mt-2">
+            <MediaUploadPicker
+              uploads={uploads}
+              disabled={doingWorkProp}
+              showButton={false}
+              onAddFiles={addFiles}
+              onRemove={removeUpload}
+              onRetry={retryUpload}
+            />
+          </div>
+        )}
         <div className="mt-2 flex min-h-20 flex-col gap-2">
           <div className="min-w-0">
             <SignalStepper
@@ -178,7 +181,17 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
             />
           </div>
           <div className="flex items-center justify-between gap-3">
-            <CustomEmojiPicker onSelect={handleEmojiSelect} />
+            <div className="flex items-center gap-2">
+              <CustomEmojiPicker onSelect={handleEmojiSelect} />
+              <MediaUploadPicker
+                uploads={uploads}
+                disabled={doingWorkProp}
+                showUploads={false}
+                onAddFiles={addFiles}
+                onRemove={removeUpload}
+                onRetry={retryUpload}
+              />
+            </div>
             <Button type="submit" variant="primary" size="sm" disabled={doingWorkProp || hasUploading} loading={doingWorkProp}>
               transmit
             </Button>

--- a/src/features/compose/buildUnsignedEvent.test.ts
+++ b/src/features/compose/buildUnsignedEvent.test.ts
@@ -28,4 +28,49 @@ describe("buildUnsignedEvent", () => {
       unsigned.tags.filter((tag) => tag[0] === "emoji" && tag[1] === "wired"),
     ).toHaveLength(1);
   });
+
+  it("adds uploaded media URLs and imeta tags", () => {
+    const unsigned = buildUnsignedEvent({
+      comment: "look",
+      media: [
+        {
+          url: "https://cdn.example/image.webp",
+          mime: "image/webp",
+          sha256: "a".repeat(64),
+          size: 1234,
+          width: 800,
+          height: 600,
+          imetaFields: ["blurhash abc", "thumb https://cdn.example/thumb.webp"],
+        },
+      ],
+    });
+
+    expect(unsigned.content).toBe("look\n\nhttps://cdn.example/image.webp");
+    expect(unsigned.tags).toContainEqual([
+      "imeta",
+      "url https://cdn.example/image.webp",
+      "m image/webp",
+      `x ${"a".repeat(64)}`,
+      "size 1234",
+      "dim 800x600",
+      "blurhash abc",
+      "thumb https://cdn.example/thumb.webp",
+    ]);
+  });
+
+  it("allows media-only notes", () => {
+    const unsigned = buildUnsignedEvent({
+      comment: "",
+      media: [
+        {
+          url: "https://cdn.example/audio.mp3",
+          mime: "audio/mpeg",
+          sha256: "b".repeat(64),
+          size: 42,
+        },
+      ],
+    });
+
+    expect(unsigned.content).toBe("https://cdn.example/audio.mp3");
+  });
 });

--- a/src/features/compose/buildUnsignedEvent.ts
+++ b/src/features/compose/buildUnsignedEvent.ts
@@ -1,10 +1,12 @@
 import { Event, UnsignedEvent } from "nostr-tools";
+import type { UploadedMedia } from "@lib/blossom";
 
 export type ComposeDraft = {
   comment: string;
   refEvent?: Event;
   tagType?: "Reply" | "Quote" | "";
   customEmojis?: CustomEmojiTag[];
+  media?: UploadedMedia[];
 };
 
 const CLIENT_TAG: string[] = ["client", "getwired.app"];
@@ -42,17 +44,45 @@ function buildCustomEmojiTags(comment: string, customEmojis: CustomEmojiTag[] = 
     .map((emoji) => ["emoji", emoji.shortcode, emoji.url]);
 }
 
+function buildMediaTags(media: UploadedMedia[] = []): string[][] {
+  return media.map((item) => {
+    const fields = [
+      "imeta",
+      `url ${item.url}`,
+      `m ${item.mime}`,
+      `x ${item.sha256}`,
+      `size ${item.size}`,
+    ];
+
+    if (item.width && item.height) {
+      fields.push(`dim ${item.width}x${item.height}`);
+    }
+    fields.push(...(item.imetaFields ?? []));
+
+    return fields;
+  });
+}
+
+function buildContent(comment: string, media: UploadedMedia[] = []): string {
+  const mediaUrls = media.map((item) => item.url).filter(Boolean);
+  if (mediaUrls.length === 0) return comment;
+
+  const body = comment.trimEnd();
+  return [body, mediaUrls.join("\n")].filter(Boolean).join("\n\n");
+}
+
 export function buildUnsignedEvent(draft: ComposeDraft): UnsignedEvent {
-  const { comment, refEvent, tagType = "", customEmojis } = draft;
+  const { comment, refEvent, tagType = "", customEmojis, media } = draft;
   const created_at = Math.floor(Date.now() / 1000);
   const refTags =
     refEvent && tagType ? buildRefTags(refEvent, tagType) : [];
   const customEmojiTags = buildCustomEmojiTags(comment, customEmojis);
+  const mediaTags = buildMediaTags(media);
 
   return {
     kind: 1,
-    tags: dedupeTags([CLIENT_TAG, ...refTags, ...customEmojiTags]),
-    content: comment,
+    tags: dedupeTags([CLIENT_TAG, ...refTags, ...customEmojiTags, ...mediaTags]),
+    content: buildContent(comment, media),
     created_at,
     pubkey: "",
   };

--- a/src/features/compose/useMediaUploads.ts
+++ b/src/features/compose/useMediaUploads.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  isSupportedMediaFile,
+  uploadMediaFile,
+  type BlossomAuthSigner,
+  type UploadedMedia,
+} from "@lib/blossom";
+
+export const MAX_MEDIA_ATTACHMENTS = 4;
+
+export type MediaUploadStatus = "uploading" | "uploaded" | "failed";
+
+export type MediaUpload = {
+  id: string;
+  file: File;
+  name: string;
+  previewUrl?: string;
+  status: MediaUploadStatus;
+  media?: UploadedMedia;
+  error?: string;
+};
+
+function createUploadId(): string {
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function createPreviewUrl(file: File): string | undefined {
+  if (!file.type.startsWith("image/") && !file.type.startsWith("video/")) return undefined;
+  if (typeof URL.createObjectURL !== "function") return undefined;
+  return URL.createObjectURL(file);
+}
+
+function revokePreviewUrl(upload: MediaUpload): void {
+  if (!upload.previewUrl || typeof URL.revokeObjectURL !== "function") return;
+  URL.revokeObjectURL(upload.previewUrl);
+}
+
+function failedUpload(file: File, error: string): MediaUpload {
+  return {
+    id: createUploadId(),
+    file,
+    name: file.name,
+    previewUrl: createPreviewUrl(file),
+    status: "failed",
+    error,
+  };
+}
+
+function pendingUpload(file: File): MediaUpload {
+  return {
+    id: createUploadId(),
+    file,
+    name: file.name,
+    previewUrl: createPreviewUrl(file),
+    status: "uploading",
+  };
+}
+
+export function useMediaUploads(signer: BlossomAuthSigner) {
+  const [uploads, setUploads] = useState<MediaUpload[]>([]);
+  const uploadsRef = useRef<MediaUpload[]>([]);
+
+  useEffect(() => {
+    uploadsRef.current = uploads;
+  }, [uploads]);
+
+  useEffect(() => () => {
+    uploadsRef.current.forEach(revokePreviewUrl);
+  }, []);
+
+  const startUpload = useCallback((upload: MediaUpload) => {
+    void uploadMediaFile({ file: upload.file, signer })
+      .then((media) => {
+        setUploads((current) =>
+          current.map((item) =>
+            item.id === upload.id ? { ...item, status: "uploaded", media, error: undefined } : item,
+          ),
+        );
+      })
+      .catch((error) => {
+        setUploads((current) =>
+          current.map((item) =>
+            item.id === upload.id
+              ? {
+                  ...item,
+                  status: "failed",
+                  error: error instanceof Error ? error.message : "Media upload failed.",
+                }
+              : item,
+          ),
+        );
+      });
+  }, [signer]);
+
+  const addFiles = useCallback((files: FileList | File[]) => {
+    const availableSlots = MAX_MEDIA_ATTACHMENTS - uploadsRef.current.length;
+    const selectedFiles = Array.from(files).slice(0, Math.max(0, availableSlots));
+    if (selectedFiles.length === 0) return;
+
+    const nextUploads = selectedFiles.map((file) =>
+      isSupportedMediaFile(file)
+        ? pendingUpload(file)
+        : failedUpload(file, "Unsupported media type or file is too large."),
+    );
+
+    setUploads((current) => [...current, ...nextUploads]);
+    nextUploads
+      .filter((upload) => upload.status === "uploading")
+      .forEach(startUpload);
+  }, [startUpload]);
+
+  const removeUpload = useCallback((id: string) => {
+    setUploads((current) => {
+      const removed = current.find((upload) => upload.id === id);
+      if (removed) revokePreviewUrl(removed);
+      return current.filter((upload) => upload.id !== id);
+    });
+  }, []);
+
+  const retryUpload = useCallback((id: string) => {
+    const upload = uploadsRef.current.find((item) => item.id === id);
+    if (!upload) return;
+
+    setUploads((current) =>
+      current.map((item) =>
+        item.id === id ? { ...item, status: "uploading", error: undefined } : item,
+      ),
+    );
+    startUpload({ ...upload, status: "uploading", error: undefined });
+  }, [startUpload]);
+
+  const clearUploads = useCallback(() => {
+    setUploads((current) => {
+      current.forEach(revokePreviewUrl);
+      return [];
+    });
+  }, []);
+
+  const uploadedMedia = useMemo(
+    () => uploads.flatMap((upload) => upload.status === "uploaded" && upload.media ? [upload.media] : []),
+    [uploads],
+  );
+  const hasUploading = uploads.some((upload) => upload.status === "uploading");
+  const hasFailed = uploads.some((upload) => upload.status === "failed");
+
+  return {
+    uploads,
+    uploadedMedia,
+    hasUploading,
+    hasFailed,
+    addFiles,
+    removeUpload,
+    retryUpload,
+    clearUploads,
+  };
+}

--- a/src/shared/hooks/useSubmitForm.ts
+++ b/src/shared/hooks/useSubmitForm.ts
@@ -1,5 +1,11 @@
 import { useEffect, useRef, useState, type FormEvent } from "react";
-import { generateSecretKey, getPublicKey, finalizeEvent, type UnsignedEvent, type Event } from "nostr-tools";
+import {
+  generateSecretKey,
+  getPublicKey,
+  finalizeEvent,
+  type UnsignedEvent,
+  type Event,
+} from "nostr-tools";
 import { publish } from "../../nostr/client";
 import { bytesToHex } from "@noble/hashes/utils";
 import { useStoredKeys } from "./useStoredKeys";
@@ -12,6 +18,11 @@ import {
 import { timeToGoEst } from "@lib/timeEstimate";
 
 export type SubmitStatus = "idle" | "mining" | "publishing" | "published" | "failed";
+
+type SubmitFormOptions = {
+  secretKey?: Uint8Array;
+  onRotateSecretKey?: (secretKey: Uint8Array) => void;
+};
 
 const POW_HASHRATE_STORAGE_KEY = "wired:last-pow-hashrate";
 const FALLBACK_POW_HASHRATE = 50_000;
@@ -43,12 +54,18 @@ export function willUseWiredAccount(
   );
 }
 
-export const useSubmitForm = (unsigned: UnsignedEvent, difficulty: string) => {
+export const useSubmitForm = (
+  unsigned: UnsignedEvent,
+  difficulty: string,
+  options: SubmitFormOptions = {},
+) => {
   const { appendKey } = useStoredKeys();
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>("idle");
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [acceptedRelays, setAcceptedRelays] = useState<string[]>([]);
-  const [sk, setSk] = useState(generateSecretKey());
+  const [internalSk, setInternalSk] = useState(generateSecretKey());
+  const sk = options.secretKey ?? internalSk;
+  const rotateSecretKey = options.onRotateSecretKey ?? setInternalSk;
   const unsignedWithPubkey = { ...unsigned, pubkey: getPublicKey(sk) };
   const [signedPoWEvent, setSignedPoWEvent] = useState<Event>();
   const [wiredAccountStatus, setWiredAccountStatus] = useState<WiredAccountStatus | null>(null);
@@ -125,6 +142,7 @@ export const useSubmitForm = (unsigned: UnsignedEvent, difficulty: string) => {
 
             setAcceptedRelays(result.acceptedRelays);
             setSignedPoWEvent(result.event);
+            rotateSecretKey(generateSecretKey());
             setSubmitStatus("published");
             return;
           }
@@ -144,7 +162,7 @@ export const useSubmitForm = (unsigned: UnsignedEvent, difficulty: string) => {
           setAcceptedRelays([...accepted]);
           setSignedPoWEvent(signedEvent);
           appendKey(bytesToHex(sk), getPublicKey(sk));
-          setSk(generateSecretKey());
+          rotateSecretKey(generateSecretKey());
           setSubmitStatus("published");
         } catch {
           if (activeSubmitId.current !== submitId) return;

--- a/src/shared/lib/blossom.test.ts
+++ b/src/shared/lib/blossom.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Event, EventTemplate } from "nostr-tools";
+import {
+  isSupportedMediaFile,
+  sha256File,
+  uploadMediaFile,
+  type BlossomAuthSigner,
+} from "./blossom";
+
+function decodeAuthHeader(header: string): Event {
+  const token = header.replace(/^Nostr\s+/, "").replace(/-/g, "+").replace(/_/g, "/");
+  const padded = token.padEnd(Math.ceil(token.length / 4) * 4, "=");
+  return JSON.parse(atob(padded));
+}
+
+function testSigner(template: EventTemplate): Event {
+  return {
+    ...template,
+    id: "1".repeat(64),
+    pubkey: "2".repeat(64),
+    sig: "3".repeat(128),
+  };
+}
+
+describe("Blossom media uploads", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("hashes files with SHA-256", async () => {
+    const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+
+    await expect(sha256File(file)).resolves.toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    );
+  });
+
+  it("validates supported media types and size", () => {
+    expect(isSupportedMediaFile(new File(["x"], "x.png", { type: "image/png" }))).toBe(true);
+    expect(isSupportedMediaFile(new File(["x"], "x.txt", { type: "text/plain" }))).toBe(false);
+  });
+
+  it("falls back from /media to /upload and returns uploaded media metadata", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response("missing", { status: 404 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        url: "https://cdn.example/video.mp4",
+        sha256: "abc123",
+        size: 4,
+        type: "video/mp4",
+        nip94: [
+          ["url", "https://cdn.example/video.mp4"],
+          ["thumb", "https://cdn.example/thumb.webp"],
+          ["blurhash", "abc"],
+        ],
+      }), { status: 200, headers: { "Content-Type": "application/json" } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const file = new File(["data"], "clip.mp4", { type: "video/mp4" });
+    const uploaded = await uploadMediaFile({
+      file,
+      signer: testSigner as BlossomAuthSigner,
+      servers: ["https://blossom.example/"],
+    });
+
+    expect(uploaded).toEqual({
+      url: "https://cdn.example/video.mp4",
+      mime: "video/mp4",
+      sha256: "abc123",
+      size: 4,
+      imetaFields: ["thumb https://cdn.example/thumb.webp", "blurhash abc"],
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://blossom.example/media",
+      expect.objectContaining({ method: "PUT" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://blossom.example/upload",
+      expect.objectContaining({ method: "PUT" }),
+    );
+
+    const secondCall = fetchMock.mock.calls[1][1] as RequestInit;
+    const headers = secondCall.headers as Record<string, string>;
+    const authEvent = decodeAuthHeader(headers.Authorization);
+
+    expect(headers["Content-Type"]).toBe("video/mp4");
+    expect(headers["X-Content-Length"]).toBe("4");
+    expect(headers["X-SHA-256"]).toBe(
+      "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7",
+    );
+    expect(authEvent.kind).toBe(24242);
+    expect(authEvent.tags).toContainEqual(["t", "upload"]);
+    expect(authEvent.tags).toContainEqual(["server", "blossom.example"]);
+    expect(authEvent.tags).toContainEqual([
+      "x",
+      "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7",
+    ]);
+  });
+});

--- a/src/shared/lib/blossom.ts
+++ b/src/shared/lib/blossom.ts
@@ -1,0 +1,277 @@
+import type { Event, EventTemplate } from "nostr-tools";
+import { BLOSSOM_SERVERS } from "../../config";
+
+export type BlossomAuthSigner = (template: EventTemplate) => Event;
+
+export type UploadedMedia = {
+  url: string;
+  mime: string;
+  sha256: string;
+  size: number;
+  width?: number;
+  height?: number;
+  imetaFields?: string[];
+};
+
+type BlossomDescriptor = {
+  url?: string;
+  sha256?: string;
+  size?: number;
+  type?: string;
+  nip94?: string[][];
+};
+
+const supportedMediaTypes = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+  "audio/mpeg",
+  "audio/wav",
+  "audio/ogg",
+  "audio/mp4",
+]);
+
+export const MAX_MEDIA_UPLOAD_BYTES = 25 * 1024 * 1024;
+
+function bytesToHex(bytes: ArrayBuffer): string {
+  return [...new Uint8Array(bytes)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function base64UrlEncode(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function normalizeServerUrl(server: string): string {
+  return server.trim().replace(/\/+$/, "");
+}
+
+function serverDomain(server: string): string {
+  return new URL(server).hostname.toLowerCase();
+}
+
+function descriptorTagValue(descriptor: BlossomDescriptor, key: string): string | undefined {
+  return descriptor.nip94?.find((tag) => tag[0] === key)?.[1];
+}
+
+function descriptorExtraImetaFields(descriptor: BlossomDescriptor): string[] {
+  const handledTags = new Set(["url", "m", "x", "size", "dim"]);
+  return (descriptor.nip94 || [])
+    .filter((tag) => tag.length >= 2 && !handledTags.has(tag[0]))
+    .map(([key, ...values]) => `${key} ${values.join(" ").trim()}`.trim())
+    .filter(Boolean);
+}
+
+function descriptorToUploadedMedia(
+  descriptor: BlossomDescriptor,
+  file: File,
+  sha256: string,
+  dimensions?: Pick<UploadedMedia, "width" | "height">,
+): UploadedMedia {
+  const url = descriptor.url || descriptorTagValue(descriptor, "url");
+  if (!url) {
+    throw new Error("Blossom response did not include a media URL.");
+  }
+
+  const mime = descriptor.type || descriptorTagValue(descriptor, "m") || file.type;
+  const descriptorSize = descriptor.size ?? Number(descriptorTagValue(descriptor, "size"));
+  const sizeValue = Number.isFinite(descriptorSize) && descriptorSize > 0
+    ? descriptorSize
+    : file.size;
+  const hashValue = descriptor.sha256 || descriptorTagValue(descriptor, "x") || sha256;
+  const imetaFields = descriptorExtraImetaFields(descriptor);
+
+  return {
+    url,
+    mime,
+    sha256: hashValue,
+    size: sizeValue,
+    ...(dimensions?.width ? { width: dimensions.width } : {}),
+    ...(dimensions?.height ? { height: dimensions.height } : {}),
+    ...(imetaFields.length > 0 ? { imetaFields } : {}),
+  };
+}
+
+function uploadAuthorizationHeader({
+  action,
+  sha256,
+  server,
+  signer,
+}: {
+  action: "media" | "upload";
+  sha256: string;
+  server: string;
+  signer: BlossomAuthSigner;
+}): string {
+  const now = Math.floor(Date.now() / 1000);
+  const event = signer({
+    kind: 24242,
+    created_at: now,
+    tags: [
+      ["t", action],
+      ["expiration", String(now + 5 * 60)],
+      ["server", serverDomain(server)],
+      ["x", sha256],
+    ],
+    content: action === "media" ? "Upload Media" : "Upload Blob",
+  });
+
+  return `Nostr ${base64UrlEncode(JSON.stringify(event))}`;
+}
+
+async function putBlossomEndpoint({
+  file,
+  server,
+  endpoint,
+  action,
+  sha256,
+  signer,
+}: {
+  file: File;
+  server: string;
+  endpoint: "/media" | "/upload";
+  action: "media" | "upload";
+  sha256: string;
+  signer: BlossomAuthSigner;
+}): Promise<BlossomDescriptor> {
+  const response = await fetch(`${server}${endpoint}`, {
+    method: "PUT",
+    headers: {
+      Authorization: uploadAuthorizationHeader({ action, sha256, server, signer }),
+      "Content-Type": file.type || "application/octet-stream",
+      "X-Content-Length": String(file.size),
+      "X-SHA-256": sha256,
+    },
+    body: file,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Blossom ${endpoint} failed with ${response.status}`);
+  }
+
+  return response.json() as Promise<BlossomDescriptor>;
+}
+
+export function isSupportedMediaFile(file: File): boolean {
+  return supportedMediaTypes.has(file.type) && file.size <= MAX_MEDIA_UPLOAD_BYTES;
+}
+
+function fileArrayBuffer(file: File): Promise<ArrayBuffer> {
+  if (typeof file.arrayBuffer === "function") return file.arrayBuffer();
+
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (reader.result instanceof ArrayBuffer) {
+        resolve(reader.result);
+        return;
+      }
+      reject(new Error("Unable to read media file."));
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("Unable to read media file."));
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+export async function sha256File(file: File): Promise<string> {
+  const bytes = new Uint8Array(await fileArrayBuffer(file));
+  return bytesToHex(await crypto.subtle.digest("SHA-256", bytes));
+}
+
+export async function readImageDimensions(
+  file: File,
+): Promise<Pick<UploadedMedia, "width" | "height"> | undefined> {
+  if (!file.type.startsWith("image/") || typeof Image === "undefined") return undefined;
+
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    return await new Promise((resolve) => {
+      const image = new Image();
+      image.onload = () => {
+        resolve({
+          width: image.naturalWidth || undefined,
+          height: image.naturalHeight || undefined,
+        });
+      };
+      image.onerror = () => resolve(undefined);
+      image.src = objectUrl;
+    });
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+export async function uploadMediaFile({
+  file,
+  signer,
+  servers = BLOSSOM_SERVERS,
+}: {
+  file: File;
+  signer: BlossomAuthSigner;
+  servers?: readonly string[];
+}): Promise<UploadedMedia> {
+  if (!isSupportedMediaFile(file)) {
+    throw new Error("Unsupported media type or file is too large.");
+  }
+
+  const serverList = servers.map(normalizeServerUrl).filter(Boolean);
+  if (serverList.length === 0) {
+    throw new Error("No Blossom upload servers are configured.");
+  }
+
+  const sha256 = await sha256File(file);
+  const dimensions = await readImageDimensions(file);
+  const errors: string[] = [];
+
+  for (const server of serverList) {
+    try {
+      const descriptor = file.type.startsWith("image/") || file.type.startsWith("video/")
+        ? await putBlossomEndpoint({
+            file,
+            server,
+            endpoint: "/media",
+            action: "media",
+            sha256,
+            signer,
+          })
+        : await putBlossomEndpoint({
+            file,
+            server,
+            endpoint: "/upload",
+            action: "upload",
+            sha256,
+            signer,
+          });
+
+      return descriptorToUploadedMedia(descriptor, file, sha256, dimensions);
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : "upload failed");
+    }
+
+    try {
+      const descriptor = await putBlossomEndpoint({
+        file,
+        server,
+        endpoint: "/upload",
+        action: "upload",
+        sha256,
+        signer,
+      });
+      return descriptorToUploadedMedia(descriptor, file, sha256, dimensions);
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : "upload failed");
+    }
+  }
+
+  throw new Error(errors[0] || "Media upload failed.");
+}


### PR DESCRIPTION
## Summary
- add client-side Blossom media uploads with kind 24242 auth, /media preferred and /upload fallback
- add composer media picker with upload status, retry/remove controls, and media-only posting support
- include uploaded media URLs plus imeta tags in kind-1 events before PoW mining
- preserve NIP-94 descriptor extras such as thumb and blurhash in imeta fields
- configure upload servers via VITE_BLOSSOM_SERVERS with a default HTTPS Blossom server

## Notes
- This PR only changes Wired; no wired-admin changes.
- Wired-account posts can attach uploaded media, but the upload authorization is still client-side because this PR intentionally avoids wired-admin changes.

## Tests
- npm test -- src/config.test.ts src/shared/lib/blossom.test.ts src/features/compose/buildUnsignedEvent.test.ts src/features/compose/PostForm.test.tsx src/shared/hooks/useSubmitForm.test.tsx
- npm test -- src/shared/lib/blossom.test.ts src/features/compose/buildUnsignedEvent.test.ts src/features/compose/PostForm.test.tsx
- npm test
- npm run typecheck
- npm run lint (passes with existing fast-refresh warnings)
- npm run build
- production preview smoke: / and /activity returned the built SPA shell