### PR TITLE
Fix thread controls, spacing, and client tag

### DIFF
--- a/src/features/compose/PostForm.test.tsx
+++ b/src/features/compose/PostForm.test.tsx
@@ -28,7 +28,7 @@ vi.mock("../thread/useThreadNavigation", () => ({
 vi.mock("./buildUnsignedEvent", () => ({
   buildUnsignedEvent: () => ({
     kind: 1,
-    tags: [["client", "getwired.app"]],
+    tags: [["client", "wiredsignal.online"]],
     content: "test",
     created_at: 1,
     pubkey: "",

--- a/src/features/compose/ThreadComposer.test.tsx
+++ b/src/features/compose/ThreadComposer.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Event } from "nostr-tools";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadComposer } from "./ThreadComposer";
+
+vi.mock("./PostForm", () => ({
+  PostForm: ({ tagType }: { tagType: string }) => (
+    <div data-testid="post-form">{tagType}</div>
+  ),
+}));
+
+const opEvent: Event = {
+  id: "a".repeat(64),
+  pubkey: "b".repeat(64),
+  created_at: 1,
+  kind: 1,
+  tags: [],
+  content: "thread opener",
+  sig: "c".repeat(128),
+};
+
+type ReactActGlobal = typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+describe("ThreadComposer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as ReactActGlobal).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <ThreadComposer
+          OPEvent={opEvent}
+          showAllReplies={false}
+          onToggleLowSignal={vi.fn()}
+        />,
+      );
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function clickButton(label: string) {
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent === label,
+    );
+
+    act(() => button?.click());
+  }
+
+  it("switches directly between reply and quote composers", async () => {
+    clickButton("reply");
+    await act(async () => {});
+
+    expect(container.querySelector('[data-testid="post-form"]')?.textContent).toBe("Reply");
+    expect(container.querySelector('button[aria-pressed="true"]')?.textContent).toBe("reply");
+
+    clickButton("quote");
+    await act(async () => {});
+
+    expect(container.querySelector('[data-testid="post-form"]')?.textContent).toBe("Quote");
+    expect(container.querySelector('button[aria-pressed="true"]')?.textContent).toBe("quote");
+  });
+
+  it("closes the composer when its active action is selected again", async () => {
+    clickButton("reply");
+    await act(async () => {});
+    clickButton("reply");
+
+    expect(container.querySelector('[data-testid="post-form"]')).toBeNull();
+    expect(container.querySelector('button[aria-pressed="true"]')).toBeNull();
+  });
+});

--- a/src/features/compose/ThreadComposer.tsx
+++ b/src/features/compose/ThreadComposer.tsx
@@ -3,50 +3,70 @@ import { Event } from "nostr-tools";
 import { Button } from "../../shared/ui/Button";
 import { ContentColumn } from "../../shared/ui/PageShell";
 
-type PostType = "" | "Reply" | "Quote" | undefined;
+type PostType = "Reply" | "Quote";
 
 const LazyPostForm = lazy(() =>
   import("./PostForm").then((module) => ({ default: module.PostForm })),
 );
 
-export function ThreadComposer({ OPEvent }: { OPEvent: Event }) {
-  const [showForm, setShowForm] = useState(false);
-  const [postType, setPostType] = useState<PostType>("");
+type ThreadComposerProps = {
+  OPEvent: Event;
+  showAllReplies: boolean;
+  onToggleLowSignal: () => void;
+};
+
+export function ThreadComposer({
+  OPEvent,
+  showAllReplies,
+  onToggleLowSignal,
+}: ThreadComposerProps) {
+  const [postType, setPostType] = useState<PostType | null>(null);
+
+  const togglePostType = (nextPostType: PostType) => {
+    setPostType((currentPostType) =>
+      currentPostType === nextPostType ? null : nextPostType,
+    );
+  };
 
   return (
-    <>
-      <div className="col-span-full flex justify-center gap-6 pb-4">
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => {
-            setShowForm((prev) => !prev);
-            setPostType("Reply");
-          }}
-        >
-          reply
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => {
-            setShowForm((prev) => !prev);
-            setPostType("Quote");
-          }}
-        >
-          quote
+    <ContentColumn>
+      <div className="flex items-center justify-between border-b border-ghost py-1">
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-pressed={postType === "Reply"}
+            aria-expanded={postType === "Reply"}
+            className={postType === "Reply" ? "text-primary" : ""}
+            onClick={() => togglePostType("Reply")}
+          >
+            reply
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-pressed={postType === "Quote"}
+            aria-expanded={postType === "Quote"}
+            className={postType === "Quote" ? "text-primary" : ""}
+            onClick={() => togglePostType("Quote")}
+          >
+            quote
+          </Button>
+        </div>
+        <Button type="button" variant="ghost" size="sm" onClick={onToggleLowSignal}>
+          {showAllReplies ? "hide low-signal" : "reveal low-signal"}
         </Button>
       </div>
-      {showForm && postType && (
-        <ContentColumn className="my-2">
+      {postType && (
+        <div className="py-2">
           <p className="text-meta text-muted text-center mb-2">{postType.toLowerCase()}</p>
           <Suspense fallback={null}>
             <LazyPostForm refEvent={OPEvent} tagType={postType} />
           </Suspense>
-        </ContentColumn>
+        </div>
       )}
-    </>
+    </ContentColumn>
   );
 }

--- a/src/features/compose/buildUnsignedEvent.test.ts
+++ b/src/features/compose/buildUnsignedEvent.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "vitest";
 import { buildUnsignedEvent } from "./buildUnsignedEvent";
 
 describe("buildUnsignedEvent", () => {
+  it("identifies published notes as coming from wiredsignal.online", () => {
+    const unsigned = buildUnsignedEvent({ comment: "hello" });
+
+    expect(unsigned.tags).toContainEqual(["client", "wiredsignal.online"]);
+    expect(unsigned.tags).not.toContainEqual(["client", "getwired.app"]);
+  });
+
   it("adds Nostr custom emoji tags for selected shortcodes still present in the comment", () => {
     const unsigned = buildUnsignedEvent({
       comment: "ship it :wired:",

--- a/src/features/compose/buildUnsignedEvent.ts
+++ b/src/features/compose/buildUnsignedEvent.ts
@@ -9,7 +9,7 @@ export type ComposeDraft = {
   media?: UploadedMedia[];
 };
 
-const CLIENT_TAG: string[] = ["client", "getwired.app"];
+const CLIENT_TAG: string[] = ["client", "wiredsignal.online"];
 
 export type CustomEmojiTag = {
   shortcode: string;

--- a/src/features/thread/ThreadPage.tsx
+++ b/src/features/thread/ThreadPage.tsx
@@ -86,18 +86,11 @@ function ThreadView({ hexID, relayHints }: { hexID: string; relayHints: string[]
             relayHints={relayHints}
           />
         </ContentColumn>
-        <ThreadComposer OPEvent={opEvent} />
-        <div className="mx-auto mb-2 h-px max-w-content bg-[var(--border-ghost)]" />
-        <div className="flex justify-center">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => setShowAllReplies(!showAllReplies)}
-          >
-            {showAllReplies ? "hide low-signal" : "reveal low-signal"}
-          </Button>
-        </div>
+        <ThreadComposer
+          OPEvent={opEvent}
+          showAllReplies={showAllReplies}
+          onToggleLowSignal={() => setShowAllReplies(!showAllReplies)}
+        />
         <ContentColumn>
           {replyEvents
             .slice(0, visibleReplyEvents)

--- a/src/shared/hooks/useSubmitForm.test.tsx
+++ b/src/shared/hooks/useSubmitForm.test.tsx
@@ -65,7 +65,7 @@ class MockWorker {
 
 const unsigned: UnsignedEvent = {
   kind: 1,
-  tags: [["client", "getwired.app"]],
+  tags: [["client", "wiredsignal.online"]],
   content: "test reply",
   created_at: 1,
   pubkey: "",


### PR DESCRIPTION
## What changed

- keep the thread composer open when switching directly between Reply and Quote
- collapse Reply, Quote, and the low-signal toggle into one compact toolbar so replies appear sooner
- publish new notes with the current `wiredsignal.online` client tag instead of the retired `getwired.app` domain
- add regression coverage for composer switching, toggling, and the outgoing client tag

## Why

The composer previously tracked visibility and post type independently. Both Reply and Quote toggled visibility before changing type, so selecting the other action closed the form. The thread page also rendered its actions and low-signal control in separate padded rows, creating unnecessary space before replies. Finally, the shared unsigned-event builder still contained the old client domain.

## Impact

Reply and Quote now switch in place, the thread action area is substantially shorter when the composer is closed, and all newly created top-level posts, replies, quotes, and media posts identify Wired correctly.

## Validation

- `npm run typecheck`
- `npm run lint` (passes with 3 pre-existing Fast Refresh warnings)
- `npm test` (58 files, 289 tests)
- `npm run build`

Closes #105
Fixes smolgrrr/wired-admin#31