### PR TITLE
Add thread share control and Wired identity

### DIFF
--- a/src/features/thread/ThreadPage.tsx
+++ b/src/features/thread/ThreadPage.tsx
@@ -58,6 +58,7 @@ function ThreadView({ hexID, relayHints }: { hexID: string; relayHints: string[]
             role="threadOp"
             totalWork={opScore?.totalWork}
             replyCount={opScore?.threadReplyCount}
+            relayHints={relayHints}
           />
         </ContentColumn>
         <ThreadComposer OPEvent={opEvent} />

--- a/src/shared/ui/MetadataRow.tsx
+++ b/src/shared/ui/MetadataRow.tsx
@@ -1,10 +1,12 @@
 import { Activity, Network } from "lucide-react";
+import type { ReactNode } from "react";
 
 type MetadataRowProps = {
   signal: number;
   replyCount: number;
   timestamp: string;
   forceSecondary?: boolean;
+  trailing?: ReactNode;
 };
 
 function getReplyLabel(replyCount: number) {
@@ -16,6 +18,7 @@ export function MetadataRow({
   replyCount,
   timestamp,
   forceSecondary = false,
+  trailing,
 }: MetadataRowProps) {
   return (
     <div
@@ -43,6 +46,7 @@ export function MetadataRow({
         </span>
         <span className="whitespace-nowrap">{timestamp}</span>
       </div>
+      {trailing && <div className="flex shrink-0 items-center gap-3">{trailing}</div>}
     </div>
   );
 }

--- a/src/shared/ui/PostCard.test.tsx
+++ b/src/shared/ui/PostCard.test.tsx
@@ -214,14 +214,14 @@ describe("PostCard thread opening", () => {
       root.render(<PostCard event={event()} replies={[]} role="threadOp" totalWork={16} />);
     });
 
-    expect(container.querySelector("button[aria-label='Share this thread']")).not.toBeNull();
+    expect(container.querySelector("button[aria-label='More sharing options']")).not.toBeNull();
     expect(container.textContent).toContain("wiredsignal.online");
 
     act(() => {
       root.render(<PostCard event={event()} replies={[]} role="feed" totalWork={16} />);
     });
 
-    expect(container.querySelector("button[aria-label='Share this thread']")).toBeNull();
+    expect(container.querySelector("button[aria-label='More sharing options']")).toBeNull();
     expect(container.textContent).not.toContain("wiredsignal.online");
   });
 });

--- a/src/shared/ui/PostCard.test.tsx
+++ b/src/shared/ui/PostCard.test.tsx
@@ -208,4 +208,20 @@ describe("PostCard thread opening", () => {
 
     expect(onOpenThread).not.toHaveBeenCalled();
   });
+
+  it("shows sharing and Wired identity only on the thread root", () => {
+    act(() => {
+      root.render(<PostCard event={event()} replies={[]} role="threadOp" totalWork={16} />);
+    });
+
+    expect(container.querySelector("button[aria-label='Share this thread']")).not.toBeNull();
+    expect(container.textContent).toContain("wiredsignal.online");
+
+    act(() => {
+      root.render(<PostCard event={event()} replies={[]} role="feed" totalWork={16} />);
+    });
+
+    expect(container.querySelector("button[aria-label='Share this thread']")).toBeNull();
+    expect(container.textContent).not.toContain("wiredsignal.online");
+  });
 });

--- a/src/shared/ui/PostCard.test.tsx
+++ b/src/shared/ui/PostCard.test.tsx
@@ -214,14 +214,14 @@ describe("PostCard thread opening", () => {
       root.render(<PostCard event={event()} replies={[]} role="threadOp" totalWork={16} />);
     });
 
-    expect(container.querySelector("button[aria-label='More sharing options']")).not.toBeNull();
+    expect(container.querySelector("button[aria-label='Share this thread']")).not.toBeNull();
     expect(container.textContent).toContain("wiredsignal.online");
 
     act(() => {
       root.render(<PostCard event={event()} replies={[]} role="feed" totalWork={16} />);
     });
 
-    expect(container.querySelector("button[aria-label='More sharing options']")).toBeNull();
+    expect(container.querySelector("button[aria-label='Share this thread']")).toBeNull();
     expect(container.textContent).not.toContain("wiredsignal.online");
   });
 });

--- a/src/shared/ui/PostCard.tsx
+++ b/src/shared/ui/PostCard.tsx
@@ -11,6 +11,7 @@ import { SignalAvatar } from "./SignalAvatar";
 import { useProfile } from "../hooks/useProfiles";
 import { useMemo, useCallback, type KeyboardEvent, type MouseEvent } from "react";
 import { useNavigate } from "react-router-dom";
