### PR TITLE
Add dynamic thread metadata and social cards

### DIFF
--- a/api/thread-card.tsx
+++ b/api/thread-card.tsx
@@ -1,0 +1,80 @@
+import { ImageResponse } from "@vercel/og";
+import { resolveThreadPreview } from "../lib/threadPreview.js";
+
+export const config = { runtime: "nodejs" };
+
+function replyLabel(count: number): string {
+  return `${count} ${count === 1 ? "reply" : "replies"}`;
+}
+
+export default async function handler(request: Request) {
+  const url = new URL(request.url);
+  const ref = url.searchParams.get("id") ?? undefined;
+  const preview = await resolveThreadPreview(ref, { origin: url.origin });
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "72px 82px",
+          color: "#e8e8ec",
+          background: "#050508",
+          fontFamily: "monospace",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "18px" }}>
+          <div
+            style={{
+              display: "flex",
+              width: "18px",
+              height: "18px",
+              borderRadius: "50%",
+              background: "#5eead4",
+              boxShadow: "0 0 30px rgba(94,234,212,.55)",
+            }}
+          />
+          <div style={{ display: "flex", fontSize: "25px", color: "#8a8a96" }}>
+            WIRED / ANONYMOUS SIGNAL
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            maxWidth: "1040px",
+            fontSize: preview ? "50px" : "58px",
+            lineHeight: 1.25,
+            letterSpacing: "-0.025em",
+          }}
+        >
+          {preview?.excerpt ?? "Say what you cannot say on main."}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderTop: "1px solid rgba(255,255,255,.12)",
+            paddingTop: "28px",
+            fontSize: "25px",
+          }}
+        >
+          <div style={{ display: "flex", color: "#5eead4" }}>
+            {preview ? replyLabel(preview.replyCount) : "the anonymous backchannel"}
+          </div>
+          <div style={{ display: "flex", color: "#8a8a96" }}>wiredsignal.online</div>
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    },
+  );
+}

--- a/api/thread-card.tsx
+++ b/api/thread-card.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "@vercel/og";
+import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { resolveThreadPreview } from "../lib/threadPreview.js";
 
 export const config = { runtime: "nodejs" };
@@ -7,11 +8,9 @@ function replyLabel(count: number): string {
   return `${count} ${count === 1 ? "reply" : "replies"}`;
 }
 
-export default async function handler(request: Request) {
-  const url = new URL(request.url);
-  const ref = url.searchParams.get("id") ?? undefined;
-  const preview = await resolveThreadPreview(ref, { origin: url.origin });
-
+export function renderThreadCard(
+  preview: Awaited<ReturnType<typeof resolveThreadPreview>>,
+) {
   return new ImageResponse(
     (
       <div
@@ -77,4 +76,29 @@ export default async function handler(request: Request) {
       height: 630,
     },
   );
+}
+
+function first(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] ?? "" : value ?? "";
+}
+
+function requestOrigin(req: VercelRequest): string {
+  const protocol = first(req.headers["x-forwarded-proto"]) || "https";
+  const host = first(req.headers["x-forwarded-host"]) || first(req.headers.host);
+  return `${protocol}://${host}`;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).send("method not allowed");
+  }
+
+  const ref = first(req.query.id) || undefined;
+  const preview = await resolveThreadPreview(ref, { origin: requestOrigin(req) });
+  const image = renderThreadCard(preview);
+  const body = Buffer.from(await image.arrayBuffer());
+
+  image.headers.forEach((value, name) => res.setHeader(name, value));
+  return res.status(image.status).send(body);
 }

