### PR TITLE
Implement NIP-57 creator revenue sharing

### DIFF
--- a/docs/staging-preview.md
+++ b/docs/staging-preview.md
@@ -22,8 +22,14 @@ The client uses it for:
 - moderation manifests
 - PoW relay writes and reads
 - Wired account status and high-PoW post submission
+- private Lightning-address validation and revenue enrollment
+- Wired NIP-57 routing configuration
 
 Production uses `https://relay.wiredsignal.online` for the Wired account API
 via `VITE_WIRED_ACCOUNT_API_BASE`.
+
+Revenue requests use `VITE_REVENUE_API_BASE`. The staging backend begins with
+FakeWallet, so `creator@fake.invalid` can exercise the complete simulated flow
+without creating or spending real Lightning funds.
 
 Do not commit local `.env*` files.

--- a/docs/staging.env.example
+++ b/docs/staging.env.example
@@ -4,3 +4,4 @@ VITE_POW_RELAYS=wss://staging.wiredsignal.online,wss://powrelay.xyz,wss://pow.re
 VITE_ENRICHMENT_RELAYS=wss://staging.wiredsignal.online,wss://relay.damus.io,wss://offchain.pub,wss://nos.lol,wss://relay.primal.net,wss://relay.nostr.band,wss://nostr.wine,wss://relay.snort.social
 VITE_CONFESS_API_BASE=https://staging.wiredsignal.online
 VITE_WIRED_ACCOUNT_API_BASE=https://staging.wiredsignal.online