+import { ShareControl } from "./ShareControl";
 
 interface PostCardProps {
   event: Event;
@@ -196,7 +197,26 @@ export function PostCard({
         replyCount={displayedReplyCount}
         timestamp={timestamp}
         forceSecondary={role === "threadOp"}
+        trailing={
+          role === "threadOp" ? (
+            <>
+              <span className="hidden text-muted sm:inline" aria-label="Wired website">
+                wiredsignal.online
+              </span>
+              <ShareControl
+                eventId={event.id}
+                relayHints={relayHints}
+                excerpt={event.content}
+              />
+            </>
+          ) : undefined
+        }
       />
+      {role === "threadOp" && (
+        <div className="pt-2 text-right text-micro text-muted sm:hidden" aria-hidden="true">
+          wiredsignal.online
+        </div>
+      )}
     </article>
   );
 }

--- a/src/shared/ui/PostCard.tsx
+++ b/src/shared/ui/PostCard.tsx
@@ -183,6 +183,11 @@ export function PostCard({
           priority={avatarPriority}
         />
         <span className="min-w-0 truncate">{authorLabel}</span>
+        {role === "threadOp" && (
+          <span className="ml-auto shrink-0 text-muted" aria-label="Wired website">
+            wiredsignal.online
+          </span>
+        )}
       </header>
 
       <div className="post-content flex flex-col gap-2 break-words">
@@ -199,24 +204,14 @@ export function PostCard({
         forceSecondary={role === "threadOp"}
         trailing={
           role === "threadOp" ? (
-            <>
-              <span className="hidden text-muted sm:inline" aria-label="Wired website">
-                wiredsignal.online
-              </span>
-              <ShareControl
-                eventId={event.id}
-                relayHints={relayHints}
-                excerpt={event.content}
-              />
-            </>
+            <ShareControl
+              eventId={event.id}
+              relayHints={relayHints}
+              excerpt={event.content}
+            />
           ) : undefined
         }
       />
-      {role === "threadOp" && (
-        <div className="pt-2 text-right text-micro text-muted sm:hidden" aria-hidden="true">
-          wiredsignal.online
-        </div>
-      )}
     </article>
   );
 }

--- a/src/shared/ui/ShareControl.test.tsx
+++ b/src/shared/ui/ShareControl.test.tsx
@@ -29,15 +29,59 @@ describe("ShareControl", () => {
     act(() => {
       root.render(<ShareControl eventId={"1".repeat(64)} excerpt="a signal" />);
     });
-    return container.querySelector("button[aria-label='More sharing options']") as HTMLButtonElement;
+    return container.querySelector<HTMLButtonElement>("button[aria-label='Share this thread']")!;
   }
 
-  it("uses the native share sheet with a canonical thread URL", async () => {
+  function openMenu() {
+    const trigger = renderControl();
+    act(() => trigger.click());
+    return trigger;
+  }
+
+  it("bundles preferred platforms beneath one share button", () => {
+    const trigger = renderControl();
+    expect(container.querySelector("[role='menu']")).toBeNull();
+
+    act(() => trigger.click());
+
+    const menu = container.querySelector("[role='menu']");
+    expect(menu).not.toBeNull();
+    expect(menu?.textContent).toContain("Share to X");
+    expect(menu?.textContent).toContain("Share to Discord");
+    expect(menu?.textContent).toContain("Share to Instagram");
+    expect(menu?.textContent).toContain("Copy link");
+    expect(menu?.textContent).toContain("More options");
+  });
+
+  it("builds an X intent with the canonical thread URL", () => {
+    openMenu();
+
+    const xLink = container.querySelector<HTMLAnchorElement>("a[href^='https://x.com/intent/post']");
+    expect(xLink).not.toBeNull();
+    expect(decodeURIComponent(xLink?.href ?? "")).toContain("/thread/nevent1");
+  });
+
+  it("copies the canonical URL for platforms without a web composer", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    openMenu();
+    const discordButton = [...container.querySelectorAll<HTMLButtonElement>("[role='menuitem']")]
+      .find((button) => button.textContent?.includes("Discord"));
+
+    await act(async () => discordButton?.click());
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/thread/nevent1"));
+    expect(container.textContent).toContain("link copied for Discord");
+  });
+
+  it("opens the native share sheet from More options", async () => {
     const share = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", { share });
-    const button = renderControl();
+    openMenu();
+    const moreButton = [...container.querySelectorAll<HTMLButtonElement>("[role='menuitem']")]
+      .find((button) => button.textContent?.includes("More options"));
 
-    await act(async () => button.click());
+    await act(async () => moreButton?.click());
 
     expect(share).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -46,63 +90,30 @@ describe("ShareControl", () => {
         url: expect.stringMatching(/^http:\/\/localhost:\d*\/thread\/nevent1/),
       }),
     );
+    expect(container.querySelector("[role='menu']")).toBeNull();
   });
 
-  it("puts an X intent link ahead of the fallback sharing options", () => {
-    renderControl();
-
-    const xLink = container.querySelector<HTMLAnchorElement>("a[aria-label='Share this thread on X']");
-    expect(xLink).not.toBeNull();
-    expect(xLink?.href).toContain("https://x.com/intent/post?text=");
-    expect(decodeURIComponent(xLink?.href ?? "")).toContain("/thread/nevent1");
-  });
-
-  it("copies the URL when native sharing is unavailable", async () => {
+  it("copies from More options when native sharing is unavailable", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", { clipboard: { writeText } });
-    const button = renderControl();
+    openMenu();
+    const moreButton = [...container.querySelectorAll<HTMLButtonElement>("[role='menuitem']")]
+      .find((button) => button.textContent?.includes("More options"));
 
-    await act(async () => button.click());
+    await act(async () => moreButton?.click());
 
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/thread/nevent1"));
     expect(container.textContent).toContain("link copied");
   });
 
-  it("copies the URL for Discord", async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    vi.stubGlobal("navigator", { clipboard: { writeText } });
-    renderControl();
-    const discordButton = container.querySelector<HTMLButtonElement>(
-      "button[aria-label='Copy this thread link for Discord']",
-    );
+  it("closes on Escape and returns focus to the trigger", () => {
+    const trigger = openMenu();
 
-    await act(async () => discordButton?.click());
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
 
-    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/thread/nevent1"));
-    expect(container.textContent).toContain("link copied");
-  });
-
-  it("does nothing when the native share sheet is cancelled", async () => {
-    const writeText = vi.fn();
-    const share = vi.fn().mockRejectedValue(new DOMException("cancelled", "AbortError"));
-    vi.stubGlobal("navigator", { share, clipboard: { writeText } });
-    const button = renderControl();
-
-    await act(async () => button.click());
-
-    expect(writeText).not.toHaveBeenCalled();
-    expect(container.textContent).not.toContain("link copied");
-  });
-
-  it("copies after a non-cancellation share failure", async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    const share = vi.fn().mockRejectedValue(new Error("not available"));
-    vi.stubGlobal("navigator", { share, clipboard: { writeText } });
-    const button = renderControl();
-
-    await act(async () => button.click());
-
-    expect(writeText).toHaveBeenCalledOnce();
-    expect(container.textContent).toContain("link copied");
+    expect(container.querySelector("[role='menu']")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
   });
 });

--- a/src/shared/ui/ShareControl.test.tsx
+++ b/src/shared/ui/ShareControl.test.tsx
@@ -3,6 +3,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { decodeThreadRef } from "@lib/threadRefs";
 import { ShareControl } from "./ShareControl";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
@@ -47,8 +48,7 @@ describe("ShareControl", () => {
     const menu = container.querySelector("[role='menu']");
     expect(menu).not.toBeNull();
     expect(menu?.textContent).toContain("Share to X");
-    expect(menu?.textContent).toContain("Share to Discord");
-    expect(menu?.textContent).toContain("Share to Instagram");
+    expect(menu?.textContent).toContain("Share to Nostr");
     expect(menu?.textContent).toContain("Copy link");
     expect(menu?.textContent).toContain("More options");
   });
@@ -56,22 +56,30 @@ describe("ShareControl", () => {
   it("builds an X intent with the canonical thread URL", () => {
     openMenu();
 
-    const xLink = container.querySelector<HTMLAnchorElement>("a[href^='https://x.com/intent/post']");
+    const xLink = container.querySelector<HTMLAnchorElement>("a[href^='https://twitter.com/intent/tweet']");
     expect(xLink).not.toBeNull();
     expect(decodeURIComponent(xLink?.href ?? "")).toContain("/thread/nevent1");
   });
 
-  it("copies the canonical URL for platforms without a web composer", async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    vi.stubGlobal("navigator", { clipboard: { writeText } });
-    openMenu();
-    const discordButton = [...container.querySelectorAll<HTMLButtonElement>("[role='menuitem']")]
-      .find((button) => button.textContent?.includes("Discord"));
+  it("opens a NIP-21 nevent URI with relay hints", () => {
+    act(() => {
+      root.render(
+        <ShareControl
+          eventId={"1".repeat(64)}
+          relayHints={["wss://relay.wiredsignal.online"]}
+        />,
+      );
+    });
+    act(() => {
+      container.querySelector<HTMLButtonElement>("button[aria-label='Share this thread']")?.click();
+    });
 
-    await act(async () => discordButton?.click());
-
-    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/thread/nevent1"));
-    expect(container.textContent).toContain("link copied for Discord");
+    const nostrLink = container.querySelector<HTMLAnchorElement>("a[href^='nostr:nevent1']");
+    expect(nostrLink).not.toBeNull();
+    expect(decodeThreadRef(nostrLink?.getAttribute("href")?.slice(6))).toEqual({
+      id: "1".repeat(64),
+      relays: ["wss://relay.wiredsignal.online"],
+    });
   });
 
   it("opens the native share sheet from More options", async () => {

--- a/src/shared/ui/ShareControl.test.tsx
+++ b/src/shared/ui/ShareControl.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ShareControl } from "./ShareControl";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ShareControl", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function renderControl() {
+    act(() => {
+      root.render(<ShareControl eventId={"1".repeat(64)} excerpt="a signal" />);
+    });
+    return container.querySelector("button") as HTMLButtonElement;
+  }
+
+  it("uses the native share sheet with a canonical thread URL", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { share });
+    const button = renderControl();
+
+    await act(async () => button.click());
+
+    expect(share).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Wired signal",
+        text: "a signal",
+        url: expect.stringMatching(/^http:\/\/localhost:\d*\/thread\/nevent1/),
+      }),
+    );
+  });
+
+  it("copies the URL when native sharing is unavailable", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const button = renderControl();
+
+    await act(async () => button.click());
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/thread/nevent1"));
+    expect(button.textContent).toContain("copied");
+  });
+
+  it("does nothing when the native share sheet is cancelled", async () => {
+    const writeText = vi.fn();
+    const share = vi.fn().mockRejectedValue(new DOMException("cancelled", "AbortError"));
+    vi.stubGlobal("navigator", { share, clipboard: { writeText } });
+    const button = renderControl();
+
+    await act(async () => button.click());
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(button.textContent).toContain("share");
+  });
+
+  it("copies after a non-cancellation share failure", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const share = vi.fn().mockRejectedValue(new Error("not available"));
+    vi.stubGlobal("navigator", { share, clipboard: { writeText } });
+    const button = renderControl();
+
+    await act(async () => button.click());
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(button.textContent).toContain("copied");
+  });
+});