--- a/api/thread.test.ts
+++ b/api/thread.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import handler from "./thread";
+
+describe("thread HTML handler", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("serves the SPA shell with crawler metadata for invalid references", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        '<html><head><meta name="description" content="The Wired" /><title>The Wired</title></head><body></body></html>',
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const headers = new Map<string, string>();
+    let status = 0;
+    let body = "";
+    const response = {
+      setHeader: (name: string, value: string) => headers.set(name, value),
+      status: (nextStatus: number) => {
+        status = nextStatus;
+        return response;
+      },
+      send: (value: string) => {
+        body = value;
+        return response;
+      },
+    };
+
+    await handler(
+      {
+        method: "GET",
+        query: { id: "invalid" },
+        headers: { host: "wiredsignal.online", "x-forwarded-proto": "https" },
+      } as never,
+      response as never,
+    );
+
+    expect(status).toBe(200);
+    expect(headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+    expect(headers.get("Cache-Control")).toContain("stale-while-revalidate");
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("https://wiredsignal.online/"),
+      expect.objectContaining({ headers: expect.objectContaining({ Accept: "text/html" }) }),
+    );
+    expect(body).toContain('property="og:title" content="Wired"');
+    expect(body).toContain('rel="canonical" href="https://wiredsignal.online/thread/invalid"');
+    expect(body).toContain("/api/thread-card?id=invalid&amp;replies=0");
+  });
+});

--- a/api/thread.ts
+++ b/api/thread.ts
@@ -1,0 +1,51 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { buildThreadMetadata, injectThreadMetadata } from "../lib/threadMetadata.js";
+import { resolveThreadPreview } from "../lib/threadPreview.js";
+
+const CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300";
+
+function first(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] ?? "" : value ?? "";
+}
+
+function requestOrigin(req: VercelRequest): string {
+  const protocol = first(req.headers["x-forwarded-proto"]) || "https";
+  const host = first(req.headers["x-forwarded-host"]) || first(req.headers.host);
+  return `${protocol}://${host}`;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).send("method not allowed");
+  }
+
+  const ref = first(req.query.id);
+  const origin = requestOrigin(req);
+  const canonicalUrl = new URL(`/thread/${encodeURIComponent(ref)}`, origin).toString();
+
+  const [shellResponse, preview] = await Promise.all([
+    fetch(new URL("/", origin), {
+      headers: { Accept: "text/html", "x-wired-thread-shell": "1" },
+    }),
+    resolveThreadPreview(ref, { origin }),
+  ]);
+
+  if (!shellResponse.ok) {
+    return res.status(502).send("Wired is temporarily unavailable");
+  }
+
+  const imageUrl = new URL(
+    `/api/thread-card?id=${encodeURIComponent(ref)}&replies=${preview?.replyCount ?? 0}`,
+    origin,
+  ).toString();
+
+  const html = injectThreadMetadata(
+    await shellResponse.text(),
+    buildThreadMetadata(preview, canonicalUrl, imageUrl),
+  );
+
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader("Cache-Control", CACHE_CONTROL);
+  return res.status(200).send(html);
+}

--- a/api/thread.ts
+++ b/api/thread.ts
@@ -1,4 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { buildThreadMetadata, injectThreadMetadata } from "../lib/threadMetadata.js";
 import { resolveThreadPreview } from "../lib/threadPreview.js";
 
@@ -14,6 +16,21 @@ function requestOrigin(req: VercelRequest): string {
   return `${protocol}://${host}`;
 }
 