+VITE_REVENUE_API_BASE=https://staging.wiredsignal.online

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -13,6 +13,7 @@ export type Settings = {
   filterDifficulty: number;
   ageHours: number;
   sortByPow: boolean;
+  lightningAddress: string;
 };
 
 type SettingsContextValue = {
@@ -37,6 +38,7 @@ const loadSettings = (): Settings => ({
   filterDifficulty: loadFilterDifficulty(),
   ageHours: Number(localStorage.getItem("age")) || 24,
   sortByPow: localStorage.getItem("sortBy") !== "false",
+  lightningAddress: localStorage.getItem("wired:lightning-address") || "",
 });
 
 const persistSettings = (settings: Settings) => {
@@ -44,6 +46,11 @@ const persistSettings = (settings: Settings) => {
   localStorage.setItem("filterDifficulty", String(settings.filterDifficulty));
   localStorage.setItem("age", String(settings.ageHours));
   localStorage.setItem("sortBy", String(settings.sortByPow));
+  if (settings.lightningAddress) {
+    localStorage.setItem("wired:lightning-address", settings.lightningAddress);
+  } else {
+    localStorage.removeItem("wired:lightning-address");
+  }
 };
 
 export function SettingsProvider({ children }: { children: ReactNode }) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,3 +98,9 @@ export const WIRED_ACCOUNT_API_BASE = (
 )
   .trim()
   .replace(/\/+$/, "");
+
+export const REVENUE_API_BASE = (
+  configuredEnv("VITE_REVENUE_API_BASE") || WIRED_ACCOUNT_API_BASE
+)
+  .trim()
+  .replace(/\/+$/, "");

--- a/src/features/compose/PostForm.test.tsx
+++ b/src/features/compose/PostForm.test.tsx
@@ -11,10 +11,11 @@ const mocks = vi.hoisted(() => ({
   handleSubmit: vi.fn(),
   useSubmitForm: vi.fn(),
   useMediaUploads: vi.fn(),
+  settings: { difficulty: 21, lightningAddress: "" },
 }));
 
 vi.mock("../../app/settings", () => ({
-  useSettings: () => ({ settings: { difficulty: 21 } }),
+  useSettings: () => ({ settings: mocks.settings }),
 }));
 
 vi.mock("../../shared/hooks/useSubmitForm", () => ({
@@ -63,6 +64,8 @@ describe("PostForm", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+    mocks.settings.difficulty = 21;
+    mocks.settings.lightningAddress = "";
     mocks.handleSubmit.mockReset();
     mocks.handleSubmit.mockResolvedValue(undefined);
     mocks.useMediaUploads.mockReturnValue({
@@ -119,6 +122,24 @@ describe("PostForm", () => {
     );
 
     expect(emojiButton?.parentElement).toBe(mediaButton?.parentElement);
+  });
+
+  it("shows payout readiness immediately left of transmit only for a saved Lightning address", () => {
+    act(() => {
+      root.render(<PostForm />);
+    });
+
+    expect(container.querySelector("[aria-label='Lightning payout ready']")).toBeNull();
+
+    mocks.settings.lightningAddress = "creator@wallet.example";
+    act(() => {
+      root.render(<PostForm />);
+    });
+
+    const payoutReady = container.querySelector("[aria-label='Lightning payout ready']");
+    expect(payoutReady).not.toBeNull();
+    expect(payoutReady?.getAttribute("role")).toBe("img");
+    expect(payoutReady?.nextElementSibling?.textContent).toBe("transmit");
   });
 
   it("does not duplicate the PoW ETA while mining", () => {

--- a/src/features/compose/PostForm.tsx
+++ b/src/features/compose/PostForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useId, useMemo, useRef, useCallback } from "react";
+import { Zap } from "lucide-react";
 import { Event as NostrEvent, finalizeEvent, generateSecretKey, type EventTemplate } from "nostr-tools";
 import { useSubmitForm } from "../../shared/hooks/useSubmitForm";
 import { buildUnsignedEvent, type CustomEmojiTag } from "./buildUnsignedEvent";
@@ -195,9 +196,21 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
                 onRetry={retryUpload}
               />
             </div>
-            <Button type="submit" variant="primary" size="sm" disabled={doingWorkProp || hasUploading} loading={doingWorkProp}>
-              transmit
-            </Button>
+            <div className="flex items-center gap-2">
+              {settings.lightningAddress && (
+                <span
+                  className="payout-ready-indicator inline-flex items-center justify-center"
+                  role="img"
+                  aria-label="Lightning payout ready"
+                  title="Lightning payout ready"
+                >
+                  <Zap aria-hidden="true" className="h-4 w-4 fill-current" strokeWidth={2.25} />
+                </span>
+              )}
+              <Button type="submit" variant="primary" size="sm" disabled={doingWorkProp || hasUploading} loading={doingWorkProp}>
+                transmit
+              </Button>
+            </div>
           </div>
         </div>
         {emptySubmitMessage && (

--- a/src/features/compose/PostForm.tsx
+++ b/src/features/compose/PostForm.tsx
@@ -78,10 +78,13 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
     signedPoWEvent,
     powEta,
     willUseWiredAccount,
+    revenueFallbackAvailable,
+    handleSubmitWithoutRevenue,
   } =
     useSubmitForm(unsigned, difficulty, {
       secretKey: composeSecretKey,
       onRotateSecretKey: setComposeSecretKey,
+      ...(settings.lightningAddress ? { payoutAddress: settings.lightningAddress } : {}),
     });
   const showPowEta = !doingWorkProp && submitStatus !== "published";
 
@@ -212,6 +215,18 @@ export function PostForm({ refEvent, tagType }: PostFormProps) {
           className="text-right"
         />
         {submitError && <p className="text-danger text-meta text-right">{submitError}</p>}
+        {revenueFallbackAvailable && (
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => void handleSubmitWithoutRevenue()}
+            >
+              transmit without payout
+            </Button>
+          </div>
+        )}
         {signedPoWEvent && (
           <PostCard
             event={signedPoWEvent}

--- a/src/features/revenue/api.test.ts
+++ b/src/features/revenue/api.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+
+import { beforeEach, expect, it, vi } from "vitest";
+import { activateRevenueEnrollment, retryPendingRevenueActivations } from "./api";
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+it("durably retries an activation whose first response is ambiguous", async () => {
+  const fetchMock = vi.fn<typeof fetch>()
+    .mockRejectedValueOnce(new Error("response lost"))
+    .mockResolvedValueOnce(Response.json({ ok: true }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await expect(activateRevenueEnrollment("enrollment-1")).rejects.toThrow("response lost");
+  expect(window.localStorage.getItem("wired:pending-revenue-activations")).toContain("enrollment-1");
+
+  await retryPendingRevenueActivations();
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  expect(window.localStorage.getItem("wired:pending-revenue-activations")).not.toContain("enrollment-1");
+});

--- a/src/features/revenue/api.ts
+++ b/src/features/revenue/api.ts
@@ -1,0 +1,96 @@
+import type { Event } from "nostr-tools";
+import { REVENUE_API_BASE } from "../../config";
+
+export type RevenueConfig = {
+  enabled: boolean;
+  recipientPubkey: string;
+  relayUrl: string;
+  callbackUrl: string;
+  walletBackend: string;
+};
+
+export type ValidatedLightningAddress = {
+  ok: true;
+  address: string;
+  minSendableMsat: number;
+  maxSendableMsat: number;
+};
+
+export type RevenueEnrollment = {
+  ok: true;
+  enrollmentId: string;
+  eventId: string;
+  state: "pending" | "active" | "failed";
+};
+
+function revenueUrl(path: string): string {
+  return `${REVENUE_API_BASE}${path}`;
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  const value = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const message = typeof value?.error === "string" ? value.error : `HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return value as T;
+}
+
+let configPromise: Promise<RevenueConfig> | null = null;
+
+export function fetchRevenueConfig(options: { force?: boolean } = {}): Promise<RevenueConfig> {
+  if (!configPromise || options.force) {
+    configPromise = fetch(revenueUrl("/api/revenue/config"), { cache: "no-store" })
+      .then((response) => readJson<RevenueConfig>(response))
+      .catch((error) => {
+        configPromise = null;
+        throw error;
+      });
+  }
+  return configPromise;
+}
+
+export async function validateLightningAddress(address: string): Promise<ValidatedLightningAddress> {
+  const response = await fetch(revenueUrl("/api/revenue/address/validate"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ address }),
+  });
+  return readJson<ValidatedLightningAddress>(response);
+}
+
+export async function enrollBrowserEvent(event: Event, address: string): Promise<RevenueEnrollment> {
+  const response = await fetch(revenueUrl("/api/revenue/enroll"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ event, address }),
+  });
+  return readJson<RevenueEnrollment>(response);
+}
+
+async function updateEnrollment(enrollmentId: string, action: "activate" | "fail"): Promise<void> {
+  const response = await fetch(
+    revenueUrl(`/api/revenue/enroll/${encodeURIComponent(enrollmentId)}/${action}`),
+    { method: "POST" },
+  );
+  await readJson(response);
+}
+
+export function activateRevenueEnrollment(enrollmentId: string): Promise<void> {
+  return updateEnrollment(enrollmentId, "activate");
+}
+
+export function failRevenueEnrollment(enrollmentId: string): Promise<void> {
+  return updateEnrollment(enrollmentId, "fail");
+}
+
+export function withRevenueZapTag<T extends { tags: string[][] }>(
+  event: T,
+  config: RevenueConfig,
+): T {
+  const tags = event.tags.filter((tag) => tag[0] !== "zap");
+  return {
+    ...event,
+    tags: [...tags, ["zap", config.recipientPubkey, config.relayUrl]],
+  };
+}

--- a/src/features/revenue/api.ts
+++ b/src/features/revenue/api.ts
@@ -37,6 +37,24 @@ async function readJson<T>(response: Response): Promise<T> {
 }
 
 let configPromise: Promise<RevenueConfig> | null = null;
+const ACTIVATION_QUEUE_KEY = "wired:pending-revenue-activations";
+
+function pendingActivations(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const value = JSON.parse(window.localStorage.getItem(ACTIVATION_QUEUE_KEY) || "[]") as unknown;
+    return Array.isArray(value)
+      ? value.filter((item): item is string => typeof item === "string" && item.length > 0)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function storePendingActivations(enrollmentIds: string[]): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(ACTIVATION_QUEUE_KEY, JSON.stringify([...new Set(enrollmentIds)]));
+}
 
 export function fetchRevenueConfig(options: { force?: boolean } = {}): Promise<RevenueConfig> {
   if (!configPromise || options.force) {
@@ -77,7 +95,16 @@ async function updateEnrollment(enrollmentId: string, action: "activate" | "fail
 }
 
 export function activateRevenueEnrollment(enrollmentId: string): Promise<void> {
-  return updateEnrollment(enrollmentId, "activate");
+  storePendingActivations([...pendingActivations(), enrollmentId]);
+  return updateEnrollment(enrollmentId, "activate").then(() => {
+    storePendingActivations(pendingActivations().filter((candidate) => candidate !== enrollmentId));
+  });
+}
+
+export async function retryPendingRevenueActivations(): Promise<void> {
+  for (const enrollmentId of pendingActivations()) {
+    await activateRevenueEnrollment(enrollmentId).catch(() => {});
+  }
 }
 
 export function failRevenueEnrollment(enrollmentId: string): Promise<void> {

--- a/src/features/settings/SettingsPage.test.tsx
+++ b/src/features/settings/SettingsPage.test.tsx
@@ -14,8 +14,13 @@ const settingsMock = vi.hoisted(() => ({
     filterDifficulty: 16,
     ageHours: 24,
     sortByPow: true,
+    lightningAddress: "",
   },
   updateSettings: vi.fn(),
+}));
+
+const revenueMock = vi.hoisted(() => ({
+  validateLightningAddress: vi.fn(),
 }));
 
 vi.mock("../../app/settings", () => ({
@@ -23,6 +28,10 @@ vi.mock("../../app/settings", () => ({
     settings: settingsMock.settings,
     updateSettings: settingsMock.updateSettings,
   }),
+}));
+
+vi.mock("../revenue/api", () => ({
+  validateLightningAddress: revenueMock.validateLightningAddress,
 }));
 
 describe("SettingsPage", () => {
@@ -42,6 +51,13 @@ describe("SettingsPage", () => {
     document.body.appendChild(container);
     root = createRoot(container);
     settingsMock.updateSettings.mockClear();
+    revenueMock.validateLightningAddress.mockReset();
+    revenueMock.validateLightningAddress.mockImplementation(async (address: string) => ({
+      ok: true,
+      address: address.trim().toLowerCase(),
+      minSendableMsat: 1_000,
+      maxSendableMsat: 1_000_000,
+    }));
   });
 
   afterEach(() => {
@@ -75,15 +91,16 @@ describe("SettingsPage", () => {
     });
   }
 
-  function submitSettings() {
+  async function submitSettings() {
     const form = container.querySelector("form");
 
     if (!form) {
       throw new Error("Missing settings form");
     }
 
-    act(() => {
+    await act(async () => {
       form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
     });
   }
 
@@ -95,30 +112,55 @@ describe("SettingsPage", () => {
     expect(container.textContent).toContain("Feed lookback");
   });
 
-  it("blocks invalid settings without persisting them", () => {
+  it("blocks invalid settings without persisting them", async () => {
     renderPage();
 
     changeInput("filterDifficulty", "15");
-    submitSettings();
+    await submitSettings();
 
     expect(container.textContent).toContain("use 16 or higher");
     expect(container.querySelector<HTMLButtonElement>('button[type="submit"]')?.disabled).toBe(true);
     expect(settingsMock.updateSettings).not.toHaveBeenCalled();
   });
 
-  it("persists valid settings and confirms the save", () => {
+  it("persists valid settings and confirms the save", async () => {
     renderPage();
 
     changeInput("filterDifficulty", "18");
     changeInput("difficulty", "21");
     changeInput("age", "48");
-    submitSettings();
+    await submitSettings();
 
     expect(settingsMock.updateSettings).toHaveBeenCalledWith({
       filterDifficulty: 18,
       difficulty: 21,
       ageHours: 48,
+      lightningAddress: "",
     });
     expect(container.textContent).toContain("settings saved");
+  });
+
+  it("validates and saves a normalized Lightning address privately", async () => {
+    renderPage();
+
+    changeInput("lightningAddress", "Creator@Wallet.Example");
+    await submitSettings();
+
+    expect(revenueMock.validateLightningAddress).toHaveBeenCalledWith("Creator@Wallet.Example");
+    expect(settingsMock.updateSettings).toHaveBeenCalledWith(expect.objectContaining({
+      lightningAddress: "creator@wallet.example",
+    }));
+    expect(container.textContent).toContain("settings saved");
+  });
+
+  it("does not replace the saved address when validation fails", async () => {
+    revenueMock.validateLightningAddress.mockRejectedValue(new Error("address unavailable"));
+    renderPage();
+
+    changeInput("lightningAddress", "creator@wallet.example");
+    await submitSettings();
+
+    expect(settingsMock.updateSettings).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("address unavailable");
   });
 });

--- a/src/features/settings/SettingsPage.test.tsx
+++ b/src/features/settings/SettingsPage.test.tsx
@@ -51,6 +51,7 @@ describe("SettingsPage", () => {
     document.body.appendChild(container);
     root = createRoot(container);
     settingsMock.updateSettings.mockClear();
+    settingsMock.settings.lightningAddress = "";
     revenueMock.validateLightningAddress.mockReset();
     revenueMock.validateLightningAddress.mockImplementation(async (address: string) => ({
       ok: true,
@@ -154,13 +155,42 @@ describe("SettingsPage", () => {
   });
 
   it("does not replace the saved address when validation fails", async () => {
-    revenueMock.validateLightningAddress.mockRejectedValue(new Error("address unavailable"));
+    revenueMock.validateLightningAddress.mockRejectedValue(
+      new Error("creator-secret@wallet.example is unavailable"),
+    );
     renderPage();
 
     changeInput("lightningAddress", "creator@wallet.example");
     await submitSettings();
 
     expect(settingsMock.updateSettings).not.toHaveBeenCalled();
-    expect(container.textContent).toContain("address unavailable");
+    expect(container.textContent).toContain("Could not validate that Lightning address");
+    expect(container.textContent).not.toContain("creator-secret@wallet.example is unavailable");
+  });
+
+  it("replaces a previously saved destination only after validation", async () => {
+    settingsMock.settings.lightningAddress = "old@wallet.example";
+    renderPage();
+
+    changeInput("lightningAddress", "New@Wallet.Example");
+    await submitSettings();
+
+    expect(revenueMock.validateLightningAddress).toHaveBeenCalledWith("New@Wallet.Example");
+    expect(settingsMock.updateSettings).toHaveBeenCalledWith(expect.objectContaining({
+      lightningAddress: "new@wallet.example",
+    }));
+  });
+
+  it("removes a saved destination without sending it for validation", async () => {
+    settingsMock.settings.lightningAddress = "old@wallet.example";
+    renderPage();
+
+    changeInput("lightningAddress", "");
+    await submitSettings();
+
+    expect(revenueMock.validateLightningAddress).not.toHaveBeenCalled();
+    expect(settingsMock.updateSettings).toHaveBeenCalledWith(expect.objectContaining({
+      lightningAddress: "",
+    }));
   });
 });

--- a/src/features/settings/SettingsPage.test.tsx
+++ b/src/features/settings/SettingsPage.test.tsx
@@ -168,6 +168,17 @@ describe("SettingsPage", () => {
     expect(container.textContent).not.toContain("creator-secret@wallet.example is unavailable");
   });
 
+  it("rejects a malformed Lightning address without persisting it", async () => {
+    revenueMock.validateLightningAddress.mockRejectedValue(new Error("invalid Lightning address"));
+    renderPage();
+
+    changeInput("lightningAddress", "not-an-address");
+    await submitSettings();
+
+    expect(settingsMock.updateSettings).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Could not validate that Lightning address");
+  });
+
   it("replaces a previously saved destination only after validation", async () => {
     settingsMock.settings.lightningAddress = "old@wallet.example";
     renderPage();

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { useSettings } from "../../app/settings";
 import { Button } from "../../shared/ui/Button";
 import { Input } from "../../shared/ui/Input";
 import { PageShell } from "../../shared/ui/PageShell";
+import { validateLightningAddress } from "../revenue/api";
 
 const MIN_SIGNAL = 16;
 const MIN_THREAD_AGE_HOURS = 1;
@@ -39,7 +40,10 @@ export default function SettingsPage() {
   const [difficulty, setDifficulty] = useState(String(settings.difficulty));
   const [age, setAge] = useState(String(settings.ageHours));
   const [threadRef, setThreadRef] = useState("");
+  const [lightningAddress, setLightningAddress] = useState(settings.lightningAddress);
+  const [lightningAddressError, setLightningAddressError] = useState<string>();
   const [saveStatus, setSaveStatus] = useState<"idle" | "saved">("idle");
+  const [saving, setSaving] = useState(false);
   const navigate = useNavigate();
   const filterDifficultyError = integerError(filterDifficulty, MIN_SIGNAL);
   const difficultyError = integerError(difficulty, MIN_SIGNAL);
@@ -54,7 +58,7 @@ export default function SettingsPage() {
     setter(value);
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (hasSettingsError) {
@@ -62,12 +66,28 @@ export default function SettingsPage() {
       return;
     }
 
-    updateSettings({
-      filterDifficulty: Number(filterDifficulty),
-      difficulty: Number(difficulty),
-      ageHours: Number(age),
-    });
-    setSaveStatus("saved");
+    setSaving(true);
+    setLightningAddressError(undefined);
+    try {
+      const normalizedAddress = lightningAddress.trim()
+        ? (await validateLightningAddress(lightningAddress)).address
+        : "";
+      updateSettings({
+        filterDifficulty: Number(filterDifficulty),
+        difficulty: Number(difficulty),
+        ageHours: Number(age),
+        lightningAddress: normalizedAddress,
+      });
+      setLightningAddress(normalizedAddress);
+      setSaveStatus("saved");
+    } catch (error) {
+      setSaveStatus("idle");
+      setLightningAddressError(
+        error instanceof Error ? error.message : "Lightning address validation failed",
+      );
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -113,9 +133,26 @@ export default function SettingsPage() {
             error={ageError}
           />
         </div>
+        <div className="max-w-md">
+          <Input
+            id="lightningAddress"
+            label="creator payout"
+            type="text"
+            value={lightningAddress}
+            onChange={(e) => {
+              setLightningAddressError(undefined);
+              handleSettingsChange(setLightningAddress, e.target.value);
+            }}
+            placeholder="you@wallet.example"
+            autoComplete="off"
+            spellCheck={false}
+            hint="Optional. Validated when saved, kept out of public Nostr events, and used only for future posts."
+            error={lightningAddressError}
+          />
+        </div>
         <div className="flex items-center gap-3">
-          <Button type="submit" variant="primary" disabled={hasSettingsError}>
-            {saveStatus === "saved" ? "saved" : "save"}
+          <Button type="submit" variant="primary" disabled={hasSettingsError || saving}>
+            {saving ? "validating…" : saveStatus === "saved" ? "saved" : "save"}
           </Button>
           {saveStatus === "saved" && (
             <p role="status" className="text-meta text-secondary">

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -80,11 +80,9 @@ export default function SettingsPage() {
       });
       setLightningAddress(normalizedAddress);
       setSaveStatus("saved");
-    } catch (error) {
+    } catch {
       setSaveStatus("idle");
-      setLightningAddressError(
-        error instanceof Error ? error.message : "Lightning address validation failed",
-      );
+      setLightningAddressError("Could not validate that Lightning address. Check it and try again.");
     } finally {
       setSaving(false);
     }

--- a/src/features/wiredAccount/api.ts
+++ b/src/features/wiredAccount/api.ts
@@ -77,13 +77,14 @@ export function clearWiredAccountStatusCache(): void {
 
 export async function submitWiredAccountPost(
   event: WiredAccountAdmissionEvent,
+  payoutAddress?: string,
 ): Promise<WiredAccountPostResponse> {
   const response = await fetch(wiredAccountUrl("/api/wired-account/posts"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ event }),
+    body: JSON.stringify({ event, ...(payoutAddress ? { payoutAddress } : {}) }),
   });
   const result = await readJson<WiredAccountPostResponse>(response);
   cachedStatus = {

--- a/src/shared/hooks/useSubmitForm.test.tsx
+++ b/src/shared/hooks/useSubmitForm.test.tsx
@@ -372,6 +372,45 @@ describe("useSubmitForm", () => {
     }));
   });
 
+  it("does not publish on enrollment failure and can retry the same event idempotently", async () => {
+    mocks.enrollBrowserEvent
+      .mockRejectedValueOnce(new Error("response lost"))
+      .mockResolvedValueOnce({
+        ok: true,
+        enrollmentId: "enrollment-1",
+        eventId: "1".repeat(64),
+        state: "pending",
+      });
+    mocks.publish.mockResolvedValue(new Set<string>(["wss://relay.example"]));
+    act(() => {
+      root.render(
+        <Probe payoutAddress="creator@wallet.example" onState={(nextState) => (state = nextState)} />,
+      );
+    });
+
+    const revenueMinedEvent = {
+      ...minedEvent,
+      tags: [...minedEvent.tags, ["zap", "a".repeat(64), "wss://wired.example"]],
+    };
+    await submitForm();
+    await act(async () => {
+      mockWorkers[0].emit({ type: "found", event: revenueMinedEvent });
+    });
+    expect(mocks.publish).not.toHaveBeenCalled();
+    expect(state.revenueFallbackAvailable).toBe(true);
+
+    await submitForm();
+    await act(async () => {
+      mockWorkers[1].emit({ type: "found", event: revenueMinedEvent });
+    });
+    expect(mocks.enrollBrowserEvent).toHaveBeenCalledTimes(2);
+    expect(mocks.enrollBrowserEvent.mock.calls[1]?.[0]).toEqual(
+      mocks.enrollBrowserEvent.mock.calls[0]?.[0],
+    );
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    expect(state.submitStatus).toBe("published");
+  });
+
   it("keeps a published enrollment queued when revenue activation is ambiguous", async () => {
     mocks.publish.mockResolvedValue(new Set<string>(["wss://relay.example"]));
     mocks.activateRevenueEnrollment.mockRejectedValue(new Error("activation unavailable"));

--- a/src/shared/hooks/useSubmitForm.test.tsx
+++ b/src/shared/hooks/useSubmitForm.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   enrollBrowserEvent: vi.fn(),
   activateRevenueEnrollment: vi.fn(),
   failRevenueEnrollment: vi.fn(),
+  retryPendingRevenueActivations: vi.fn(),
 }));
 let mockWorkers: MockWorker[] = [];
 
@@ -56,6 +57,7 @@ vi.mock("../../features/revenue/api", async (importOriginal) => {
     enrollBrowserEvent: mocks.enrollBrowserEvent,
     activateRevenueEnrollment: mocks.activateRevenueEnrollment,
     failRevenueEnrollment: mocks.failRevenueEnrollment,
+    retryPendingRevenueActivations: mocks.retryPendingRevenueActivations,
   };
 });
 
@@ -151,6 +153,8 @@ describe("useSubmitForm", () => {
     mocks.enrollBrowserEvent.mockReset();
     mocks.activateRevenueEnrollment.mockReset();
     mocks.failRevenueEnrollment.mockReset();
+    mocks.retryPendingRevenueActivations.mockReset();
+    mocks.retryPendingRevenueActivations.mockResolvedValue(undefined);
     mocks.fetchWiredAccountStatus.mockResolvedValue(disabledWiredAccountStatus);
     mocks.fetchRevenueConfig.mockResolvedValue({
       enabled: true,
@@ -324,6 +328,9 @@ describe("useSubmitForm", () => {
       expect.objectContaining({ tags: expect.arrayContaining([["zap", "a".repeat(64), "wss://wired.example"]]) }),
       "creator@wallet.example",
     );
+    expect(JSON.stringify(mocks.enrollBrowserEvent.mock.calls[0]?.[0])).not.toContain(
+      "creator@wallet.example",
+    );
     expect(mocks.enrollBrowserEvent.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.publish.mock.invocationCallOrder[0],
     );
@@ -365,7 +372,7 @@ describe("useSubmitForm", () => {
     }));
   });
 
-  it("reports a published post separately when revenue activation fails", async () => {
+  it("keeps a published enrollment queued when revenue activation is ambiguous", async () => {
     mocks.publish.mockResolvedValue(new Set<string>(["wss://relay.example"]));
     mocks.activateRevenueEnrollment.mockRejectedValue(new Error("activation unavailable"));
     act(() => {
@@ -387,9 +394,10 @@ describe("useSubmitForm", () => {
 
     expect(state.signedPoWEvent).toBeDefined();
     expect(state.acceptedRelays).toEqual(["wss://relay.example"]);
-    expect(state.submitError).toMatch(/post was published/i);
+    expect(state.submitStatus).toBe("published");
+    expect(state.submitError).toMatch(/retry automatically/i);
     expect(state.revenueFallbackAvailable).toBe(false);
-    expect(mocks.failRevenueEnrollment).toHaveBeenCalledWith("enrollment-1");
+    expect(mocks.failRevenueEnrollment).not.toHaveBeenCalled();
   });
 
   it("mines high-PoW posts with the Wired account pubkey and submits them to wired-admin", async () => {
@@ -466,6 +474,9 @@ describe("useSubmitForm", () => {
 
     expect(mocks.submitWiredAccountPost).toHaveBeenCalledWith(
       wiredRevenueMinedEvent,
+      "creator@wallet.example",
+    );
+    expect(JSON.stringify(mocks.submitWiredAccountPost.mock.calls[0]?.[0])).not.toContain(
       "creator@wallet.example",
     );
     expect(mocks.enrollBrowserEvent).not.toHaveBeenCalled();

--- a/src/shared/hooks/useSubmitForm.test.tsx
+++ b/src/shared/hooks/useSubmitForm.test.tsx
@@ -327,8 +327,69 @@ describe("useSubmitForm", () => {
     expect(mocks.enrollBrowserEvent.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.publish.mock.invocationCallOrder[0],
     );
+    expect(mocks.publish.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.activateRevenueEnrollment.mock.invocationCallOrder[0],
+    );
     expect(mocks.activateRevenueEnrollment).toHaveBeenCalledWith("enrollment-1");
     expect(state.submitStatus).toBe("published");
+  });
+
+  it("keeps a relay-rejected revenue enrollment non-creditable and offers a rebuilt fallback", async () => {
+    mocks.publish.mockResolvedValue(new Set<string>());
+    act(() => {
+      root.render(
+        <Probe payoutAddress="creator@wallet.example" onState={(nextState) => (state = nextState)} />,
+      );
+    });
+
+    await submitForm();
+    const revenueMinedEvent = {
+      ...minedEvent,
+      tags: [...minedEvent.tags, ["zap", "a".repeat(64), "wss://wired.example"]],
+    };
+    await act(async () => {
+      mockWorkers[0].emit({ type: "found", event: revenueMinedEvent });
+    });
+
+    expect(mocks.activateRevenueEnrollment).not.toHaveBeenCalled();
+    expect(mocks.failRevenueEnrollment).toHaveBeenCalledWith("enrollment-1");
+    expect(state.revenueFallbackAvailable).toBe(true);
+
+    await act(async () => {
+      await state.handleSubmitWithoutRevenue();
+    });
+    expect(mockWorkers[1].postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      unsigned: expect.objectContaining({
+        tags: expect.not.arrayContaining([expect.arrayContaining(["zap"])]),
+      }),
+    }));
+  });
+
+  it("reports a published post separately when revenue activation fails", async () => {
+    mocks.publish.mockResolvedValue(new Set<string>(["wss://relay.example"]));
+    mocks.activateRevenueEnrollment.mockRejectedValue(new Error("activation unavailable"));
+    act(() => {
+      root.render(
+        <Probe payoutAddress="creator@wallet.example" onState={(nextState) => (state = nextState)} />,
+      );
+    });
+
+    await submitForm();
+    await act(async () => {
+      mockWorkers[0].emit({
+        type: "found",
+        event: {
+          ...minedEvent,
+          tags: [...minedEvent.tags, ["zap", "a".repeat(64), "wss://wired.example"]],
+        },
+      });
+    });
+
+    expect(state.signedPoWEvent).toBeDefined();
+    expect(state.acceptedRelays).toEqual(["wss://relay.example"]);
+    expect(state.submitError).toMatch(/post was published/i);
+    expect(state.revenueFallbackAvailable).toBe(false);
+    expect(mocks.failRevenueEnrollment).toHaveBeenCalledWith("enrollment-1");
   });
 
   it("mines high-PoW posts with the Wired account pubkey and submits them to wired-admin", async () => {
@@ -409,6 +470,34 @@ describe("useSubmitForm", () => {
     );
     expect(mocks.enrollBrowserEvent).not.toHaveBeenCalled();
     expect(state.submitStatus).toBe("published");
+  });
+
+  it("offers a non-revenue fallback when a Wired-account relay rejects the post", async () => {
+    mocks.fetchWiredAccountStatus.mockResolvedValue(configuredWiredAccountStatus);
+    mocks.submitWiredAccountPost.mockResolvedValue({
+      ok: true,
+      event: { ...minedEvent, sig: "4".repeat(128) },
+      acceptedRelays: [],
+    });
+    act(() => {
+      root.render(
+        <Probe payoutAddress="creator@wallet.example" onState={(nextState) => (state = nextState)} />,
+      );
+    });
+
+    await submitForm();
+    await act(async () => {
+      mockWorkers[0].emit({
+        type: "found",
+        event: {
+          ...minedEvent,
+          pubkey: wiredPubkey,
+          tags: [...minedEvent.tags, ["zap", "a".repeat(64), "wss://wired.example"]],
+        },
+      });
+    });
+
+    expect(state.revenueFallbackAvailable).toBe(true);
   });
 
   it("keeps below-threshold posts on the anonymous publish path", async () => {

--- a/src/shared/hooks/useSubmitForm.test.tsx
+++ b/src/shared/hooks/useSubmitForm.test.tsx
@@ -13,6 +13,10 @@ const mocks = vi.hoisted(() => ({
   publish: vi.fn(),
   fetchWiredAccountStatus: vi.fn(),
   submitWiredAccountPost: vi.fn(),
+  fetchRevenueConfig: vi.fn(),
+  enrollBrowserEvent: vi.fn(),
+  activateRevenueEnrollment: vi.fn(),
+  failRevenueEnrollment: vi.fn(),
 }));
 let mockWorkers: MockWorker[] = [];
 
@@ -43,6 +47,17 @@ vi.mock("../../features/wiredAccount/api", () => ({
   fetchWiredAccountStatus: mocks.fetchWiredAccountStatus,
   submitWiredAccountPost: mocks.submitWiredAccountPost,
 }));
+
+vi.mock("../../features/revenue/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../features/revenue/api")>();
+  return {
+    ...actual,
+    fetchRevenueConfig: mocks.fetchRevenueConfig,
+    enrollBrowserEvent: mocks.enrollBrowserEvent,
+    activateRevenueEnrollment: mocks.activateRevenueEnrollment,
+    failRevenueEnrollment: mocks.failRevenueEnrollment,
+  };
+});
 
 class MockWorker {
   onmessage: ((event: MessageEvent) => void) | null = null;
@@ -93,12 +108,14 @@ const configuredWiredAccountStatus = {
 
 function Probe({
   difficulty = "1",
+  payoutAddress,
   onState,
 }: {
   difficulty?: string;
+  payoutAddress?: string;
   onState: (state: ReturnType<typeof useSubmitForm>) => void;
 }) {
-  const state = useSubmitForm(unsigned, difficulty);
+  const state = useSubmitForm(unsigned, difficulty, { payoutAddress });
   onState(state);
 
   return (
@@ -130,7 +147,26 @@ describe("useSubmitForm", () => {
     mocks.publish.mockReset();
     mocks.fetchWiredAccountStatus.mockReset();
     mocks.submitWiredAccountPost.mockReset();
+    mocks.fetchRevenueConfig.mockReset();
+    mocks.enrollBrowserEvent.mockReset();
+    mocks.activateRevenueEnrollment.mockReset();
+    mocks.failRevenueEnrollment.mockReset();
     mocks.fetchWiredAccountStatus.mockResolvedValue(disabledWiredAccountStatus);
+    mocks.fetchRevenueConfig.mockResolvedValue({
+      enabled: true,
+      recipientPubkey: "a".repeat(64),
+      relayUrl: "wss://wired.example",
+      callbackUrl: "https://wired.example/api/revenue/zap",
+      walletBackend: "fake",
+    });
+    mocks.enrollBrowserEvent.mockResolvedValue({
+      ok: true,
+      enrollmentId: "enrollment-1",
+      eventId: "1".repeat(64),
+      state: "pending",
+    });
+    mocks.activateRevenueEnrollment.mockResolvedValue(undefined);
+    mocks.failRevenueEnrollment.mockResolvedValue(undefined);
     window.localStorage.clear();
     vi.stubGlobal("Worker", MockWorker);
     Object.defineProperty(window.navigator, "hardwareConcurrency", {
@@ -260,6 +296,41 @@ describe("useSubmitForm", () => {
     expect(mocks.appendKey).toHaveBeenCalledTimes(1);
   });
 
+  it("enrolls a revenue-tagged browser event before relay publication", async () => {
+    mocks.publish.mockResolvedValue(new Set<string>(["wss://relay.example"]));
+
+    act(() => {
+      root.render(
+        <Probe payoutAddress="creator@wallet.example" onState={(nextState) => (state = nextState)} />,
+      );
+    });
+
+    await submitForm();
+    expect(mockWorkers[0].postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      unsigned: expect.objectContaining({
+        tags: expect.arrayContaining([["zap", "a".repeat(64), "wss://wired.example"]]),
+      }),
+    }));
+
+    const revenueMinedEvent = {
+      ...minedEvent,
+      tags: [...minedEvent.tags, ["zap", "a".repeat(64), "wss://wired.example"]],
+    };
+    await act(async () => {
+      mockWorkers[0].emit({ type: "found", event: revenueMinedEvent });
+    });
+
+    expect(mocks.enrollBrowserEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: expect.arrayContaining([["zap", "a".repeat(64), "wss://wired.example"]]) }),
+      "creator@wallet.example",
+    );
+    expect(mocks.enrollBrowserEvent.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.publish.mock.invocationCallOrder[0],
+    );
+    expect(mocks.activateRevenueEnrollment).toHaveBeenCalledWith("enrollment-1");
+    expect(state.submitStatus).toBe("published");
+  });
+
   it("mines high-PoW posts with the Wired account pubkey and submits them to wired-admin", async () => {
     const wiredMinedEvent = {
       ...unsigned,
@@ -300,6 +371,43 @@ describe("useSubmitForm", () => {
     expect(mocks.appendKey).not.toHaveBeenCalled();
     expect(state.signedPoWEvent).toEqual(wiredSignedEvent);
     expect(state.acceptedRelays).toEqual(["wss://wired.example"]);
+    expect(state.submitStatus).toBe("published");
+  });
+
+  it("sends the private payout snapshot with a revenue-tagged Wired-account submission", async () => {
+    const wiredRevenueMinedEvent = {
+      ...unsigned,
+      id: "3".repeat(64),
+      pubkey: wiredPubkey,
+      tags: [
+        ...unsigned.tags,
+        ["zap", "a".repeat(64), "wss://wired.example"],
+        ["nonce", "2", "1"],
+      ],
+    };
+    const wiredSignedEvent = { ...wiredRevenueMinedEvent, sig: "4".repeat(128) };
+    mocks.fetchWiredAccountStatus.mockResolvedValue(configuredWiredAccountStatus);
+    mocks.submitWiredAccountPost.mockResolvedValue({
+      ok: true,
+      event: wiredSignedEvent,
+      acceptedRelays: ["wss://wired.example"],
+    });
+
+    act(() => {
+      root.render(
+        <Probe payoutAddress="creator@wallet.example" onState={(nextState) => (state = nextState)} />,
+      );
+    });
+    await submitForm();
+    await act(async () => {
+      mockWorkers[0].emit({ type: "found", event: wiredRevenueMinedEvent });
+    });
+
+    expect(mocks.submitWiredAccountPost).toHaveBeenCalledWith(
+      wiredRevenueMinedEvent,
+      "creator@wallet.example",
+    );
+    expect(mocks.enrollBrowserEvent).not.toHaveBeenCalled();
     expect(state.submitStatus).toBe("published");
   });
 

--- a/src/shared/hooks/useSubmitForm.ts
+++ b/src/shared/hooks/useSubmitForm.ts
@@ -21,6 +21,7 @@ import {
   enrollBrowserEvent,
   failRevenueEnrollment,
   fetchRevenueConfig,
+  retryPendingRevenueActivations,
   withRevenueZapTag,
 } from "../../features/revenue/api";
 
@@ -96,6 +97,7 @@ export const useSubmitForm = (
       .catch(() => {
         if (!cancelled) setWiredAccountStatus(null);
       });
+    void retryPendingRevenueActivations();
 
     return () => {
       cancelled = true;
@@ -211,7 +213,16 @@ export const useSubmitForm = (
           rotateSecretKey(generateSecretKey());
           browserEventPublished = true;
           if (enrollment) {
-            await activateRevenueEnrollment(enrollment.enrollmentId);
+            try {
+              await activateRevenueEnrollment(enrollment.enrollmentId);
+            } catch {
+              setSubmitStatus("published");
+              setSubmitError(
+                "Your post was published. Revenue activation will retry automatically.",
+              );
+              browserEnrollmentId = null;
+              return;
+            }
           }
           setSubmitStatus("published");
           browserEnrollmentId = null;

--- a/src/shared/hooks/useSubmitForm.ts
+++ b/src/shared/hooks/useSubmitForm.ts
@@ -157,6 +157,7 @@ export const useSubmitForm = (
         setSubmitStatus("publishing");
         setSubmitError(null);
         let browserEnrollmentId: string | null = null;
+        let browserEventPublished = false;
 
         try {
           if (shouldUseWiredAccount) {
@@ -170,6 +171,7 @@ export const useSubmitForm = (
               setSubmitError("No relay accepted the event. Your draft was not posted.");
               setSignedPoWEvent(undefined);
               setAcceptedRelays([]);
+              if (payoutAddress) setRevenueFallbackAvailable(true);
               return;
             }
 
@@ -186,7 +188,6 @@ export const useSubmitForm = (
             : null;
           if (enrollment) {
             browserEnrollmentId = enrollment.enrollmentId;
-            await activateRevenueEnrollment(enrollment.enrollmentId);
           }
           const accepted = await publish(signedEvent);
           if (activeSubmitId.current !== submitId) return;
@@ -200,6 +201,7 @@ export const useSubmitForm = (
             setSubmitError("No relay accepted the event. Your draft was not posted.");
             setSignedPoWEvent(undefined);
             setAcceptedRelays([]);
+            if (payoutAddress) setRevenueFallbackAvailable(true);
             return;
           }
 
@@ -207,19 +209,27 @@ export const useSubmitForm = (
           setSignedPoWEvent(signedEvent);
           appendKey(bytesToHex(sk), getPublicKey(sk));
           rotateSecretKey(generateSecretKey());
+          browserEventPublished = true;
+          if (enrollment) {
+            await activateRevenueEnrollment(enrollment.enrollmentId);
+          }
           setSubmitStatus("published");
           browserEnrollmentId = null;
         } catch {
           if (activeSubmitId.current !== submitId) return;
 
           setSubmitStatus("failed");
-          setSubmitError("Publishing failed. Your draft was not posted.");
-          setSignedPoWEvent(undefined);
-          setAcceptedRelays([]);
+          setSubmitError(browserEventPublished
+            ? "Your post was published, but revenue enrollment could not be activated."
+            : "Publishing failed. Your draft was not posted.");
+          if (!browserEventPublished) {
+            setSignedPoWEvent(undefined);
+            setAcceptedRelays([]);
+          }
           if (browserEnrollmentId) {
             await failRevenueEnrollment(browserEnrollmentId).catch(() => {});
           }
-          if (payoutAddress) setRevenueFallbackAvailable(true);
+          if (payoutAddress && !browserEventPublished) setRevenueFallbackAvailable(true);
         }
       },
       onError: () => {

--- a/src/shared/hooks/useSubmitForm.ts
+++ b/src/shared/hooks/useSubmitForm.ts
@@ -16,12 +16,20 @@ import {
   type WiredAccountStatus,
 } from "../../features/wiredAccount/api";
 import { timeToGoEst } from "@lib/timeEstimate";
+import {
+  activateRevenueEnrollment,
+  enrollBrowserEvent,
+  failRevenueEnrollment,
+  fetchRevenueConfig,
+  withRevenueZapTag,
+} from "../../features/revenue/api";
 
 export type SubmitStatus = "idle" | "mining" | "publishing" | "published" | "failed";
 
 type SubmitFormOptions = {
   secretKey?: Uint8Array;
   onRotateSecretKey?: (secretKey: Uint8Array) => void;
+  payoutAddress?: string;
 };
 
 const POW_HASHRATE_STORAGE_KEY = "wired:last-pow-hashrate";
@@ -70,7 +78,9 @@ export const useSubmitForm = (
   const [signedPoWEvent, setSignedPoWEvent] = useState<Event>();
   const [wiredAccountStatus, setWiredAccountStatus] = useState<WiredAccountStatus | null>(null);
   const [estimatedHashrate, setEstimatedHashrate] = useState(readStoredHashrate);
+  const [revenueFallbackAvailable, setRevenueFallbackAvailable] = useState(false);
   const activeSubmitId = useRef(0);
+  const skipRevenueNext = useRef(false);
 
   const numCores = navigator.hardwareConcurrency || 4;
   const { startWork, hashrate, bestPow } = usePowMining(numCores, unsignedWithPubkey, difficulty);
@@ -98,10 +108,14 @@ export const useSubmitForm = (
     const submitId = activeSubmitId.current + 1;
     activeSubmitId.current = submitId;
     const submitDifficulty = difficulty;
+    const skipRevenue = skipRevenueNext.current;
+    skipRevenueNext.current = false;
+    const payoutAddress = skipRevenue ? undefined : options.payoutAddress;
     setSubmitStatus("mining");
     setSubmitError(null);
     setAcceptedRelays([]);
     setSignedPoWEvent(undefined);
+    setRevenueFallbackAvailable(false);
 
     const status = await fetchWiredAccountStatus({ force: true }).catch(() => wiredAccountStatus);
     if (activeSubmitId.current !== submitId) return;
@@ -110,9 +124,25 @@ export const useSubmitForm = (
     }
 
     const shouldUseWiredAccount = willUseWiredAccount(submitDifficulty, status);
-    const submitUnsigned = shouldUseWiredAccount && status?.pubkey
+    let revenueConfig = null;
+    if (payoutAddress) {
+      try {
+        revenueConfig = await fetchRevenueConfig({ force: true });
+        if (!revenueConfig.enabled) throw new Error("revenue routing is unavailable");
+      } catch {
+        if (activeSubmitId.current !== submitId) return;
+        setSubmitStatus("failed");
+        setSubmitError("Revenue enrollment is unavailable. Your draft was not posted.");
+        setRevenueFallbackAvailable(true);
+        return;
+      }
+    }
+    const baseUnsigned = shouldUseWiredAccount && status?.pubkey
       ? { ...unsigned, pubkey: status.pubkey }
       : unsignedWithPubkey;
+    const submitUnsigned = revenueConfig
+      ? withRevenueZapTag(baseUnsigned, revenueConfig)
+      : baseUnsigned;
 
     startWork({
       unsigned: submitUnsigned,
@@ -126,10 +156,13 @@ export const useSubmitForm = (
 
         setSubmitStatus("publishing");
         setSubmitError(null);
+        let browserEnrollmentId: string | null = null;
 
         try {
           if (shouldUseWiredAccount) {
-            const result = await submitWiredAccountPost(minedEvent);
+            const result = payoutAddress
+              ? await submitWiredAccountPost(minedEvent, payoutAddress)
+              : await submitWiredAccountPost(minedEvent);
             if (activeSubmitId.current !== submitId) return;
 
             if (result.acceptedRelays.length === 0) {
@@ -148,10 +181,21 @@ export const useSubmitForm = (
           }
 
           const signedEvent = finalizeEvent(minedEvent, sk);
+          const enrollment = payoutAddress
+            ? await enrollBrowserEvent(signedEvent, payoutAddress)
+            : null;
+          if (enrollment) {
+            browserEnrollmentId = enrollment.enrollmentId;
+            await activateRevenueEnrollment(enrollment.enrollmentId);
+          }
           const accepted = await publish(signedEvent);
           if (activeSubmitId.current !== submitId) return;
 
           if (accepted.size === 0) {
+            if (enrollment) {
+              await failRevenueEnrollment(enrollment.enrollmentId).catch(() => {});
+              browserEnrollmentId = null;
+            }
             setSubmitStatus("failed");
             setSubmitError("No relay accepted the event. Your draft was not posted.");
             setSignedPoWEvent(undefined);
@@ -164,6 +208,7 @@ export const useSubmitForm = (
           appendKey(bytesToHex(sk), getPublicKey(sk));
           rotateSecretKey(generateSecretKey());
           setSubmitStatus("published");
+          browserEnrollmentId = null;
         } catch {
           if (activeSubmitId.current !== submitId) return;
 
@@ -171,6 +216,10 @@ export const useSubmitForm = (
           setSubmitError("Publishing failed. Your draft was not posted.");
           setSignedPoWEvent(undefined);
           setAcceptedRelays([]);
+          if (browserEnrollmentId) {
+            await failRevenueEnrollment(browserEnrollmentId).catch(() => {});
+          }
+          if (payoutAddress) setRevenueFallbackAvailable(true);
         }
       },
       onError: () => {
@@ -184,6 +233,11 @@ export const useSubmitForm = (
     });
   };
 
+  const handleSubmitWithoutRevenue = async () => {
+    skipRevenueNext.current = true;
+    await handleSubmit({ preventDefault() {} } as FormEvent);
+  };
+
   return {
     handleSubmit,
     doingWorkProp,
@@ -195,5 +249,7 @@ export const useSubmitForm = (
     signedPoWEvent,
     powEta: timeToGoEst(difficulty, hashrate || estimatedHashrate),
     willUseWiredAccount: willUseWiredAccount(difficulty, wiredAccountStatus),
+    revenueFallbackAvailable,
+    handleSubmitWithoutRevenue,
   };
 };

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -40,6 +40,8 @@
   /* Semantic */
   --danger: #f87171;
   --danger-dim: rgba(248, 113, 113, 0.6);
+  --lightning: #facc15;
+  --lightning-glow: rgba(250, 204, 21, 0.65);
 
   /* Typography */
   --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
@@ -104,6 +106,11 @@ body {
 
 .wired-pressable:active:not(:disabled) {
   transform: translateY(1px) scale(0.98);
+}
+
+.payout-ready-indicator {
+  color: var(--lightning);
+  filter: drop-shadow(0 0 4px var(--lightning-glow));
 }
 
 .post-card--openable {


### PR DESCRIPTION
Implements Wired client enrollment for NIP-57 creator revenue sharing.

- private Lightning address validation and storage
- standard zap tags before PoW
- browser and Wired-account posting paths
- durable activation retry and non-revenue fallback
- staging Vercel configuration

Tracks #117, #118, #119, and #120.