--- a/src/shared/ui/ShareControl.test.tsx
+++ b/src/shared/ui/ShareControl.test.tsx
@@ -29,7 +29,7 @@ describe("ShareControl", () => {
     act(() => {
       root.render(<ShareControl eventId={"1".repeat(64)} excerpt="a signal" />);
     });
-    return container.querySelector("button") as HTMLButtonElement;
+    return container.querySelector("button[aria-label='More sharing options']") as HTMLButtonElement;
   }
 
   it("uses the native share sheet with a canonical thread URL", async () => {
@@ -48,6 +48,15 @@ describe("ShareControl", () => {
     );
   });
 
+  it("puts an X intent link ahead of the fallback sharing options", () => {
+    renderControl();
+
+    const xLink = container.querySelector<HTMLAnchorElement>("a[aria-label='Share this thread on X']");
+    expect(xLink).not.toBeNull();
+    expect(xLink?.href).toContain("https://x.com/intent/post?text=");
+    expect(decodeURIComponent(xLink?.href ?? "")).toContain("/thread/nevent1");
+  });
+
   it("copies the URL when native sharing is unavailable", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", { clipboard: { writeText } });
@@ -56,7 +65,21 @@ describe("ShareControl", () => {
     await act(async () => button.click());
 
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/thread/nevent1"));
-    expect(button.textContent).toContain("copied");
+    expect(container.textContent).toContain("link copied");
+  });
+
+  it("copies the URL for Discord", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    renderControl();
+    const discordButton = container.querySelector<HTMLButtonElement>(
+      "button[aria-label='Copy this thread link for Discord']",
+    );
+
+    await act(async () => discordButton?.click());
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/thread/nevent1"));
+    expect(container.textContent).toContain("link copied");
   });
 
   it("does nothing when the native share sheet is cancelled", async () => {
@@ -68,7 +91,7 @@ describe("ShareControl", () => {
     await act(async () => button.click());
 
     expect(writeText).not.toHaveBeenCalled();
-    expect(button.textContent).toContain("share");
+    expect(container.textContent).not.toContain("link copied");
   });
 
   it("copies after a non-cancellation share failure", async () => {
@@ -80,6 +103,6 @@ describe("ShareControl", () => {
     await act(async () => button.click());
 
     expect(writeText).toHaveBeenCalledOnce();
-    expect(button.textContent).toContain("copied");
+    expect(container.textContent).toContain("link copied");
   });
 });

--- a/src/shared/ui/ShareControl.tsx
+++ b/src/shared/ui/ShareControl.tsx
@@ -1,4 +1,4 @@
-import { Check, Share2 } from "lucide-react";
+import { Check, MessageCircle, Share2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { buildThreadPath } from "@lib/threadRefs";
 
@@ -83,19 +83,54 @@ export function ShareControl({
     showStatus((await copyText(url)) ? "copied" : "error");
   }, [eventId, excerpt, relayHints, showStatus]);
 
-  const label = status === "copied" ? "copied" : status === "error" ? "copy failed" : "share";
-  const Icon = status === "copied" ? Check : Share2;
+  const handleDiscord = useCallback(async () => {
+    const url = canonicalThreadUrl(eventId, relayHints);
+    showStatus((await copyText(url)) ? "copied" : "error");
+  }, [eventId, relayHints, showStatus]);
+
+  const url = canonicalThreadUrl(eventId, relayHints);
+  const xIntentUrl = new URL("https://x.com/intent/post");
+  xIntentUrl.searchParams.set(
+    "text",
+    `${excerpt?.trim().slice(0, 180) || "Wired signal"}\n${url}`,
+  );
+  const statusLabel = status === "copied" ? "link copied" : "copy failed";
 
   return (
-    <button
-      type="button"
-      onClick={handleShare}
-      className="wired-touch-target wired-pressable inline-flex min-h-[24px] min-w-[24px] items-center gap-1 rounded-sm text-secondary transition-colors duration-hover hover:text-primary focus-visible:outline-none"
-      aria-label={status === "idle" ? "Share this thread" : label}
-      aria-live="polite"
-    >
-      <Icon aria-hidden="true" className="h-3.5 w-3.5" strokeWidth={1.8} />
-      <span>{label}</span>
-    </button>
+    <div className="flex items-center gap-3" aria-label="Share this thread">
+      <a
+        href={xIntentUrl.toString()}
+        target="_blank"
+        rel="noreferrer"
+        className="wired-touch-target wired-pressable inline-flex min-h-[24px] min-w-[24px] items-center rounded-sm text-secondary transition-colors duration-hover hover:text-primary focus-visible:outline-none"
+        aria-label="Share this thread on X"
+      >
+        X
+      </a>
+      <button
+        type="button"
+        onClick={handleDiscord}
+        className="wired-touch-target wired-pressable inline-flex min-h-[24px] min-w-[24px] items-center gap-1 rounded-sm text-secondary transition-colors duration-hover hover:text-primary focus-visible:outline-none"
+        aria-label="Copy this thread link for Discord"
+      >
+        <MessageCircle aria-hidden="true" className="h-3.5 w-3.5" strokeWidth={1.8} />
+        <span>Discord</span>
+      </button>
+      <button
+        type="button"
+        onClick={handleShare}
+        className="wired-touch-target wired-pressable inline-flex min-h-[24px] min-w-[24px] items-center gap-1 rounded-sm text-secondary transition-colors duration-hover hover:text-primary focus-visible:outline-none"
+        aria-label="More sharing options"
+      >
+        <Share2 aria-hidden="true" className="h-3.5 w-3.5" strokeWidth={1.8} />
+        <span>more</span>
+      </button>
+      {status !== "idle" && (
+        <span className="inline-flex items-center gap-1 text-signal" aria-live="polite">
+          {status === "copied" && <Check aria-hidden="true" className="h-3.5 w-3.5" strokeWidth={1.8} />}
+          {statusLabel}
+        </span>
+      )}
+    </div>
   );
 }

--- a/src/shared/ui/ShareControl.tsx
+++ b/src/shared/ui/ShareControl.tsx
@@ -1,13 +1,12 @@
 import {
-  Camera,
   Check,
   Copy,
-  MessageCircle,
+  Radio,
   Share2,
   X as CloseIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { buildThreadPath } from "@lib/threadRefs";
+import { buildThreadPath, encodeThreadRef } from "@lib/threadRefs";
 
 type ShareControlProps = {
   eventId: string;
@@ -116,7 +115,7 @@ export function ShareControl({
   );
 
   const url = canonicalThreadUrl(eventId, relayHints);
-  const xIntentUrl = new URL("https://x.com/intent/post");
+  const xIntentUrl = new URL("https://twitter.com/intent/tweet");
   xIntentUrl.searchParams.set(
     "text",
     `${excerpt?.trim().slice(0, 180) || "Wired signal"}\n${url}`,
@@ -209,24 +208,15 @@ export function ShareControl({
               <span aria-hidden="true" className="w-4 text-center text-body">X</span>
               <span>Share to X</span>
             </a>
-            <button
-              type="button"
+            <a
+              href={`nostr:${encodeThreadRef(eventId, relayHints)}`}
               role="menuitem"
               className={menuItemClass}
-              onClick={() => void copyFor("Discord")}
+              onClick={closeMenu}
             >
-              <MessageCircle aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} />
-              <span>Share to Discord</span>
-            </button>
-            <button
-              type="button"
-              role="menuitem"
-              className={menuItemClass}
-              onClick={() => void copyFor("Instagram")}
-            >
-              <Camera aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} />
-              <span>Share to Instagram</span>
-            </button>
+              <Radio aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} />
+              <span>Share to Nostr</span>
+            </a>
             <button
               type="button"
               role="menuitem"

--- a/src/shared/ui/ShareControl.tsx
+++ b/src/shared/ui/ShareControl.tsx
@@ -1,4 +1,11 @@
-import { Check, MessageCircle, Share2 } from "lucide-react";
+import {
+  Camera,
+  Check,
+  Copy,
+  MessageCircle,
+  Share2,
+  X as CloseIcon,
+} from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { buildThreadPath } from "@lib/threadRefs";
 
@@ -48,8 +55,45 @@ export function ShareControl({
   relayHints = [],
   excerpt,
 }: ShareControlProps) {
+  const [isOpen, setIsOpen] = useState(false);
   const [status, setStatus] = useState<"idle" | "copied" | "error">("idle");
+  const [statusContext, setStatusContext] = useState("");
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const resetTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  const closeMenu = useCallback(() => {
+    setIsOpen(false);
+    wrapperRef.current?.querySelector<HTMLButtonElement>("[data-share-trigger]")?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      panelRef.current?.querySelector<HTMLElement>("[role='menuitem']")?.focus();
+    });
+
+    function handlePointerDown(event: PointerEvent) {
+      if (wrapperRef.current?.contains(event.target as Node)) return;
+      closeMenu();
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      closeMenu();
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [closeMenu, isOpen]);
 
   useEffect(
     () => () => {
@@ -58,35 +102,18 @@ export function ShareControl({
     [],
   );
 
-  const showStatus = useCallback((nextStatus: "copied" | "error") => {
-    setStatus(nextStatus);
-    if (resetTimer.current) clearTimeout(resetTimer.current);
-    resetTimer.current = setTimeout(() => setStatus("idle"), FEEDBACK_DURATION_MS);
-  }, []);
-
-  const handleShare = useCallback(async () => {
-    const url = canonicalThreadUrl(eventId, relayHints);
-
-    if (navigator.share) {
-      try {
-        await navigator.share({
-          title: "Wired signal",
-          text: excerpt?.trim().slice(0, 180) || undefined,
-          url,
-        });
-        return;
-      } catch (error) {
-        if (error instanceof DOMException && error.name === "AbortError") return;
-      }
-    }
-
-    showStatus((await copyText(url)) ? "copied" : "error");
-  }, [eventId, excerpt, relayHints, showStatus]);
-
-  const handleDiscord = useCallback(async () => {
-    const url = canonicalThreadUrl(eventId, relayHints);
-    showStatus((await copyText(url)) ? "copied" : "error");
-  }, [eventId, relayHints, showStatus]);
+  const showStatus = useCallback(
+    (nextStatus: "copied" | "error", context = "") => {
+      setStatus(nextStatus);
+      setStatusContext(context);
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => {
+        setStatus("idle");
+        setStatusContext("");
+      }, FEEDBACK_DURATION_MS);
+    },
+    [],
+  );
 
   const url = canonicalThreadUrl(eventId, relayHints);
   const xIntentUrl = new URL("https://x.com/intent/post");
@@ -94,42 +121,150 @@ export function ShareControl({
     "text",
     `${excerpt?.trim().slice(0, 180) || "Wired signal"}\n${url}`,
   );
-  const statusLabel = status === "copied" ? "link copied" : "copy failed";
+
+  const copyFor = useCallback(
+    async (destination: string) => {
+      showStatus((await copyText(url)) ? "copied" : "error", destination);
+    },
+    [showStatus, url],
+  );
+
+  const handleMore = useCallback(async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: "Wired signal",
+          text: excerpt?.trim().slice(0, 180) || undefined,
+          url,
+        });
+        closeMenu();
+        return;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          closeMenu();
+          return;
+        }
+      }
+    }
+
+    showStatus((await copyText(url)) ? "copied" : "error");
+  }, [closeMenu, excerpt, showStatus, url]);
+
+  const menuItemClass =
+    "wired-pressable flex min-h-11 w-full items-center gap-3 rounded-sm px-3 py-2 text-left text-meta text-secondary hover:bg-signal-ghost hover:text-primary focus-visible:bg-signal-ghost focus-visible:text-primary";
 
   return (
-    <div className="flex items-center gap-3" aria-label="Share this thread">
-      <a
-        href={xIntentUrl.toString()}
-        target="_blank"
-        rel="noreferrer"
-        className="wired-touch-target wired-pressable inline-flex min-h-[24px] min-w-[24px] items-center rounded-sm text-secondary transition-colors duration-hover hover:text-primary focus-visible:outline-none"
-        aria-label="Share this thread on X"
-      >
-        X
-      </a>
+    <div ref={wrapperRef} className="relative">
       <button
         type="button"
-        onClick={handleDiscord}
+        data-share-trigger="true"
+        onClick={() => setIsOpen((open) => !open)}
         className="wired-touch-target wired-pressable inline-flex min-h-[24px] min-w-[24px] items-center gap-1 rounded-sm text-secondary transition-colors duration-hover hover:text-primary focus-visible:outline-none"
-        aria-label="Copy this thread link for Discord"
-      >
-        <MessageCircle aria-hidden="true" className="h-3.5 w-3.5" strokeWidth={1.8} />
-        <span>Discord</span>
-      </button>
-      <button
-        type="button"
-        onClick={handleShare}
-        className="wired-touch-target wired-pressable inline-flex min-h-[24px] min-w-[24px] items-center gap-1 rounded-sm text-secondary transition-colors duration-hover hover:text-primary focus-visible:outline-none"
-        aria-label="More sharing options"
+        aria-label="Share this thread"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
       >
         <Share2 aria-hidden="true" className="h-3.5 w-3.5" strokeWidth={1.8} />
-        <span>more</span>
+        <span>share</span>
       </button>
-      {status !== "idle" && (
-        <span className="inline-flex items-center gap-1 text-signal" aria-live="polite">
-          {status === "copied" && <Check aria-hidden="true" className="h-3.5 w-3.5" strokeWidth={1.8} />}
-          {statusLabel}
-        </span>
+
+      {isOpen && (
+        <>
+          <div
+            aria-hidden="true"
+            className="fixed inset-0 z-40 bg-void/60 backdrop-blur-sm animate-fade-in motion-reduce:animate-none sm:hidden"
+            onPointerDown={closeMenu}
+          />
+          <div
+            ref={panelRef}
+            role="menu"
+            aria-label="Share this thread"
+            className={[
+              "z-50 overflow-hidden border border-ghost bg-surface-raised shadow-2xl",
+              "fixed inset-x-0 bottom-0 rounded-t-sm p-2",
+              "animate-[slideUp_180ms_var(--ease-out)] motion-reduce:animate-none",
+              "sm:absolute sm:inset-x-auto sm:bottom-full sm:right-0 sm:mb-2 sm:w-56 sm:rounded-sm sm:animate-fade-in",
+            ].join(" ")}
+          >
+            <div className="mb-1 flex items-center justify-between px-3 py-2 sm:hidden">
+              <span className="text-body font-medium text-primary">Share signal</span>
+              <button
+                type="button"
+                aria-label="Close share menu"
+                className="wired-touch-target wired-pressable inline-flex h-8 w-8 items-center justify-center rounded-sm text-secondary hover:text-primary"
+                onClick={closeMenu}
+              >
+                <CloseIcon aria-hidden="true" className="h-4 w-4" />
+              </button>
+            </div>
+
+            <a
+              href={xIntentUrl.toString()}
+              target="_blank"
+              rel="noreferrer"
+              role="menuitem"
+              className={menuItemClass}
+              onClick={closeMenu}
+            >
+              <span aria-hidden="true" className="w-4 text-center text-body">X</span>
+              <span>Share to X</span>
+            </a>
+            <button
+              type="button"
+              role="menuitem"
+              className={menuItemClass}
+              onClick={() => void copyFor("Discord")}
+            >
+              <MessageCircle aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} />
+              <span>Share to Discord</span>
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className={menuItemClass}
+              onClick={() => void copyFor("Instagram")}
+            >
+              <Camera aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} />
+              <span>Share to Instagram</span>
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className={menuItemClass}
+              onClick={() => void copyFor("")}
+            >
+              <Copy aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} />
+              <span>Copy link</span>
+            </button>
+            <div className="my-1 h-px bg-[var(--border-ghost)]" />
+            <button
+              type="button"
+              role="menuitem"
+              className={menuItemClass}
+              onClick={handleMore}
+            >
+              <Share2 aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} />
+              <span>More options</span>
+            </button>
+
+            {status !== "idle" && (
+              <div
+                className={[
+                  "mx-3 mt-1 flex items-center gap-2 border-t border-ghost pt-2 text-micro",
+                  status === "copied" ? "text-signal" : "text-danger",
+                ].join(" ")}
+                role="status"
+              >
+                {status === "copied" && <Check aria-hidden="true" className="h-3.5 w-3.5" />}
+                <span>
+                  {status === "copied"
+                    ? `link copied${statusContext ? ` for ${statusContext}` : ""}`
+                    : "copy failed"}
+                </span>
+              </div>
+            )}
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/shared/ui/ShareControl.tsx
+++ b/src/shared/ui/ShareControl.tsx
@@ -1,0 +1,101 @@
+import { Check, Share2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { buildThreadPath } from "@lib/threadRefs";
+
+type ShareControlProps = {
+  eventId: string;
+  relayHints?: readonly string[];
+  excerpt?: string;
+};
+
+const FEEDBACK_DURATION_MS = 2_000;
+
+function canonicalThreadUrl(eventId: string, relayHints: readonly string[]): string {
+  return new URL(buildThreadPath(eventId, relayHints), window.location.origin).toString();
+}
+
+function legacyCopy(text: string): boolean {
+  const input = document.createElement("textarea");
+  input.value = text;
+  input.setAttribute("readonly", "");
+  input.style.position = "fixed";
+  input.style.opacity = "0";
+  document.body.appendChild(input);
+  input.select();
+
+  try {
+    return document.execCommand("copy");
+  } finally {
+    input.remove();
+  }
+}
+
+async function copyText(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Some browsers expose the Clipboard API but reject it outside a secure context.
+    }
+  }
+
+  return legacyCopy(text);
+}
+
+export function ShareControl({
+  eventId,
+  relayHints = [],
+  excerpt,
+}: ShareControlProps) {
+  const [status, setStatus] = useState<"idle" | "copied" | "error">("idle");
+  const resetTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    },
+    [],
+  );
+
+  const showStatus = useCallback((nextStatus: "copied" | "error") => {
+    setStatus(nextStatus);
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+    resetTimer.current = setTimeout(() => setStatus("idle"), FEEDBACK_DURATION_MS);
+  }, []);
+
+  const handleShare = useCallback(async () => {
+    const url = canonicalThreadUrl(eventId, relayHints);
+
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: "Wired signal",
+          text: excerpt?.trim().slice(0, 180) || undefined,
+          url,
+        });
+        return;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+      }
+    }
+
+    showStatus((await copyText(url)) ? "copied" : "error");
+  }, [eventId, excerpt, relayHints, showStatus]);
+
+  const label = status === "copied" ? "copied" : status === "error" ? "copy failed" : "share";
+  const Icon = status === "copied" ? Check : Share2;
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      className="wired-touch-target wired-pressable inline-flex min-h-[24px] min-w-[24px] items-center gap-1 rounded-sm text-secondary transition-colors duration-hover hover:text-primary focus-visible:outline-none"
+      aria-label={status === "idle" ? "Share this thread" : label}
+      aria-live="polite"
+    >
+      <Icon aria-hidden="true" className="h-3.5 w-3.5" strokeWidth={1.8} />
+      <span>{label}</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## What changed

- add a share control to the root post on thread pages
- use the Web Share API when available, with Clipboard API and legacy copy fallbacks
- treat share-sheet cancellation as a no-op and show brief copy feedback
- preserve thread relay hints in the canonical shared URL
- add a persistent `wiredsignal.online` identity to the root post for screenshots

## Why

Shared thread links should be one tap away on supported mobile browsers and remain usable everywhere else. A visible domain mark also gives ordinary screenshots clear Wired attribution; browsers do not expose a reliable screenshot-detection API.

## Validation

- `npm run typecheck`
- `npm run lint` (passes with 3 existing Fast Refresh warnings)
- `npm run test` (52 files, 274 tests)
- `npm run build`