+async function loadHtmlShell(origin: string): Promise<string | null> {
+  try {
+    return await readFile(path.join(process.cwd(), "dist/index.html"), "utf8");
+  } catch {
+    try {
+      const response = await fetch(new URL("/", origin), {
+        headers: { Accept: "text/html", "x-wired-thread-shell": "1" },
+      });
+      return response.ok ? await response.text() : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== "GET") {
     res.setHeader("Allow", "GET");
@@ -24,14 +41,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const origin = requestOrigin(req);
   const canonicalUrl = new URL(`/thread/${encodeURIComponent(ref)}`, origin).toString();
 
-  const [shellResponse, preview] = await Promise.all([
-    fetch(new URL("/", origin), {
-      headers: { Accept: "text/html", "x-wired-thread-shell": "1" },
-    }),
+  const [shell, preview] = await Promise.all([
+    loadHtmlShell(origin),
     resolveThreadPreview(ref, { origin }),
   ]);
 
-  if (!shellResponse.ok) {
+  if (!shell) {
     return res.status(502).send("Wired is temporarily unavailable");
   }
 
@@ -41,7 +56,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   ).toString();
 
   const html = injectThreadMetadata(
-    await shellResponse.text(),
+    shell,
     buildThreadMetadata(preview, canonicalUrl, imageUrl),
   );
 

--- a/lib/threadCard.test.tsx
+++ b/lib/threadCard.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { renderThreadCard } from "../api/thread-card";
+
+describe("thread social card", () => {
+  it("renders a 1200 by 630 PNG", async () => {
+    const response = renderThreadCard({
+      eventId: "1".repeat(64),
+      excerpt: "A useful anonymous signal",
+      replyCount: 2,
+    });
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect([...bytes.slice(0, 8)]).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
+    expect(bytes.byteLength).toBeGreaterThan(10_000);
+  });
+});

--- a/lib/threadHandler.test.ts
+++ b/lib/threadHandler.test.ts
@@ -1,18 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import handler from "../api/thread";
 
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn().mockResolvedValue(
+    '<html><head><meta name="description" content="The Wired" /><title>The Wired</title></head><body><div id="root"></div></body></html>',
+  ),
+}));
+
 describe("thread HTML handler", () => {
   afterEach(() => vi.unstubAllGlobals());
 
   it("serves the SPA shell with crawler metadata for invalid references", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        '<html><head><meta name="description" content="The Wired" /><title>The Wired</title></head><body></body></html>',
-        { status: 200 },
-      ),
-    );
-    vi.stubGlobal("fetch", fetchMock);
-
     const headers = new Map<string, string>();
     let status = 0;
     let body = "";
@@ -40,10 +38,7 @@ describe("thread HTML handler", () => {
     expect(status).toBe(200);
     expect(headers.get("Content-Type")).toBe("text/html; charset=utf-8");
     expect(headers.get("Cache-Control")).toContain("stale-while-revalidate");
-    expect(fetchMock).toHaveBeenCalledWith(
-      new URL("https://wiredsignal.online/"),
-      expect.objectContaining({ headers: expect.objectContaining({ Accept: "text/html" }) }),
-    );
+    expect(body).toContain('<div id="root"></div>');
     expect(body).toContain('property="og:title" content="Wired"');
     expect(body).toContain('rel="canonical" href="https://wiredsignal.online/thread/invalid"');
     expect(body).toContain("/api/thread-card?id=invalid&amp;replies=0");

--- a/lib/threadHandler.test.ts
+++ b/lib/threadHandler.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import handler from "./thread";
+import handler from "../api/thread";
 
 describe("thread HTML handler", () => {
   afterEach(() => vi.unstubAllGlobals());

--- a/lib/threadMetadata.test.ts
+++ b/lib/threadMetadata.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildThreadMetadata,
+  injectThreadMetadata,
+  metadataTags,
+} from "./threadMetadata";
+
+describe("thread metadata", () => {
+  const metadata = buildThreadMetadata(
+    { eventId: "1".repeat(64), excerpt: 'Signal <script> "quoted"', replyCount: 1 },
+    "https://wiredsignal.online/thread/example",
+    "https://wiredsignal.online/api/thread-card?id=example",
+  );
+
+  it("describes the thread and pluralizes replies", () => {
+    expect(metadata.title).toContain("Signal <script>");
+    expect(metadata.description).toContain("1 reply on Wired");
+  });
+
+  it("escapes user content in social metadata", () => {
+    const tags = metadataTags(metadata);
+    expect(tags).toContain("Signal &lt;script&gt; &quot;quoted&quot;");
+    expect(tags).not.toContain("<script>");
+    expect(tags).toContain('name="twitter:card" content="summary_large_image"');
+    expect(tags).toContain('property="og:image:width" content="1200"');
+  });
+
+  it("injects crawler metadata into the initial HTML shell", () => {
+    const html = injectThreadMetadata(
+      '<html><head><meta name="description" content="The Wired" /><title>The Wired</title></head></html>',
+      metadata,
+    );
+    expect(html).toContain("<title>Signal &lt;script&gt;");
+    expect(html).toContain('rel="canonical"');
+    expect(html).toContain('property="og:title"');
+    expect(html).not.toContain('content="The Wired"');
+  });
+});

--- a/lib/threadMetadata.ts
+++ b/lib/threadMetadata.ts
@@ -1,0 +1,83 @@
+import type { ThreadPreview } from "./threadPreview.js";
+
+export const WIRED_SITE_NAME = "Wired";
+export const WIRED_DEFAULT_DESCRIPTION =
+  "Anonymous signals from people who live online.";
+
+export type ThreadMetadata = {
+  title: string;
+  description: string;
+  canonicalUrl: string;
+  imageUrl: string;
+};
+
+function replyLabel(replyCount: number): string {
+  return `${replyCount} ${replyCount === 1 ? "reply" : "replies"}`;
+}
+
+export function buildThreadMetadata(
+  preview: ThreadPreview | null,
+  canonicalUrl: string,
+  imageUrl: string,
+): ThreadMetadata {
+  if (!preview) {
+    return {
+      title: WIRED_SITE_NAME,
+      description: WIRED_DEFAULT_DESCRIPTION,
+      canonicalUrl,
+      imageUrl,
+    };
+  }
+
+  return {
+    title: `${preview.excerpt} — Wired`,
+    description: `Read this anonymous signal and ${replyLabel(preview.replyCount)} on Wired.`,
+    canonicalUrl,
+    imageUrl,
+  };
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function metadataTags(metadata: ThreadMetadata): string {
+  const title = escapeHtml(metadata.title);
+  const description = escapeHtml(metadata.description);
+  const canonicalUrl = escapeHtml(metadata.canonicalUrl);
+  const imageUrl = escapeHtml(metadata.imageUrl);
+
+  return [
+    `<link rel="canonical" href="${canonicalUrl}" />`,
+    `<meta property="og:type" content="article" />`,
+    `<meta property="og:site_name" content="${WIRED_SITE_NAME}" />`,
+    `<meta property="og:title" content="${title}" />`,
+    `<meta property="og:description" content="${description}" />`,
+    `<meta property="og:url" content="${canonicalUrl}" />`,
+    `<meta property="og:image" content="${imageUrl}" />`,
+    `<meta property="og:image:width" content="1200" />`,
+    `<meta property="og:image:height" content="630" />`,
+    `<meta property="og:image:alt" content="Wired thread preview" />`,
+    `<meta name="twitter:card" content="summary_large_image" />`,
+    `<meta name="twitter:title" content="${title}" />`,
+    `<meta name="twitter:description" content="${description}" />`,
+    `<meta name="twitter:image" content="${imageUrl}" />`,
+  ].join("\n    ");
+}
+
+export function injectThreadMetadata(html: string, metadata: ThreadMetadata): string {
+  const title = escapeHtml(metadata.title);
+  const description = escapeHtml(metadata.description);
+  const withTitle = html.replace(/<title>[^<]*<\/title>/i, `<title>${title}</title>`);
+  const withDescription = withTitle.replace(
+    /<meta\s+name=["']description["']\s+content=["'][^"']*["']\s*\/?>/i,
+    `<meta name="description" content="${description}" />`,
+  );
+
+  return withDescription.replace("</head>", `    ${metadataTags(metadata)}\n  </head>`);
+}

--- a/lib/threadPreview.test.ts
+++ b/lib/threadPreview.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Event } from "nostr-tools";
+import type { FeedBootstrapSnapshot } from "../src/shared/lib/feedBootstrapTypes";
+import { previewFromSnapshot, resolveThreadPreview } from "./threadPreview";
+
+const rootId = "1".repeat(64);
+
+function event(overrides: Partial<Event> = {}): Event {
+  return {
+    id: rootId,
+    pubkey: "2".repeat(64),
+    created_at: 1,
+    kind: 1,
+    tags: [],
+    content: "A useful anonymous signal https://example.com/image.jpg",
+    sig: "3".repeat(128),
+    ...overrides,
+  };
+}
+
+function snapshot(): FeedBootstrapSnapshot {
+  return {
+    fetchedAt: 1,
+    processedEvents: [
+      {
+        postEventId: rootId,
+        replyIds: ["4".repeat(64)],
+        threadReplyCount: 7,
+        rootWork: 1,
+        replyWork: 1,
+        totalWork: 2,
+        rankingReplyCount: 1,
+      },
+    ],
+    eventsById: { [rootId]: event() },
+    relayHintsByEventId: {},
+    profiles: {},
+    scoring: { ageHours: 24, minPow: 16, replyDepth: 2, sort: "totalWork" },
+  };
+}
+
+describe("thread preview", () => {
+  it("builds a clean excerpt and uses the snapshot thread reply count", () => {
+    expect(previewFromSnapshot(snapshot(), rootId)).toEqual({
+      eventId: rootId,
+      excerpt: "A useful anonymous signal",
+      replyCount: 7,
+    });
+  });
+
+  it("falls back to relay events when snapshots do not contain the thread", async () => {
+    const reply = event({ id: "5".repeat(64), tags: [["e", rootId]] });
+    const relayFallback = vi.fn().mockResolvedValue([event(), reply]);
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ unavailable: true }), { status: 200 }),
+    );
+
+    const preview = await resolveThreadPreview(rootId, {
+      origin: "https://wiredsignal.online",
+      fetchImpl,
+      relayFallback,
+    });
+
+    expect(preview?.replyCount).toBe(1);
+    expect(relayFallback).toHaveBeenCalledWith(rootId, []);
+  });
+
+  it("rejects invalid thread references without network work", async () => {
+    const fetchImpl = vi.fn();
+    const relayFallback = vi.fn();
+    expect(
+      await resolveThreadPreview("invalid", {
+        origin: "https://wiredsignal.online",
+        fetchImpl,
+        relayFallback,
+      }),
+    ).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(relayFallback).not.toHaveBeenCalled();
+  });
+});

--- a/lib/threadPreview.ts
+++ b/lib/threadPreview.ts
@@ -1,0 +1,169 @@
+import { Relay, type Event, useWebSocketImplementation } from "nostr-tools";
+import { WebSocket } from "ws";
+import { THREAD_RELAYS } from "../src/config.js";
+import {
+  isFeedBootstrapSnapshot,
+  type FeedBootstrapSnapshot,
+} from "../src/shared/lib/feedBootstrapTypes.js";
+import { decodeThreadRef, uniqueRelays } from "../src/shared/lib/threadRefs.js";
+import { cleanThreadExcerpt } from "../src/shared/lib/threadExcerpt.js";
+
+useWebSocketImplementation(WebSocket);
+
+const SNAPSHOT_TIMEOUT_MS = 1_500;
+const RELAY_TIMEOUT_MS = 2_500;
+
+export type ThreadPreview = {
+  eventId: string;
+  excerpt: string;
+  replyCount: number;
+};
+
+export type ResolveThreadPreviewOptions = {
+  origin: string;
+  snapshotUrl?: string;
+  fetchImpl?: typeof fetch;
+  relayFallback?: (eventId: string, relayHints: readonly string[]) => Promise<Event[]>;
+};
+
+function replyCountFromEvents(events: readonly Event[], eventId: string): number {
+  return new Set(
+    events
+      .filter(
+        (event) =>
+          event.id !== eventId &&
+          event.tags.some((tag) => tag[0] === "e" && tag[1] === eventId),
+      )
+      .map((event) => event.id),
+  ).size;
+}
+
+export function previewFromSnapshot(
+  snapshot: FeedBootstrapSnapshot,
+  eventId: string,
+): ThreadPreview | null {
+  const event = snapshot.eventsById[eventId];
+  if (!event) return null;
+
+  const processed = snapshot.processedEvents.find(
+    (candidate) => candidate.postEventId === eventId,
+  );
+
+  return {
+    eventId,
+    excerpt: cleanThreadExcerpt(event.content) || "An anonymous signal on Wired.",
+    replyCount:
+      processed?.threadReplyCount ??
+      replyCountFromEvents(Object.values(snapshot.eventsById), eventId),
+  };
+}
+
+async function fetchSnapshot(
+  url: string,
+  fetchImpl: typeof fetch,
+): Promise<FeedBootstrapSnapshot | null> {
+  try {
+    const response = await fetchImpl(url, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(SNAPSHOT_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const value: unknown = await response.json();
+    return isFeedBootstrapSnapshot(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchThreadEventsFromRelays(
+  eventId: string,
+  relayHints: readonly string[],
+): Promise<Event[]> {
+  const relayUrls = uniqueRelays([...relayHints, ...THREAD_RELAYS]);
+  const relays: Relay[] = [];
+  const events = new Map<string, Event>();
+
+  await Promise.race([
+    Promise.all(
+      relayUrls.map(async (url) => {
+        try {
+          const relay = await Relay.connect(url);
+          relays.push(relay);
+        } catch {
+          // A preview can succeed from any available relay.
+        }
+      }),
+    ),
+    new Promise<void>((resolve) => setTimeout(resolve, RELAY_TIMEOUT_MS)),
+  ]);
+
+  if (relays.length === 0) return [];
+
+  await new Promise<void>((resolve) => {
+    let eoseCount = 0;
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      subscriptions.forEach((subscription) => subscription.close());
+      resolve();
+    };
+    const timer = setTimeout(finish, RELAY_TIMEOUT_MS);
+    const subscriptions = relays.map((relay) =>
+      relay.subscribe(
+        [
+          { ids: [eventId], kinds: [1], limit: 1 },
+          { "#e": [eventId], kinds: [1], limit: 500 },
+        ],
+        {
+          onevent: (event) => events.set(event.id, event),
+          oneose: () => {
+            eoseCount += 1;
+            if (eoseCount >= relays.length) finish();
+          },
+        },
+      ),
+    );
+  });
+
+  relays.forEach((relay) => relay.close());
+  return [...events.values()];
+}
+
+export async function resolveThreadPreview(
+  ref: string | undefined,
+  {
+    origin,
+    snapshotUrl = process.env.VITE_FEED_SNAPSHOT_URL,
+    fetchImpl = fetch,
+    relayFallback = fetchThreadEventsFromRelays,
+  }: ResolveThreadPreviewOptions,
+): Promise<ThreadPreview | null> {
+  const decoded = decodeThreadRef(ref);
+  if (!decoded) return null;
+
+  const snapshotUrls = uniqueRelays(
+    [snapshotUrl, new URL("/api/feed/bootstrap", origin).toString()].filter(
+      (url): url is string => Boolean(url),
+    ),
+  );
+
+  const snapshots = await Promise.all(
+    snapshotUrls.map((url) => fetchSnapshot(url, fetchImpl)),
+  );
+  const snapshotPreview = snapshots
+    .map((snapshot) => snapshot && previewFromSnapshot(snapshot, decoded.id))
+    .find((preview): preview is ThreadPreview => Boolean(preview));
+  if (snapshotPreview) return snapshotPreview;
+
+  const events = await relayFallback(decoded.id, decoded.relays);
+  const event = events.find((candidate) => candidate.id === decoded.id);
+  if (!event) return null;
+
+  return {
+    eventId: event.id,
+    excerpt: cleanThreadExcerpt(event.content) || "An anonymous signal on Wired.",
+    replyCount: replyCountFromEvents(events, event.id),
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
         "@vercel/functions": "^3.7.1",
+        "@vercel/og": "^0.11.1",
         "@vercel/speed-insights": "^2.0.0",
         "lucide-react": "^1.22.0",
         "nostr-tools": "2.5.1",
@@ -481,6 +482,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.27.0",
       "cpu": [
@@ -737,6 +748,472 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "dev": true,
@@ -912,6 +1389,15 @@
         "pnpm": "^10.0.0"
       }
     },
+    "node_modules/@resvg/resvg-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.4.0.tgz",
+      "integrity": "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "dev": true,
@@ -991,6 +1477,22 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/@tailwindcss/forms": {
@@ -1530,6 +2032,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vercel/og": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@vercel/og/-/og-0.11.1.tgz",
+      "integrity": "sha512-02rXXRABFq1B03w3aNhcVfxkY+8Ba5QFi4ax0zS0oOiD/LL9WUd/LA7BjVPakrQmVhIBjuo2oBM5U25R9IuXMg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@resvg/resvg-wasm": "2.4.0",
+        "satori": "0.25.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.34.5"
+      }
+    },
     "node_modules/@vercel/oidc": {
       "version": "3.7.1",
       "license": "Apache-2.0",
@@ -1879,6 +2397,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.40",
       "dev": true,
@@ -1995,6 +2522,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2119,7 +2655,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -2177,6 +2712,47 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -2268,7 +2844,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2336,6 +2912,15 @@
       "version": "1.5.380",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2441,6 +3026,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2752,6 +3343,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "dev": true,
@@ -3052,6 +3649,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -3372,6 +3981,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3805,6 +4424,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "dev": true,
@@ -3814,6 +4439,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
       }
     },
     "node_modules/parse-ms": {
@@ -4085,7 +4720,6 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -4352,6 +4986,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/satori": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.25.0.tgz",
+      "integrity": "sha512-utINfLxrYrmSnLvxFT4ZwgwWa8KOjrz7ans32V5wItgHVmzESl/9i33nE38uG0miycab8hUqQtDlOpqrIpB/iw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "dev": true,
@@ -4372,13 +5028,58 @@
     },
     "node_modules/semver": {
       "version": "7.8.5",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/shebang-command": {
@@ -4441,6 +5142,12 @@
     "node_modules/std-env": {
       "version": "3.10.0",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
       "license": "MIT"
     },
     "node_modules/strip-final-newline": {
@@ -4601,6 +5308,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "dev": true,
@@ -4729,6 +5442,13 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "dev": true,
@@ -4807,6 +5527,16 @@
       "version": "8.3.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -5483,6 +6213,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
     "@vercel/functions": "^3.7.1",
+    "@vercel/og": "^0.11.1",
     "@vercel/speed-insights": "^2.0.0",
     "lucide-react": "^1.22.0",
     "nostr-tools": "2.5.1",

--- a/src/features/thread/ThreadPage.tsx
+++ b/src/features/thread/ThreadPage.tsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { Event } from "nostr-tools";
 import { getThreadDepth } from "@lib/getThreadDepth";
 import { Placeholder } from "../../shared/ui/Placeholder";
@@ -16,6 +16,7 @@ import {
 import { useThreadNavigation } from "./useThreadNavigation";
 import { decodeThreadRef } from "@lib/threadRefs";
 import { uniqBy } from "@lib/collections";
+import { cleanThreadExcerpt } from "@lib/threadExcerpt";
 
 function ThreadView({ hexID, relayHints }: { hexID: string; relayHints: string[] }) {
   const visibleReplyEvents = useInfiniteScroll();
@@ -36,6 +37,30 @@ function ThreadView({ hexID, relayHints }: { hexID: string; relayHints: string[]
     setShowAllReplies,
     uniqMentions,
   } = useThreadViewModel(hexID, seedEvents, relayHints);
+
+  useEffect(() => {
+    if (!opEvent) return;
+
+    const previousTitle = document.title;
+    const description = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+    const previousDescription = description?.content;
+    const excerpt = cleanThreadExcerpt(opEvent.content) || "An anonymous signal on Wired.";
+    const replyCount = opScore?.threadReplyCount ?? 0;
+
+    document.title = `${excerpt} — Wired`;
+    if (description) {
+      description.content = `Read this anonymous signal and ${replyCount} ${
+        replyCount === 1 ? "reply" : "replies"
+      } on Wired.`;
+    }
+
+    return () => {
+      document.title = previousTitle;
+      if (description && previousDescription !== undefined) {
+        description.content = previousDescription;
+      }
+    };
+  }, [opEvent, opScore?.threadReplyCount]);
 
   if (opEvent) {
     return (

--- a/src/shared/lib/threadExcerpt.test.ts
+++ b/src/shared/lib/threadExcerpt.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { cleanThreadExcerpt, THREAD_EXCERPT_MAX_LENGTH } from "./threadExcerpt";
+
+describe("cleanThreadExcerpt", () => {
+  it("removes links and normalizes whitespace", () => {
+    expect(
+      cleanThreadExcerpt("  a signal\nwith https://example.com/media.jpg   context "),
+    ).toBe("a signal with context");
+  });
+
+  it("truncates long excerpts with an ellipsis", () => {
+    const excerpt = cleanThreadExcerpt("x".repeat(THREAD_EXCERPT_MAX_LENGTH + 20));
+    expect(excerpt).toHaveLength(THREAD_EXCERPT_MAX_LENGTH);
+    expect(excerpt.endsWith("…")).toBe(true);
+  });
+});

--- a/src/shared/lib/threadExcerpt.ts
+++ b/src/shared/lib/threadExcerpt.ts
@@ -1,0 +1,12 @@
+export const THREAD_EXCERPT_MAX_LENGTH = 180;
+
+export function cleanThreadExcerpt(content: string): string {
+  const cleaned = content
+    .replace(/https?:\/\/\S+/gi, "")
+    .replace(/nostr:(?:note|nevent|npub|nprofile|naddr)1\S+/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (cleaned.length <= THREAD_EXCERPT_MAX_LENGTH) return cleaned;
+  return `${cleaned.slice(0, THREAD_EXCERPT_MAX_LENGTH - 1).trimEnd()}…`;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -92,6 +92,10 @@
   ],
   "rewrites": [
     {
+      "source": "/thread/:id",
+      "destination": "/api/thread?id=:id"
+    },
+    {
       "source": "/((?!api/|_vercel/|src/|@|node_modules/|assets/|fonts/|favicon\\.svg|robots\\.txt|noise\\.png).*)",
       "destination": "/index.html"
     }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "npm ci",
+  "functions": {
+    "api/thread.ts": {
+      "includeFiles": "dist/index.html"
+    }
+  },
   "crons": [
     {
       "path": "/api/cron/refresh-feed",


### PR DESCRIPTION
## What changed

- route thread requests through a server-rendered HTML shell with dynamic title, description, canonical, Open Graph, and Twitter/X metadata
- resolve preview data from the existing feed snapshot first, with bounded direct-relay fallback for older or absent threads
- generate a 1200×630 PNG social card with a cleaned excerpt, reply count, Wired identity, and `wiredsignal.online`
- key card URLs by reply count so immutable image caching refreshes when conversation activity changes
- keep browser metadata in sync during client-side thread navigation
- add escaping, fallback, cache, preview-model, and HTML-handler tests

## Why

The Vite SPA currently returns generic metadata to social crawlers. Updating the DOM after hydration does not reliably affect link unfurls, so thread routes need metadata in their initial HTML response and a crawler-compatible raster card.

`wired-admin` already publishes the root events and `threadReplyCount` needed by this feature at `/api/feed/bootstrap`. Reusing that contract avoids another public endpoint and cross-repository deployment dependency.

## Validation

- `npm run typecheck`
- `npm run lint` (passes with 3 existing Fast Refresh warnings)
- `npm run test` (54 files, 277 tests), plus the final PNG/handler regression tests
- `npm run build`
- direct Node render of the card endpoint: HTTP 200, `image/png`, 45 KB PNG

## Preview verification

Please verify the Vercel preview before merging:

- raw `/thread/:id` HTML contains the thread-specific tags
- `/api/thread-card?id=:id` renders the expected card
- the thread route still hydrates as the normal Vite app
- an X/Slack/Discord unfurl debugger accepts the preview image

Verified against the protected Vercel preview with authenticated requests:

- `/thread/invalid`: HTTP 200 HTML containing the production hashed script, canonical URL, Open Graph tags, and image dimensions
- `/api/thread-card?id=invalid`: HTTP 200 `image/png`, 1200×630, 45 KB
