### PR TITLE
Add workflow-level relay transcript coverage

### DIFF
--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -59,6 +59,7 @@ export type { FeedBootstrapSnapshot };
 export type FeedSnapshotOptions = {
   ageHours?: number;
   filterDifficulty?: number;
+  relayUrls?: readonly string[];
   timeoutMs?: number;
 };
 
@@ -208,6 +209,7 @@ async function fetchRootEvents(
   rootRefs: FeedRootRef[],
   knownEvents: Event[],
   timeoutMs: number,
+  snapshotRelayUrls: readonly string[],
 ): Promise<EventBatch> {
   if (rootRefs.length === 0) {
     return { events: [], relayHintsByEventId: new Map() };
@@ -234,7 +236,7 @@ async function fetchRootEvents(
     pendingRefs.forEach((ref) => requestedIds.add(ref.id));
 
     const relayUrls = uniqueRelays([
-      ...FEED_SNAPSHOT_RELAYS,
+      ...snapshotRelayUrls,
       ...pendingRefs.flatMap((ref) => ref.relays),
     ]);
     const relays = await connectRelays(relayUrls, timeoutMs);
@@ -280,8 +282,13 @@ async function fetchGlobalFeedEvents(
   ageHours: number,
   filterDifficulty: number,
   timeoutMs: number,
+  relayUrls: {
+    pow: readonly string[];
+    replies: readonly string[];
+    snapshot: readonly string[];
+  },
 ): Promise<FeedEventBatch> {
-  const relays = await connectRelays(FEED_SNAPSHOT_RELAYS, timeoutMs);
+  const relays = await connectRelays(relayUrls.snapshot, timeoutMs);
 
   try {
     const since = sinceFromAgeHours(ageHours);
@@ -290,7 +297,7 @@ async function fetchGlobalFeedEvents(
       relays,
       { kinds: [1], since, limit: 500 },
       timeoutMs,
-      [...POW_RELAYS],
+      [...relayUrls.pow],
     );
     const activityEvents = activityBatch.events;
     const activityRootRefs = feedRootRefsFromQualifyingActivity(
@@ -306,6 +313,7 @@ async function fetchGlobalFeedEvents(
       activityRootRefs,
       activityEvents,
       timeoutMs,
+      relayUrls.snapshot,
     );
     const seedEvents = mergeEvents(activityEvents, resolvedRootBatch.events);
     const seedEventsById = buildFeedEventMap(seedEvents);
@@ -332,7 +340,7 @@ async function fetchGlobalFeedEvents(
         relays,
         replyFilter,
         timeoutMs,
-        REPLY_RELAYS,
+        [...relayUrls.replies],
       );
       const nextReplies = replyBatch.events;
       const nextParentIds: string[] = [];
@@ -388,6 +396,7 @@ async function fetchReferencedEvents(
   knownEventIds: Set<string>,
   ageHours: number,
   timeoutMs: number,
+  snapshotRelayUrls: readonly string[],
 ): Promise<EventBatch> {
   const missingRefs = refs.filter((ref) => !knownEventIds.has(ref.id));
   if (missingRefs.length === 0) {
@@ -395,7 +404,7 @@ async function fetchReferencedEvents(
   }
 
   const relayUrls = uniqueRelays([
-    ...FEED_SNAPSHOT_RELAYS,
+    ...snapshotRelayUrls,
     ...missingRefs.flatMap((ref) => ref.relays),
   ]);
   const relays = await connectRelays(relayUrls, timeoutMs);
@@ -461,12 +470,13 @@ async function fetchReferencedEvents(
 async function fetchProfileMetadata(
   pubkeys: string[],
   timeoutMs: number,
+  profileRelayUrls: readonly string[],
 ): Promise<Record<string, ProfileMetadata>> {
   if (pubkeys.length === 0) {
     return {};
   }
 
-  const relays = await connectRelays(PROFILE_RELAYS, timeoutMs);
+  const relays = await connectRelays(profileRelayUrls, timeoutMs);
 
   try {
     const { events } = await subscribeOnce(
@@ -477,7 +487,7 @@ async function fetchProfileMetadata(
         limit: profileQueryLimit(pubkeys.length),
       },
       timeoutMs,
-      PROFILE_RELAYS,
+      [...profileRelayUrls],
     );
 
     const profiles: Record<string, { profile: ProfileMetadata; createdAt: number }> =
@@ -551,11 +561,20 @@ export async function fetchFeedSnapshot(
   const ageHours = options.ageHours ?? BOOTSTRAP_AGE_HOURS;
   const filterDifficulty = options.filterDifficulty ?? BOOTSTRAP_FILTER_DIFFICULTY;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const snapshotRelayUrls = options.relayUrls ?? FEED_SNAPSHOT_RELAYS;
+  const powRelayUrls = options.relayUrls ?? POW_RELAYS;
+  const replyRelayUrls = options.relayUrls ?? REPLY_RELAYS;
+  const profileRelayUrls = options.relayUrls ?? PROFILE_RELAYS;
 
   const feedBatch = await fetchGlobalFeedEvents(
     ageHours,
     filterDifficulty,
     timeoutMs,
+    {
+      pow: powRelayUrls,
+      replies: replyRelayUrls,
+      snapshot: snapshotRelayUrls,
+    },
   );
   const processedEvents = processFeedEvents(
     feedBatch.events,
@@ -569,6 +588,7 @@ export async function fetchFeedSnapshot(
     knownEventIds,
     ageHours,
     timeoutMs,
+    snapshotRelayUrls,
   );
   const events = mergeEvents(feedBatch.events, referencedBatch.events);
   const relayHintsByEventId = mergeRelayHints(
@@ -581,6 +601,7 @@ export async function fetchFeedSnapshot(
       ...pubkeysFromEvents(referencedBatch.events),
     ])],
     timeoutMs,
+    profileRelayUrls,
   );
 
   return {

--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -59,7 +59,12 @@ export type { FeedBootstrapSnapshot };
 export type FeedSnapshotOptions = {
   ageHours?: number;
   filterDifficulty?: number;
-  relayUrls?: readonly string[];
+  relayCoverage?: {
+    snapshot: readonly string[];
+    pow: readonly string[];
+    replies: readonly string[];
+    profiles: readonly string[];
+  };
   timeoutMs?: number;
 };
 
@@ -561,10 +566,10 @@ export async function fetchFeedSnapshot(
   const ageHours = options.ageHours ?? BOOTSTRAP_AGE_HOURS;
   const filterDifficulty = options.filterDifficulty ?? BOOTSTRAP_FILTER_DIFFICULTY;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const snapshotRelayUrls = options.relayUrls ?? FEED_SNAPSHOT_RELAYS;
-  const powRelayUrls = options.relayUrls ?? POW_RELAYS;
-  const replyRelayUrls = options.relayUrls ?? REPLY_RELAYS;
-  const profileRelayUrls = options.relayUrls ?? PROFILE_RELAYS;
+  const snapshotRelayUrls = options.relayCoverage?.snapshot ?? FEED_SNAPSHOT_RELAYS;
+  const powRelayUrls = options.relayCoverage?.pow ?? POW_RELAYS;
+  const replyRelayUrls = options.relayCoverage?.replies ?? REPLY_RELAYS;
+  const profileRelayUrls = options.relayCoverage?.profiles ?? PROFILE_RELAYS;
 
   const feedBatch = await fetchGlobalFeedEvents(
     ageHours,

--- a/lib/threadPreview.ts
+++ b/lib/threadPreview.ts
@@ -27,7 +27,8 @@ export type ResolveThreadPreviewOptions = {
 };
 
 export type FetchThreadEventsOptions = {
-  relayUrls?: readonly string[];
+  configuredRelayUrls?: readonly string[];
+  timeoutMs?: number;
 };
 
 function replyCountFromEvents(events: readonly Event[], eventId: string): number {
@@ -84,9 +85,11 @@ export async function fetchThreadEventsFromRelays(
   relayHints: readonly string[],
   options: FetchThreadEventsOptions = {},
 ): Promise<Event[]> {
-  const relayUrls = options.relayUrls
-    ? uniqueRelays(options.relayUrls)
-    : uniqueRelays([...relayHints, ...THREAD_RELAYS]);
+  const relayUrls = uniqueRelays([
+    ...relayHints,
+    ...(options.configuredRelayUrls ?? THREAD_RELAYS),
+  ]);
+  const timeoutMs = options.timeoutMs ?? RELAY_TIMEOUT_MS;
   const relays: Relay[] = [];
   const events = new Map<string, Event>();
 
@@ -101,7 +104,7 @@ export async function fetchThreadEventsFromRelays(
         }
       }),
     ),
-    new Promise<void>((resolve) => setTimeout(resolve, RELAY_TIMEOUT_MS)),
+    new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
   ]);
 
   if (relays.length === 0) return [];
@@ -116,7 +119,7 @@ export async function fetchThreadEventsFromRelays(
       subscriptions.forEach((subscription) => subscription.close());
       resolve();
     };
-    const timer = setTimeout(finish, RELAY_TIMEOUT_MS);
+    const timer = setTimeout(finish, timeoutMs);
     const subscriptions = relays.map((relay) =>
       relay.subscribe(
         [

--- a/lib/threadPreview.ts
+++ b/lib/threadPreview.ts
@@ -26,6 +26,10 @@ export type ResolveThreadPreviewOptions = {
   relayFallback?: (eventId: string, relayHints: readonly string[]) => Promise<Event[]>;
 };
 
+export type FetchThreadEventsOptions = {
+  relayUrls?: readonly string[];
+};
+
 function replyCountFromEvents(events: readonly Event[], eventId: string): number {
   return new Set(
     events
@@ -78,8 +82,11 @@ async function fetchSnapshot(
 export async function fetchThreadEventsFromRelays(
   eventId: string,
   relayHints: readonly string[],
+  options: FetchThreadEventsOptions = {},
 ): Promise<Event[]> {
-  const relayUrls = uniqueRelays([...relayHints, ...THREAD_RELAYS]);
+  const relayUrls = options.relayUrls
+    ? uniqueRelays(options.relayUrls)
+    : uniqueRelays([...relayHints, ...THREAD_RELAYS]);
   const relays: Relay[] = [];
   const events = new Map<string, Event>();
 

--- a/lib/threadPreview.ts
+++ b/lib/threadPreview.ts
@@ -1,4 +1,9 @@
-import { Relay, type Event, useWebSocketImplementation } from "nostr-tools";
+import {
+  Relay,
+  type Event,
+  type Subscription,
+  useWebSocketImplementation,
+} from "nostr-tools";
 import { WebSocket } from "ws";
 import { THREAD_RELAYS } from "../src/config.js";
 import {
@@ -137,8 +142,10 @@ export async function fetchThreadEventsFromRelays(
       settledRelays.add(index);
       if (settledRelays.size >= relays.length) finish();
     };
-    const subscriptions = relays.map((relay, index) =>
-      relay.subscribe(
+    const subscriptions: Subscription[] = [];
+    relays.forEach((relay, index) => {
+      let subscription: Subscription;
+      subscription = relay.subscribe(
         [
           { ids: [eventId], kinds: [1], limit: 1 },
           { "#e": [eventId], kinds: [1], limit: 500 },
@@ -146,10 +153,14 @@ export async function fetchThreadEventsFromRelays(
         {
           onevent: (event) => events.set(event.id, event),
           oneose: () => settleRelay(index),
-          onclose: () => settleRelay(index),
+          onclose: () => {
+            subscription.receivedEose();
+            settleRelay(index);
+          },
         },
-      ),
-    );
+      );
+      subscriptions.push(subscription);
+    });
   });
 
   relays.forEach((relay) => relay.close());

--- a/lib/threadPreview.ts
+++ b/lib/threadPreview.ts
@@ -28,6 +28,7 @@ export type ResolveThreadPreviewOptions = {
 
 export type FetchThreadEventsOptions = {
   configuredRelayUrls?: readonly string[];
+  connectRelay?: typeof Relay.connect;
   timeoutMs?: number;
 };
 
@@ -90,27 +91,39 @@ export async function fetchThreadEventsFromRelays(
     ...(options.configuredRelayUrls ?? THREAD_RELAYS),
   ]);
   const timeoutMs = options.timeoutMs ?? RELAY_TIMEOUT_MS;
+  const connectRelay = options.connectRelay ?? Relay.connect;
   const relays: Relay[] = [];
   const events = new Map<string, Event>();
+  let acceptingConnections = true;
+  let connectionTimer: ReturnType<typeof setTimeout> | undefined;
 
-  await Promise.race([
-    Promise.all(
-      relayUrls.map(async (url) => {
-        try {
-          const relay = await Relay.connect(url);
-          relays.push(relay);
-        } catch {
-          // A preview can succeed from any available relay.
+  const connectionAttempts = Promise.all(
+    relayUrls.map(async (url) => {
+      try {
+        const relay = await connectRelay(url);
+        if (!acceptingConnections) {
+          relay.close();
+          return;
         }
-      }),
-    ),
-    new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+        relays.push(relay);
+      } catch {
+        // A preview can succeed from any available relay.
+      }
+    }),
+  );
+  await Promise.race([
+    connectionAttempts,
+    new Promise<void>((resolve) => {
+      connectionTimer = setTimeout(resolve, timeoutMs);
+    }),
   ]);
+  acceptingConnections = false;
+  if (connectionTimer) clearTimeout(connectionTimer);
 
   if (relays.length === 0) return [];
 
   await new Promise<void>((resolve) => {
-    let eoseCount = 0;
+    const settledRelays = new Set<number>();
     let settled = false;
     const finish = () => {
       if (settled) return;
@@ -120,7 +133,11 @@ export async function fetchThreadEventsFromRelays(
       resolve();
     };
     const timer = setTimeout(finish, timeoutMs);
-    const subscriptions = relays.map((relay) =>
+    const settleRelay = (index: number) => {
+      settledRelays.add(index);
+      if (settledRelays.size >= relays.length) finish();
+    };
+    const subscriptions = relays.map((relay, index) =>
       relay.subscribe(
         [
           { ids: [eventId], kinds: [1], limit: 1 },
@@ -128,10 +145,8 @@ export async function fetchThreadEventsFromRelays(
         ],
         {
           onevent: (event) => events.set(event.id, event),
-          oneose: () => {
-            eoseCount += 1;
-            if (eoseCount >= relays.length) finish();
-          },
+          oneose: () => settleRelay(index),
+          onclose: () => settleRelay(index),
         },
       ),
     );

--- a/src/nostr/relay-pool.test.ts
+++ b/src/nostr/relay-pool.test.ts
@@ -14,6 +14,9 @@ vi.mock("nostr-tools", () => ({
 function relay(url: string) {
   return {
     url,
+    connected: true,
+    onclose: null as (() => void) | null,
+    openSubs: new Map(),
     subscribe: vi.fn(),
     publish: vi.fn(),
   };
@@ -45,5 +48,25 @@ describe("RelayPool", () => {
     await connected;
 
     expect(pool.connectedUrls).toEqual(["wss://fast.example"]);
+  });
+
+  it("settles open subscriptions and removes a terminal relay", async () => {
+    const pool = new RelayPool();
+    const connectedRelay = relay("wss://closed.example");
+    const subscription = {
+      receivedEose: vi.fn(),
+      close: vi.fn(),
+      oneose: undefined as (() => void) | undefined,
+    };
+    connectedRelay.openSubs.set("sub", subscription);
+    connectedRelay.subscribe.mockReturnValue(subscription);
+    mocks.connect.mockResolvedValue(connectedRelay);
+
+    await pool.ensureConnected([connectedRelay.url]);
+    pool.subscribe({ kinds: [1] }, vi.fn(), { onEose: vi.fn() });
+    connectedRelay.onclose?.();
+
+    expect(subscription.receivedEose).toHaveBeenCalledOnce();
+    expect(pool.connectedUrls).toEqual([]);
   });
 });

--- a/src/nostr/relay-pool.test.ts
+++ b/src/nostr/relay-pool.test.ts
@@ -16,7 +16,6 @@ function relay(url: string) {
     url,
     connected: true,
     onclose: null as (() => void) | null,
-    openSubs: new Map(),
     subscribe: vi.fn(),
     publish: vi.fn(),
   };
@@ -57,12 +56,15 @@ describe("RelayPool", () => {
       receivedEose: vi.fn(),
       close: vi.fn(),
       oneose: undefined as (() => void) | undefined,
+      onclose: undefined as ((reason: string) => void) | undefined,
     };
-    connectedRelay.openSubs.set("sub", subscription);
-    connectedRelay.subscribe.mockReturnValue(subscription);
+    connectedRelay.subscribe.mockImplementation((_filters, params) => {
+      subscription.onclose = params.onclose;
+      return subscription;
+    });
     mocks.connect.mockResolvedValue(connectedRelay);
 
-    await pool.ensureConnected([connectedRelay.url]);
+    await pool.connect([connectedRelay.url]);
     pool.subscribe({ kinds: [1] }, vi.fn(), { onEose: vi.fn() });
     connectedRelay.onclose?.();
 

--- a/src/nostr/relay-pool.ts
+++ b/src/nostr/relay-pool.ts
@@ -11,6 +11,7 @@ export type SubscribeOptions = {
 
 export class RelayPool {
   private readonly relays = new Map<string, Relay>();
+  private readonly subscriptionsByRelay = new Map<string, Set<Subscription>>();
   private defaultRelayUrls = new Set<string>();
   private readonly inFlightPublishes = new Map<string, Promise<Set<string>>>();
 
@@ -50,9 +51,11 @@ export class RelayPool {
         if (this.relays.get(url) !== relay) return;
         this.relays.delete(url);
         // A terminal relay cannot deliver more events. Count its open subscriptions
-        // as EOSE before nostr-tools closes them so aggregate traversals can continue
-        // immediately and their library EOSE timers are cleared.
-        [...relay.openSubs.values()].forEach((subscription) => {
+        // as EOSE so aggregate traversals can continue immediately and their
+        // library EOSE timers are cleared.
+        const subscriptions = this.subscriptionsByRelay.get(url) ?? [];
+        this.subscriptionsByRelay.delete(url);
+        [...subscriptions].forEach((subscription) => {
           subscription.receivedEose();
         });
       };
@@ -88,7 +91,18 @@ export class RelayPool {
         onevent(event) {
           cb(event, relay.url);
         },
+        onclose: () => {
+          const tracked = this.subscriptionsByRelay.get(url);
+          tracked?.delete(sub);
+          if (tracked?.size === 0) {
+            this.subscriptionsByRelay.delete(url);
+          }
+        },
       });
+
+      const tracked = this.subscriptionsByRelay.get(url) ?? new Set<Subscription>();
+      tracked.add(sub);
+      this.subscriptionsByRelay.set(url, tracked);
 
       if (closeOnEose || onEose) {
         sub.oneose = () => handleEose(sub);

--- a/src/nostr/relay-pool.ts
+++ b/src/nostr/relay-pool.ts
@@ -12,6 +12,7 @@ export type SubscribeOptions = {
 export class RelayPool {
   private readonly relays = new Map<string, Relay>();
   private defaultRelayUrls = new Set<string>();
+  private readonly inFlightPublishes = new Map<string, Promise<Set<string>>>();
 
   get connectedUrls(): string[] {
     return [...this.relays.keys()];
@@ -103,7 +104,20 @@ export class RelayPool {
     return subscriptions;
   }
 
-  async publish(event: Event): Promise<Set<string>> {
+  publish(event: Event): Promise<Set<string>> {
+    const existing = this.inFlightPublishes.get(event.id);
+    if (existing) return existing;
+
+    const publish = this.publishToRelays(event).finally(() => {
+      if (this.inFlightPublishes.get(event.id) === publish) {
+        this.inFlightPublishes.delete(event.id);
+      }
+    });
+    this.inFlightPublishes.set(event.id, publish);
+    return publish;
+  }
+
+  private async publishToRelays(event: Event): Promise<Set<string>> {
     const accepted = new Set<string>();
 
     await Promise.allSettled(

--- a/src/nostr/relay-pool.ts
+++ b/src/nostr/relay-pool.ts
@@ -45,6 +45,16 @@ export class RelayPool {
         }),
       ]);
       this.relays.set(url, relay);
+      relay.onclose = () => {
+        if (this.relays.get(url) !== relay) return;
+        this.relays.delete(url);
+        // A terminal relay cannot deliver more events. Count its open subscriptions
+        // as EOSE before nostr-tools closes them so aggregate traversals can continue
+        // immediately and their library EOSE timers are cleared.
+        [...relay.openSubs.values()].forEach((subscription) => {
+          subscription.receivedEose();
+        });
+      };
     } catch {
       // Relay unavailable; other relays may still connect.
     } finally {
@@ -56,7 +66,7 @@ export class RelayPool {
     const { closeOnEose = false, relayUrls, onEose } = options;
     const targetUrls = relayUrls ?? [...this.defaultRelayUrls];
     const subscriptions: Subscription[] = [];
-    const connectedUrls = targetUrls.filter((url) => this.relays.has(url));
+    const connectedUrls = targetUrls.filter((url) => this.relays.get(url)?.connected);
     let eoseCount = 0;
 
     const handleEose = (sub: Subscription) => {

--- a/src/nostr/subscriptions/index.ts
+++ b/src/nostr/subscriptions/index.ts
@@ -44,12 +44,17 @@ export async function subProfilesOnce(
   pubkeys: string[],
   onEvent: SubCallback,
   onEose?: () => void,
+  options: { relayUrls?: readonly string[] } = {},
 ): Promise<SubHandle> {
   if (pubkeys.length === 0) {
     return emptySubHandle("profiles-once:empty");
   }
 
-  await initNostr();
+  if (options.relayUrls) {
+    await ensureRelaysConnected(options.relayUrls);
+  } else {
+    await initNostr();
+  }
 
   return getRegistry().subscribe([
     {
@@ -61,7 +66,7 @@ export async function subProfilesOnce(
       cb: onEvent,
       closeOnEose: true,
       onEose,
-      relayUrls: PROFILE_RELAYS,
+      relayUrls: options.relayUrls ?? PROFILE_RELAYS,
     },
   ]);
 }
@@ -70,17 +75,26 @@ function uniqueRelayUrls(relays: readonly string[]): string[] {
   return [...new Set(relays)];
 }
 
-function fallbackRelayUrlsForQuote(ref: QuotedRef): string[] {
-  return uniqueRelayUrls([...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS, ...ref.relays]);
+function fallbackRelayUrlsForQuote(
+  ref: QuotedRef,
+  fallbackRelayUrls: readonly string[] = [...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS],
+): string[] {
+  return uniqueRelayUrls([...fallbackRelayUrls, ...ref.relays]);
 }
 
-function extraRelayHintsForQuote(ref: QuotedRef): string[] {
-  const fallbackRelays = new Set([...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS]);
+function extraRelayHintsForQuote(
+  ref: QuotedRef,
+  fallbackRelayUrls: readonly string[] = [...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS],
+): string[] {
+  const fallbackRelays = new Set(fallbackRelayUrls);
   return uniqueRelayUrls(ref.relays.filter((relay) => !fallbackRelays.has(relay)));
 }
 
-function hasExtraRelayHints(ref: QuotedRef): boolean {
-  return extraRelayHintsForQuote(ref).length > 0;
+function hasExtraRelayHints(
+  ref: QuotedRef,
+  fallbackRelayUrls?: readonly string[],
+): boolean {
+  return extraRelayHintsForQuote(ref, fallbackRelayUrls).length > 0;
 }
 
 function quoteRequests(
@@ -107,15 +121,26 @@ export async function subQuotedEventsOnce(
   refs: QuotedRef[],
   onEvent: SubCallback,
   onEose?: (refId: string) => void,
+  options: { fallbackRelayUrls?: readonly string[] } = {},
 ): Promise<SubHandle> {
   if (refs.length === 0) {
     return emptySubHandle("quoted-events-once:empty");
   }
 
-  await initNostr();
+  const fallbackRelayUrls = options.fallbackRelayUrls ?? [
+    ...POW_RELAYS,
+    ...QUOTE_FALLBACK_RELAYS,
+  ];
+  if (options.fallbackRelayUrls) {
+    await ensureRelaysConnected(fallbackRelayUrls);
+  } else {
+    await initNostr();
+  }
 
   const owner = createSubHandleOwner("quoted-events-once");
-  const refsWithExtraHints = refs.filter(hasExtraRelayHints);
+  const refsWithExtraHints = refs.filter((ref) =>
+    hasExtraRelayHints(ref, fallbackRelayUrls)
+  );
 
   owner.add(
     getRegistry().subscribe(
@@ -123,21 +148,28 @@ export async function subQuotedEventsOnce(
         refs,
         onEvent,
         onEose,
-        fallbackRelayUrlsForQuote,
-        (ref) => !hasExtraRelayHints(ref),
+        (ref) => fallbackRelayUrlsForQuote(ref, fallbackRelayUrls),
+        (ref) => !hasExtraRelayHints(ref, fallbackRelayUrls),
       ),
     ),
   );
 
   if (refsWithExtraHints.length > 0) {
     const extraRelayHints = uniqueRelayUrls(
-      refsWithExtraHints.flatMap(extraRelayHintsForQuote),
+      refsWithExtraHints.flatMap((ref) =>
+        extraRelayHintsForQuote(ref, fallbackRelayUrls)
+      ),
     );
     void ensureRelaysConnected(extraRelayHints)
       .then(() => {
         owner.add(
           getRegistry().subscribe(
-            quoteRequests(refsWithExtraHints, onEvent, onEose, extraRelayHintsForQuote),
+            quoteRequests(
+              refsWithExtraHints,
+              onEvent,
+              onEose,
+              (ref) => extraRelayHintsForQuote(ref, fallbackRelayUrls),
+            ),
           ),
         );
       })

--- a/src/nostr/subscriptions/index.ts
+++ b/src/nostr/subscriptions/index.ts
@@ -76,10 +76,9 @@ function uniqueRelayUrls(relays: readonly string[]): string[] {
 }
 
 function fallbackRelayUrlsForQuote(
-  ref: QuotedRef,
   fallbackRelayUrls: readonly string[] = [...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS],
 ): string[] {
-  return uniqueRelayUrls([...fallbackRelayUrls, ...ref.relays]);
+  return uniqueRelayUrls(fallbackRelayUrls);
 }
 
 function extraRelayHintsForQuote(
@@ -148,7 +147,7 @@ export async function subQuotedEventsOnce(
         refs,
         onEvent,
         onEose,
-        (ref) => fallbackRelayUrlsForQuote(ref, fallbackRelayUrls),
+        () => fallbackRelayUrlsForQuote(fallbackRelayUrls),
         (ref) => !hasExtraRelayHints(ref, fallbackRelayUrls),
       ),
     ),

--- a/src/nostr/subscriptions/notifications.ts
+++ b/src/nostr/subscriptions/notifications.ts
@@ -6,6 +6,7 @@ export const subNotifications = (
   pubkeys: string[],
   onEvent: SubCallback,
   onEose?: () => void,
+  options: { relayUrls?: readonly string[] } = {},
 ): SubHandle => {
   if (pubkeys.length === 0) {
     return emptySubHandle("notifications:empty");
@@ -29,6 +30,7 @@ export const subNotifications = (
       cb: onEvent,
       closeOnEose: true,
       onEose: handleEose,
+      relayUrls: options.relayUrls,
     },
     {
       filter: {
@@ -39,6 +41,7 @@ export const subNotifications = (
       cb: onEvent,
       closeOnEose: true,
       onEose: handleEose,
+      relayUrls: options.relayUrls,
     },
   ]);
 };

--- a/src/nostr/subscriptions/notifications.ts
+++ b/src/nostr/subscriptions/notifications.ts
@@ -24,7 +24,7 @@ export const subNotifications = (
     {
       filter: {
         authors: pubkeys,
-        kinds: [1, 7],
+        kinds: [1],
         limit: 25,
       },
       cb: onEvent,

--- a/src/nostr/subscriptions/quoted-events.test.ts
+++ b/src/nostr/subscriptions/quoted-events.test.ts
@@ -60,7 +60,7 @@ describe("subQuotedEventsOnce", () => {
       limit: 1,
     });
     expect(fallbackRequest.relayUrls).toEqual([
-      ...new Set([...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS, "wss://nostr.land"]),
+      ...new Set([...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS]),
     ]);
     expect(fallbackRequest.onEose).toBeUndefined();
 
@@ -121,7 +121,6 @@ describe("subQuotedEventsOnce", () => {
       ...powRelays,
       ...defaultQuoteRelays,
       ...configuredQuoteRelays,
-      "wss://nostr.land",
     ]);
     expect(mocks.ensureRelaysConnected).toHaveBeenCalledWith(["wss://nostr.land"]);
   });

--- a/src/nostr/testing/audit-metrics.ts
+++ b/src/nostr/testing/audit-metrics.ts
@@ -1,0 +1,20 @@
+export function auditSampleCount(): number {
+  return process.env.RELAY_AUDIT_OUTPUT === "1" ? 20 : 1;
+}
+
+export function summarizeSamples(samples: readonly number[]) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const percentile = (value: number) =>
+    sorted[Math.ceil((value / 100) * sorted.length) - 1] ?? 0;
+  return {
+    p50: percentile(50),
+    p95: percentile(95),
+    samples,
+  };
+}
+
+export function emitAuditMeasurement(value: object): void {
+  if (process.env.RELAY_AUDIT_OUTPUT === "1") {
+    console.info(JSON.stringify(value));
+  }
+}

--- a/src/nostr/testing/feed-snapshot-transcript.test.ts
+++ b/src/nostr/testing/feed-snapshot-transcript.test.ts
@@ -83,7 +83,12 @@ describe("server feed snapshot relay transcript", () => {
       fetchSnapshot: () => fetchFeedSnapshot({
         ageHours: 24,
         filterDifficulty: 0,
-        relayUrls,
+        relayCoverage: {
+          snapshot: relayUrls,
+          pow: relayUrls,
+          replies: relayUrls,
+          profiles: relayUrls,
+        },
         timeoutMs: 1_000,
       }),
     });
@@ -229,7 +234,12 @@ describe("server feed snapshot relay transcript", () => {
     const snapshot = await fetchFeedSnapshot({
       ageHours: 24,
       filterDifficulty: 0,
-      relayUrls: harnesses.map((harness) => harness.url),
+      relayCoverage: {
+        snapshot: harnesses.map((harness) => harness.url),
+        pow: harnesses.map((harness) => harness.url),
+        replies: harnesses.map((harness) => harness.url),
+        profiles: harnesses.map((harness) => harness.url),
+      },
       timeoutMs: 50,
     });
     workflow.complete();
@@ -299,7 +309,12 @@ describe("server feed snapshot relay transcript", () => {
     const snapshot = await fetchFeedSnapshot({
       ageHours: 24,
       filterDifficulty: 0,
-      relayUrls,
+      relayCoverage: {
+        snapshot: relayUrls,
+        pow: relayUrls,
+        replies: relayUrls,
+        profiles: relayUrls,
+      },
       timeoutMs: 1_000,
     });
     await session.waitFor((entries) =>

--- a/src/nostr/testing/feed-snapshot-transcript.test.ts
+++ b/src/nostr/testing/feed-snapshot-transcript.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  finalizeEvent,
+  useWebSocketImplementation as configureWebSocketImplementation,
+} from "nostr-tools";
+import { WebSocket } from "ws";
+import { fetchFeedSnapshot } from "../../../lib/feedSnapshot";
+import type { FeedBootstrapSnapshot } from "../../shared/lib/feedBootstrapTypes";
+import {
+  FeedBootstrapCacheService,
+  MemoryFeedBootstrapStore,
+} from "../../../lib/feedBootstrapCache";
+import {
+  auditSampleCount,
+  emitAuditMeasurement,
+  summarizeSamples,
+} from "./audit-metrics";
+import {
+  RelayTranscriptHarness,
+  RelayTranscriptSession,
+  type RelayRequestController,
+  type RelayTranscriptEntry,
+} from "./relay-transcript";
+
+configureWebSocketImplementation(WebSocket);
+
+const secretKey = new Uint8Array(32).fill(6);
+const root = finalizeEvent({
+  created_at: 2_000_000_000,
+  kind: 1,
+  tags: [],
+  content: "server root",
+}, secretKey);
+const reply = finalizeEvent({
+  created_at: root.created_at + 1,
+  kind: 1,
+  tags: [["e", root.id, "", "reply"]],
+  content: "server reply",
+}, secretKey);
+const nestedReply = finalizeEvent({
+  created_at: reply.created_at + 1,
+  kind: 1,
+  tags: [["e", reply.id, "", "reply"]],
+  content: "server nested reply",
+}, secretKey);
+
+function driveSnapshot(request: RelayRequestController): void {
+  const [filter] = request.filters;
+  if (filter?.["#e"]?.includes(reply.id)) {
+    request.sendEvent(nestedReply);
+  } else if (filter?.["#e"]?.includes(root.id)) {
+    request.sendEvent(reply);
+  } else if (filter?.kinds?.includes(1)) {
+    request.sendEvent(root);
+  }
+  request.sendEose();
+}
+
+function completionIds(entries: readonly RelayTranscriptEntry[], type: "eose" | "close") {
+  return entries
+    .flatMap((entry) => entry.type === type ? [entry.subscriptionId] : [])
+    .sort();
+}
+
+describe("server feed snapshot relay transcript", () => {
+  const harnesses: RelayTranscriptHarness[] = [];
+
+  afterEach(async () => {
+    await Promise.all(harnesses.splice(0).map((harness) => harness.close()));
+  });
+
+  it("captures recursive output, relay duplicates, finite cleanup, and profile enrichment", async () => {
+    const session = new RelayTranscriptSession();
+    harnesses.push(
+      await RelayTranscriptHarness.listen({ session, onRequest: driveSnapshot }),
+      await RelayTranscriptHarness.listen({ session, onRequest: driveSnapshot }),
+    );
+    const relayUrls = harnesses.map((harness) => harness.url);
+    const service = new FeedBootstrapCacheService({
+      store: new MemoryFeedBootstrapStore(),
+      fetchSnapshot: () => fetchFeedSnapshot({
+        ageHours: 24,
+        filterDifficulty: 0,
+        relayUrls,
+        timeoutMs: 1_000,
+      }),
+    });
+    const completionLatencies: number[] = [];
+    let evidenceEntries: readonly RelayTranscriptEntry[] = [];
+    let lastSnapshot: FeedBootstrapSnapshot | undefined;
+
+    for (let run = 0; run < auditSampleCount(); run += 1) {
+      const workflow = session.beginWorkflow(`wired-server-feed-snapshot-${run + 1}`);
+      const [snapshot, coalescedSnapshot] = await Promise.all([
+        service.refresh(),
+        service.refresh(),
+      ]);
+      await session.waitFor(
+        (entries) =>
+          entries.filter((entry) => entry.type === "connection-closed").length ===
+          (run + 1) * 4,
+      );
+      workflow.complete();
+      expect(coalescedSnapshot).toBe(snapshot);
+      lastSnapshot = snapshot;
+
+      expect(Object.keys(snapshot.eventsById).sort()).toEqual(
+        [root.id, reply.id, nestedReply.id].sort(),
+      );
+      expect(snapshot.processedEvents[0]?.replyIds.sort()).toEqual(
+        [reply.id, nestedReply.id].sort(),
+      );
+      const summary = session.summary(workflow);
+      expect(summary).toMatchObject({
+        openedConnections: 4,
+        closedConnections: 4,
+        connectionReuseCount: 4,
+        requests: 8,
+        closes: 8,
+        returnedEvents: 6,
+        eose: 8,
+        repeatedOperations: 4,
+        relayFanout: 2,
+      });
+      const entries = session.entries.slice(
+        workflow.startIndex,
+        workflow.completedIndex,
+      );
+      const requests = entries.filter((entry) => entry.type === "request");
+      const requestIds = requests.map((entry) => entry.subscriptionId).sort();
+      expect(completionIds(entries, "eose")).toEqual(requestIds);
+      expect(completionIds(entries, "close")).toEqual(requestIds);
+      const filterCounts = new Map<string, number>();
+      requests.forEach((request) => {
+        const filters = request.filters.map(({ since: _since, ...filter }) => filter);
+        const key = JSON.stringify(filters);
+        filterCounts.set(key, (filterCounts.get(key) ?? 0) + 1);
+      });
+      expect([...filterCounts.values()]).toEqual([2, 2, 2, 2]);
+
+      completionLatencies.push(summary.completionLatencyMs);
+      evidenceEntries = entries;
+    }
+
+    expect(lastSnapshot).toBeDefined();
+    const cacheWorkflow = session.beginWorkflow("wired-server-feed-cache-hit");
+    expect(await service.get()).toBe(lastSnapshot);
+    cacheWorkflow.complete();
+    expect(session.summary(cacheWorkflow)).toMatchObject({
+      openedConnections: 0,
+      requests: 0,
+      returnedEvents: 0,
+      relayFanout: 0,
+    });
+
+    emitAuditMeasurement({
+      scenario: "wired-server-feed-snapshot-local-fixture",
+      samples: completionLatencies.length,
+      completionLatencyMs: summarizeSamples(completionLatencies),
+      evidence: {
+        filters: evidenceEntries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.filters),
+        requestBytes: evidenceEntries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.bytes),
+        returnedEventBytes: evidenceEntries
+          .filter((entry) => entry.type === "event-returned")
+          .map((entry) => entry.bytes),
+        subscriptionLifetimesMs: evidenceEntries
+          .filter((entry) => entry.type === "close")
+          .map((entry) => entry.lifetimeMs),
+      },
+    });
+  });
+
+  it("retains complete results when one relay never sends EOSE", async () => {
+    const session = new RelayTranscriptSession();
+    harnesses.push(
+      await RelayTranscriptHarness.listen({
+        session,
+        onRequest(request) {
+          const [filter] = request.filters;
+          if (filter?.["#e"]?.includes(reply.id)) {
+            request.sendEvent(nestedReply, 5);
+          } else if (filter?.["#e"]?.includes(root.id)) {
+            request.sendEvent(reply, 5);
+          } else if (filter?.kinds?.includes(1)) {
+            request.sendEvent(root, 5);
+          }
+          request.sendEose(5);
+        },
+      }),
+      await RelayTranscriptHarness.listen({
+        session,
+        onRequest() {},
+      }),
+    );
+    const workflow = session.beginWorkflow("wired-server-feed-no-eose-relay");
+    const snapshot = await fetchFeedSnapshot({
+      ageHours: 24,
+      filterDifficulty: 0,
+      relayUrls: harnesses.map((harness) => harness.url),
+      timeoutMs: 50,
+    });
+    workflow.complete();
+
+    expect(Object.keys(snapshot.eventsById).sort()).toEqual(
+      [root.id, reply.id, nestedReply.id].sort(),
+    );
+    const summary = session.summary(workflow);
+    expect(summary).toMatchObject({
+      requests: 8,
+      returnedEvents: 3,
+      eose: 4,
+      relayFanout: 2,
+    });
+    emitAuditMeasurement({
+      scenario: "wired-server-feed-no-eose-relay-local-fixture",
+      samples: 1,
+      completionLatencyMs: summary.completionLatencyMs,
+    });
+  });
+});

--- a/src/nostr/testing/feed-snapshot-transcript.test.ts
+++ b/src/nostr/testing/feed-snapshot-transcript.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   finalizeEvent,
+  nip19,
   useWebSocketImplementation as configureWebSocketImplementation,
 } from "nostr-tools";
 import { WebSocket } from "ws";
 import { fetchFeedSnapshot } from "../../../lib/feedSnapshot";
+import { handleFeedRefreshApi } from "../../../api/_shared/handlers";
 import type { FeedBootstrapSnapshot } from "../../shared/lib/feedBootstrapTypes";
 import {
   FeedBootstrapCacheService,
@@ -91,9 +93,16 @@ describe("server feed snapshot relay transcript", () => {
 
     for (let run = 0; run < auditSampleCount(); run += 1) {
       const workflow = session.beginWorkflow(`wired-server-feed-snapshot-${run + 1}`);
+      const waitUntil = vi.fn<(promise: Promise<unknown>) => void>();
+      const response = await handleFeedRefreshApi(
+        { method: "GET" },
+        { service, waitUntil },
+      );
+      const backgroundRefresh = waitUntil.mock.calls[0]?.[0];
+      expect(backgroundRefresh).toBeDefined();
       const [snapshot, coalescedSnapshot] = await Promise.all([
         service.refresh(),
-        service.refresh(),
+        backgroundRefresh as Promise<FeedBootstrapSnapshot>,
       ]);
       await session.waitFor(
         (entries) =>
@@ -102,6 +111,10 @@ describe("server feed snapshot relay transcript", () => {
       );
       workflow.complete();
       expect(coalescedSnapshot).toBe(snapshot);
+      expect(response).toMatchObject({
+        status: 202,
+        body: { ok: true, refresh: "started" },
+      });
       lastSnapshot = snapshot;
 
       expect(Object.keys(snapshot.eventsById).sort()).toEqual(
@@ -130,13 +143,29 @@ describe("server feed snapshot relay transcript", () => {
       const requestIds = requests.map((entry) => entry.subscriptionId).sort();
       expect(completionIds(entries, "eose")).toEqual(requestIds);
       expect(completionIds(entries, "close")).toEqual(requestIds);
+      const since = requests.find((request) =>
+        request.filters.some((filter) => filter.kinds?.includes(1))
+      )?.filters[0]?.since;
+      expect(typeof since).toBe("number");
+      expect(requests.every((request) => request.filters.every((filter) =>
+        filter.kinds?.includes(1) ? filter.since === since : filter.since === undefined
+      ))).toBe(true);
       const filterCounts = new Map<string, number>();
       requests.forEach((request) => {
-        const filters = request.filters.map(({ since: _since, ...filter }) => filter);
+        const filters = request.filters.map((filter) => {
+          const withoutSince = { ...filter };
+          delete withoutSince.since;
+          return withoutSince;
+        });
         const key = JSON.stringify(filters);
         filterCounts.set(key, (filterCounts.get(key) ?? 0) + 1);
       });
-      expect([...filterCounts.values()]).toEqual([2, 2, 2, 2]);
+      expect(filterCounts).toEqual(new Map([
+        [JSON.stringify([{ kinds: [1], limit: 500 }]), 2],
+        [JSON.stringify([{ "#e": [root.id], kinds: [1], limit: 100 }]), 2],
+        [JSON.stringify([{ "#e": [reply.id], kinds: [1], limit: 100 }]), 2],
+        [JSON.stringify([{ authors: [root.pubkey], kinds: [0], limit: 1 }]), 2],
+      ]));
 
       completionLatencies.push(summary.completionLatencyMs);
       evidenceEntries = entries;
@@ -219,6 +248,90 @@ describe("server feed snapshot relay transcript", () => {
       scenario: "wired-server-feed-no-eose-relay-local-fixture",
       samples: 1,
       completionLatencyMs: summary.completionLatencyMs,
+    });
+  });
+
+  it("resolves referenced context and deterministically selects newest metadata", async () => {
+    const session = new RelayTranscriptSession();
+    const rootKey = new Uint8Array(32).fill(70);
+    const referenceKey = new Uint8Array(32).fill(71);
+    const referenced = finalizeEvent({
+      created_at: 2_000_000_010,
+      kind: 1,
+      tags: [],
+      content: "referenced context",
+    }, referenceKey);
+    let relayUrls: string[] = [];
+    const makeRoot = () => finalizeEvent({
+      created_at: 2_000_000_020,
+      kind: 1,
+      tags: [],
+      content: `nostr:${nip19.neventEncode({ id: referenced.id, relays: [relayUrls[1]!] })}`,
+    }, rootKey);
+    const listen = async (profileName: string, profileCreatedAt: number) =>
+      RelayTranscriptHarness.listen({
+        session,
+        onRequest(request) {
+          const [filter] = request.filters;
+          if (filter?.authors && filter.kinds?.includes(0)) {
+            [rootKey, referenceKey].forEach((key, index) => request.sendEvent(finalizeEvent({
+              created_at: profileCreatedAt,
+              kind: 0,
+              tags: [],
+              content: JSON.stringify({ name: `${profileName}-${index}` }),
+            }, key)));
+          } else if (filter?.ids?.includes(referenced.id)) {
+            request.sendEvent(referenced);
+          } else if (filter?.kinds?.includes(1) && !filter["#e"]) {
+            request.sendEvent(enrichedRoot);
+          }
+          request.sendEose();
+        },
+      });
+
+    const olderRelay = await listen("older", 2_000_000_030);
+    const newerRelay = await listen("newer", 2_000_000_040);
+    harnesses.push(olderRelay, newerRelay);
+    relayUrls = [olderRelay.url, newerRelay.url];
+    const enrichedRoot = makeRoot();
+
+    const workflow = session.beginWorkflow("wired-server-feed-reference-metadata");
+    const snapshot = await fetchFeedSnapshot({
+      ageHours: 24,
+      filterDifficulty: 0,
+      relayUrls,
+      timeoutMs: 1_000,
+    });
+    await session.waitFor((entries) =>
+      entries.filter((entry) => entry.type === "connection-closed").length === 6 &&
+      entries.filter((entry) => entry.type === "close").length === 10
+    );
+    workflow.complete();
+
+    expect(Object.keys(snapshot.eventsById).sort()).toEqual(
+      [enrichedRoot.id, referenced.id].sort(),
+    );
+    expect(snapshot.profiles[enrichedRoot.pubkey]).toEqual({ name: "newer-0" });
+    expect(snapshot.profiles[referenced.pubkey]).toEqual({ name: "newer-1" });
+    const requests = session.entries
+      .slice(workflow.startIndex, workflow.completedIndex)
+      .filter((entry) => entry.type === "request");
+    const referenceRequests = requests.filter((request) =>
+      request.filters[0]?.ids?.includes(referenced.id)
+    );
+    expect(referenceRequests).toHaveLength(2);
+    expect(referenceRequests.every((request) =>
+      request.filters[0]?.kinds?.join(",") === "1,1068" &&
+      request.filters[0]?.limit === 1
+    )).toBe(true);
+    expect(session.summary(workflow)).toMatchObject({
+      openedConnections: 6,
+      closedConnections: 6,
+      requests: 10,
+      closes: 10,
+      eose: 10,
+      returnedEvents: 8,
+      relayFanout: 2,
     });
   });
 });

--- a/src/nostr/testing/global-feed-transcript.test.ts
+++ b/src/nostr/testing/global-feed-transcript.test.ts
@@ -5,7 +5,10 @@ import {
 } from "nostr-tools";
 import { WebSocket } from "ws";
 import { ensureRelaysConnected } from "../client";
-import { subGlobalFeed } from "../subscriptions/global-feed";
+import {
+  subGlobalFeed,
+  subRepliesForRootIds,
+} from "../subscriptions/global-feed";
 import {
   auditSampleCount,
   emitAuditMeasurement,
@@ -122,9 +125,16 @@ describe("global feed relay transcript", () => {
       const requests = entries.filter((entry) => entry.type === "request");
       const since = requests[0]?.filters[0]?.since;
       expect(typeof since).toBe("number");
+      expect(requests.every((request) => request.filters.every((filter) =>
+        filter.kinds?.includes(1) ? filter.since === since : true
+      ))).toBe(true);
       const filterCounts = new Map<string, number>();
       requests.forEach((request) => {
-        const filters = request.filters.map(({ since: _since, ...filter }) => filter);
+        const filters = request.filters.map((filter) => {
+          const withoutSince = { ...filter };
+          delete withoutSince.since;
+          return withoutSince;
+        });
         const key = JSON.stringify(filters);
         filterCounts.set(key, (filterCounts.get(key) ?? 0) + 1);
       });
@@ -158,6 +168,204 @@ describe("global feed relay transcript", () => {
           .filter((entry) => entry.type === "close")
           .map((entry) => entry.lifetimeMs),
       },
+    });
+  });
+
+  it("captures missing-root chunking and a distinct NIP-10 relay hint", async () => {
+    const session = new RelayTranscriptSession();
+    let activityEvents: ReturnType<typeof finalizeEvent>[] = [];
+    let rootEvents: ReturnType<typeof finalizeEvent>[] = [];
+    const activityDriver = (request: RelayRequestController) => {
+      const [filter] = request.filters;
+      if (filter?.kinds?.includes(1) && !filter.ids && !filter["#e"]) {
+        activityEvents.forEach((event) => request.sendEvent(event));
+      }
+      request.sendEose();
+    };
+    const rootDriver = (request: RelayRequestController) => {
+      const ids = request.filters[0]?.ids ?? [];
+      rootEvents
+        .filter((event) => ids.includes(event.id))
+        .forEach((event) => request.sendEvent(event));
+      request.sendEose();
+    };
+    const activityRelays = [
+      await RelayTranscriptHarness.listen({ session, onRequest: activityDriver }),
+      await RelayTranscriptHarness.listen({ session, onRequest: activityDriver }),
+    ];
+    const hintedRelay = await RelayTranscriptHarness.listen({
+      session,
+      onRequest: rootDriver,
+    });
+    harnesses.push(...activityRelays, hintedRelay);
+
+    rootEvents = Array.from({ length: 21 }, (_, index) => finalizeEvent({
+      created_at: rootEvent.created_at + index,
+      kind: 1,
+      tags: [],
+      content: `hinted root ${index}`,
+    }, new Uint8Array(32).fill(index + 10)));
+    activityEvents = rootEvents.map((root, index) => finalizeEvent({
+      created_at: root.created_at + 100,
+      kind: 1,
+      tags: [["e", root.id, hintedRelay.url, "root"]],
+      content: `activity reply ${index}`,
+    }, new Uint8Array(32).fill(index + 40)));
+
+    const activityRelayUrls = activityRelays.map((relay) => relay.url);
+    await ensureRelaysConnected([...activityRelayUrls, hintedRelay.url]);
+    const workflow = session.beginWorkflow("global-feed-missing-roots-hint-chunk");
+    const receivedIds = new Set<string>();
+    const handle = subGlobalFeed((event) => receivedIds.add(event.id), 24, {
+      rootRelayUrls: activityRelayUrls,
+      replyRelayUrls: activityRelayUrls,
+      replyDepth: 1,
+    });
+
+    const expectedIds = [...activityEvents, ...rootEvents].map((event) => event.id);
+    await session.waitFor(() => expectedIds.every((id) => receivedIds.has(id)));
+    await session.waitFor(
+      (entries) => entries.filter((entry) => entry.type === "close").length === 50,
+    );
+    handle.close();
+    workflow.complete();
+
+    expect([...receivedIds].sort()).toEqual(expectedIds.sort());
+    const entries = session.entries.slice(workflow.startIndex, workflow.completedIndex);
+    const requests = entries.filter((entry) => entry.type === "request");
+    const rootRequests = requests.filter((request) => request.filters[0]?.ids);
+    expect(rootRequests).toHaveLength(6);
+    expect(rootRequests.filter((request) => request.relayUrl === hintedRelay.url)
+      .map((request) => request.filters[0]?.ids?.length)).toEqual([20, 1]);
+    expect(new Set(rootRequests.flatMap((request) => request.filters[0]?.ids ?? [])))
+      .toEqual(new Set(rootEvents.map((event) => event.id)));
+    expect(session.summary(workflow)).toMatchObject({
+      openedConnections: 0,
+      requests: 50,
+      closes: 50,
+      eose: 50,
+      returnedEvents: 63,
+      relayFanout: 3,
+    });
+  });
+
+  it("retains exact recursive output when a peer relay disconnects", async () => {
+    const session = new RelayTranscriptSession();
+    const healthyRelay = await RelayTranscriptHarness.listen({
+      session,
+      onRequest(request) {
+        const [filter] = request.filters;
+        if (filter?.["#e"]?.includes(replyEvent.id)) {
+          request.sendEvent(nestedReplyEvent, 5);
+        } else if (filter?.["#e"]?.includes(rootEvent.id)) {
+          request.sendEvent(replyEvent, 5);
+        } else {
+          request.sendEvent(rootEvent, 5);
+        }
+        request.sendEose(5);
+      },
+    });
+    const disconnectedRelay = await RelayTranscriptHarness.listen({
+      session,
+      onRequest(request) {
+        request.closeConnection(1);
+      },
+    });
+    harnesses.push(healthyRelay, disconnectedRelay);
+    const relayUrls = [healthyRelay.url, disconnectedRelay.url];
+    await ensureRelaysConnected(relayUrls);
+
+    const workflow = session.beginWorkflow("global-feed-partial-relay-disconnect");
+    const receivedIds = new Set<string>();
+    const handle = subGlobalFeed((event) => receivedIds.add(event.id), 24, {
+      rootRelayUrls: relayUrls,
+      replyRelayUrls: relayUrls,
+      replyDepth: 2,
+    });
+    await session.waitFor(() => receivedIds.has(nestedReplyEvent.id), 7_000);
+    await session.waitFor((entries) =>
+      entries.filter((entry) => entry.type === "close").length === 3
+    , 7_000);
+    handle.close();
+    workflow.complete();
+
+    expect([...receivedIds].sort()).toEqual(
+      [rootEvent.id, replyEvent.id, nestedReplyEvent.id].sort(),
+    );
+    const summary = session.summary(workflow);
+    expect(summary).toMatchObject({
+      requests: 4,
+      closes: 3,
+      returnedEvents: 3,
+      eose: 3,
+      relayFanout: 2,
+    });
+    emitAuditMeasurement({
+      scenario: "wired-browser-global-feed-partial-disconnect-after-fix",
+      samples: 1,
+      completionLatencyMs: summary.completionLatencyMs,
+    });
+  });
+
+  it("captures slow bootstrap reply traversal overlapping live traversal", async () => {
+    const session = new RelayTranscriptSession();
+    const relayDriver = (request: RelayRequestController) => {
+      const [filter] = request.filters;
+      if (filter?.["#e"]?.includes(replyEvent.id)) {
+        request.sendEvent(nestedReplyEvent, 15);
+      } else if (filter?.["#e"]?.includes(rootEvent.id)) {
+        request.sendEvent(replyEvent, 15);
+      }
+      request.sendEose(20);
+    };
+    const runHarnesses = [
+      await RelayTranscriptHarness.listen({ session, onRequest: relayDriver }),
+      await RelayTranscriptHarness.listen({ session, onRequest: relayDriver }),
+    ];
+    harnesses.push(...runHarnesses);
+    const relayUrls = runHarnesses.map((harness) => harness.url);
+    await ensureRelaysConnected(relayUrls);
+
+    const workflow = session.beginWorkflow("bootstrap-live-reply-overlap");
+    const liveIds = new Set<string>();
+    const bootstrapIds = new Set<string>();
+    const live = subRepliesForRootIds(
+      [rootEvent.id],
+      (event) => liveIds.add(event.id),
+      { relayUrls, depth: 2 },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const bootstrap = subRepliesForRootIds(
+      [rootEvent.id],
+      (event) => bootstrapIds.add(event.id),
+      { relayUrls, depth: 2 },
+    );
+    await session.waitFor(() =>
+      liveIds.has(nestedReplyEvent.id) && bootstrapIds.has(nestedReplyEvent.id)
+    );
+    await session.waitFor((entries) =>
+      entries.filter((entry) => entry.type === "close").length === 8
+    );
+    live.close();
+    bootstrap.close();
+    workflow.complete();
+
+    const expectedIds = [replyEvent.id, nestedReplyEvent.id].sort();
+    expect([...liveIds].sort()).toEqual(expectedIds);
+    expect([...bootstrapIds].sort()).toEqual(expectedIds);
+    const summary = session.summary(workflow);
+    expect(summary).toMatchObject({
+      requests: 8,
+      closes: 8,
+      eose: 8,
+      returnedEvents: 8,
+      repeatedOperations: 6,
+      relayFanout: 2,
+    });
+    emitAuditMeasurement({
+      scenario: "wired-browser-bootstrap-live-reply-overlap-local-fixture",
+      samples: 1,
+      completionLatencyMs: summary.completionLatencyMs,
     });
   });
 });

--- a/src/nostr/testing/global-feed-transcript.test.ts
+++ b/src/nostr/testing/global-feed-transcript.test.ts
@@ -7,8 +7,15 @@ import { WebSocket } from "ws";
 import { ensureRelaysConnected } from "../client";
 import { subGlobalFeed } from "../subscriptions/global-feed";
 import {
+  auditSampleCount,
+  emitAuditMeasurement,
+  summarizeSamples,
+} from "./audit-metrics";
+import {
   RelayTranscriptHarness,
+  RelayTranscriptSession,
   type RelayRequestController,
+  type RelayTranscriptEntry,
 } from "./relay-transcript";
 
 configureWebSocketImplementation(WebSocket);
@@ -20,117 +27,137 @@ const rootEvent = finalizeEvent({
   tags: [],
   content: "root",
 }, secretKey);
-
 const replyEvent = finalizeEvent({
-  created_at: rootEvent.created_at,
+  created_at: rootEvent.created_at + 1,
   kind: 1,
   tags: [["e", rootEvent.id, "", "reply"]],
   content: "reply",
 }, secretKey);
+const nestedReplyEvent = finalizeEvent({
+  created_at: replyEvent.created_at + 1,
+  kind: 1,
+  tags: [["e", replyEvent.id, "", "reply"]],
+  content: "nested reply",
+}, secretKey);
+
+function driveFeed(request: RelayRequestController): void {
+  const [filter] = request.filters;
+  if (filter?.["#e"]?.includes(replyEvent.id)) {
+    request.sendEvent(nestedReplyEvent);
+  } else if (filter?.["#e"]?.includes(rootEvent.id)) {
+    request.sendEvent(replyEvent);
+  } else {
+    request.sendEvent(rootEvent);
+  }
+  request.sendEose();
+}
+
+function matchingIds(entries: readonly RelayTranscriptEntry[], type: "eose" | "close") {
+  return entries
+    .flatMap((entry) => entry.type === type ? [entry.subscriptionId] : [])
+    .sort();
+}
 
 describe("global feed relay transcript", () => {
-  let harness: RelayTranscriptHarness | undefined;
+  const harnesses: RelayTranscriptHarness[] = [];
 
   afterEach(async () => {
-    await harness?.close();
-    harness = undefined;
+    await Promise.all(harnesses.splice(0).map((harness) => harness.close()));
   });
 
-  it("captures complete workflow output and finite relay work", async () => {
-    harness = await RelayTranscriptHarness.listen({
-      onRequest(request: RelayRequestController) {
-        const [filter] = request.filters;
-        if (filter?.["#e"]?.includes(rootEvent.id)) {
-          request.sendEvent(replyEvent);
-        } else {
-          request.sendEvent(rootEvent);
+  it("captures cold recursive feed output, duplicate relays, and cleanup", async () => {
+    const initialContentLatencies: number[] = [];
+    const completionLatencies: number[] = [];
+    let evidenceEntries: readonly RelayTranscriptEntry[] = [];
+
+    for (let run = 0; run < auditSampleCount(); run += 1) {
+      const session = new RelayTranscriptSession();
+      const runHarnesses = [
+        await RelayTranscriptHarness.listen({ session, onRequest: driveFeed }),
+        await RelayTranscriptHarness.listen({ session, onRequest: driveFeed }),
+      ];
+      harnesses.push(...runHarnesses);
+      const relayUrls = runHarnesses.map((harness) => harness.url);
+      const workflow = session.beginWorkflow(`global-feed-${run + 1}`);
+      const receivedIds = new Set<string>();
+      let initialContentLatencyMs: number | undefined;
+
+      await ensureRelaysConnected(relayUrls);
+      const handle = subGlobalFeed((event) => {
+        if (event.id === rootEvent.id && initialContentLatencyMs === undefined) {
+          initialContentLatencyMs = Date.now() - workflow.startedAt;
         }
-        request.sendEose();
+        receivedIds.add(event.id);
+      }, 24, {
+        rootRelayUrls: relayUrls,
+        replyRelayUrls: relayUrls,
+        replyDepth: 2,
+      });
+
+      await session.waitFor(() => receivedIds.has(nestedReplyEvent.id));
+      await session.waitFor(
+        (entries) => entries.filter((entry) => entry.type === "close").length === 6,
+      );
+      handle.close();
+      workflow.complete();
+
+      expect([...receivedIds].sort()).toEqual(
+        [rootEvent.id, replyEvent.id, nestedReplyEvent.id].sort(),
+      );
+      const summary = session.summary(workflow);
+      expect(summary).toMatchObject({
+        openedConnections: 2,
+        connectionReuseCount: 4,
+        requests: 6,
+        closes: 6,
+        returnedEvents: 6,
+        eose: 6,
+        repeatedOperations: 3,
+        relayFanout: 2,
+      });
+      const entries = session.entries.slice(
+        workflow.startIndex,
+        workflow.completedIndex,
+      );
+      const requests = entries.filter((entry) => entry.type === "request");
+      const since = requests[0]?.filters[0]?.since;
+      expect(typeof since).toBe("number");
+      const filterCounts = new Map<string, number>();
+      requests.forEach((request) => {
+        const filters = request.filters.map(({ since: _since, ...filter }) => filter);
+        const key = JSON.stringify(filters);
+        filterCounts.set(key, (filterCounts.get(key) ?? 0) + 1);
+      });
+      expect(filterCounts).toEqual(new Map([
+        [JSON.stringify([{ kinds: [1], limit: 500 }]), 2],
+        [JSON.stringify([{ "#e": [rootEvent.id], kinds: [1], limit: 100 }]), 2],
+        [JSON.stringify([{ "#e": [replyEvent.id], kinds: [1], limit: 100 }]), 2],
+      ]));
+      const requestIds = requests.map((entry) => entry.subscriptionId).sort();
+      expect(matchingIds(entries, "eose")).toEqual(requestIds);
+      expect(matchingIds(entries, "close")).toEqual(requestIds);
+
+      initialContentLatencies.push(initialContentLatencyMs ?? summary.completionLatencyMs);
+      completionLatencies.push(summary.completionLatencyMs);
+      evidenceEntries = entries;
+    }
+
+    emitAuditMeasurement({
+      scenario: "wired-browser-global-feed-cold-local-fixture",
+      samples: completionLatencies.length,
+      initialContentLatencyMs: summarizeSamples(initialContentLatencies),
+      completionLatencyMs: summarizeSamples(completionLatencies),
+      evidence: {
+        requestBytes: evidenceEntries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.bytes),
+        returnedEventBytes: evidenceEntries
+          .filter((entry) => entry.type === "event-returned")
+          .map((entry) => entry.bytes),
+        subscriptionLifetimesMs: evidenceEntries
+          .filter((entry) => entry.type === "close")
+          .map((entry) => entry.lifetimeMs),
       },
     });
-
-    const workflow = harness.beginWorkflow("global-feed");
-    await ensureRelaysConnected([harness.url]);
-    const receivedIds: string[] = [];
-    const handle = subGlobalFeed(
-      (event) => receivedIds.push(event.id),
-      24,
-      {
-        rootRelayUrls: [harness.url],
-        replyRelayUrls: [harness.url],
-        replyDepth: 1,
-      },
-    );
-
-    await harness.waitFor(
-      (entries) => entries.filter((entry) => entry.type === "close").length === 2,
-    );
-    handle.close();
-    workflow.complete();
-
-    expect(receivedIds).toEqual([rootEvent.id, replyEvent.id]);
-    expect(harness.summary(workflow)).toMatchObject({
-      openedConnections: 1,
-      connectionReuseCount: 1,
-      requests: 2,
-      closes: 2,
-      returnedEvents: 2,
-      eose: 2,
-      publishes: 0,
-      acknowledgements: 0,
-      rejections: 0,
-      retries: 0,
-      repeatedOperations: 0,
-      relayFanout: 1,
-    });
-    const summary = harness.summary(workflow);
-    expect(summary.returnedEventBytes).toBeGreaterThan(0);
-    expect(summary.subscriptionLifetimesMs).toHaveLength(2);
-    expect(summary.completionLatencyMs).toBeGreaterThanOrEqual(0);
-
-    const entries = harness.entries.slice(
-      workflow.startIndex,
-      workflow.completedIndex,
-    );
-    const requests = entries.filter((entry) => entry.type === "request");
-    expect(requests).toHaveLength(2);
-    expect(requests[0]?.filters).toEqual([
-      { kinds: [1], since: expect.any(Number), limit: 500 },
-    ]);
-    expect(requests[1]?.filters).toEqual([
-      {
-        "#e": [rootEvent.id],
-        kinds: [1],
-        since: expect.any(Number),
-        limit: 100,
-      },
-    ]);
-    expect(requests[1]?.filters[0]?.since).toBe(
-      requests[0]?.filters[0]?.since,
-    );
-    expect(requests.every((request) => request.bytes > 0)).toBe(true);
-
-    const returnedEvents = entries.filter(
-      (entry) => entry.type === "event-returned",
-    );
-    expect(returnedEvents.map((entry) => entry.eventId)).toEqual([
-      rootEvent.id,
-      replyEvent.id,
-    ]);
-    expect(returnedEvents.every((entry) => entry.bytes > 0)).toBe(true);
-
-    const requestIds = requests.map((request) => request.subscriptionId).sort();
-    expect(
-      entries
-        .filter((entry) => entry.type === "eose")
-        .map((entry) => entry.subscriptionId)
-        .sort(),
-    ).toEqual(requestIds);
-    expect(
-      entries
-        .filter((entry) => entry.type === "close")
-        .map((entry) => entry.subscriptionId)
-        .sort(),
-    ).toEqual(requestIds);
   });
 });

--- a/src/nostr/testing/global-feed-transcript.test.ts
+++ b/src/nostr/testing/global-feed-transcript.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  finalizeEvent,
+  useWebSocketImplementation as configureWebSocketImplementation,
+} from "nostr-tools";
+import { WebSocket } from "ws";
+import { ensureRelaysConnected } from "../client";
+import { subGlobalFeed } from "../subscriptions/global-feed";
+import {
+  RelayTranscriptHarness,
+  type RelayRequestController,
+} from "./relay-transcript";
+
+configureWebSocketImplementation(WebSocket);
+
+const secretKey = new Uint8Array(32).fill(1);
+const rootEvent = finalizeEvent({
+  created_at: Math.floor(Date.now() / 1000),
+  kind: 1,
+  tags: [],
+  content: "root",
+}, secretKey);
+
+const replyEvent = finalizeEvent({
+  created_at: rootEvent.created_at,
+  kind: 1,
+  tags: [["e", rootEvent.id, "", "reply"]],
+  content: "reply",
+}, secretKey);
+
+describe("global feed relay transcript", () => {
+  let harness: RelayTranscriptHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.close();
+    harness = undefined;
+  });
+
+  it("captures complete workflow output and finite relay work", async () => {
+    harness = await RelayTranscriptHarness.listen({
+      onRequest(request: RelayRequestController) {
+        const [filter] = request.filters;
+        if (filter?.["#e"]?.includes(rootEvent.id)) {
+          request.sendEvent(replyEvent);
+        } else {
+          request.sendEvent(rootEvent);
+        }
+        request.sendEose();
+      },
+    });
+
+    const workflow = harness.beginWorkflow("global-feed");
+    await ensureRelaysConnected([harness.url]);
+    const receivedIds: string[] = [];
+    const handle = subGlobalFeed(
+      (event) => receivedIds.push(event.id),
+      24,
+      {
+        rootRelayUrls: [harness.url],
+        replyRelayUrls: [harness.url],
+        replyDepth: 1,
+      },
+    );
+
+    await harness.waitFor(
+      (entries) => entries.filter((entry) => entry.type === "close").length === 2,
+    );
+    handle.close();
+    workflow.complete();
+
+    expect(receivedIds).toEqual([rootEvent.id, replyEvent.id]);
+    expect(harness.summary(workflow)).toMatchObject({
+      openedConnections: 1,
+      connectionReuseCount: 1,
+      requests: 2,
+      closes: 2,
+      returnedEvents: 2,
+      eose: 2,
+      publishes: 0,
+      acknowledgements: 0,
+      rejections: 0,
+      retries: 0,
+      relayFanout: 1,
+    });
+    expect(harness.summary(workflow).returnedEventBytes).toBeGreaterThan(0);
+    expect(harness.summary(workflow).completionLatencyMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/nostr/testing/global-feed-transcript.test.ts
+++ b/src/nostr/testing/global-feed-transcript.test.ts
@@ -15,7 +15,7 @@ configureWebSocketImplementation(WebSocket);
 
 const secretKey = new Uint8Array(32).fill(1);
 const rootEvent = finalizeEvent({
-  created_at: Math.floor(Date.now() / 1000),
+  created_at: 2_000_000_000,
   kind: 1,
   tags: [],
   content: "root",
@@ -80,9 +80,57 @@ describe("global feed relay transcript", () => {
       acknowledgements: 0,
       rejections: 0,
       retries: 0,
+      repeatedOperations: 0,
       relayFanout: 1,
     });
-    expect(harness.summary(workflow).returnedEventBytes).toBeGreaterThan(0);
-    expect(harness.summary(workflow).completionLatencyMs).toBeGreaterThanOrEqual(0);
+    const summary = harness.summary(workflow);
+    expect(summary.returnedEventBytes).toBeGreaterThan(0);
+    expect(summary.subscriptionLifetimesMs).toHaveLength(2);
+    expect(summary.completionLatencyMs).toBeGreaterThanOrEqual(0);
+
+    const entries = harness.entries.slice(
+      workflow.startIndex,
+      workflow.completedIndex,
+    );
+    const requests = entries.filter((entry) => entry.type === "request");
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.filters).toEqual([
+      { kinds: [1], since: expect.any(Number), limit: 500 },
+    ]);
+    expect(requests[1]?.filters).toEqual([
+      {
+        "#e": [rootEvent.id],
+        kinds: [1],
+        since: expect.any(Number),
+        limit: 100,
+      },
+    ]);
+    expect(requests[1]?.filters[0]?.since).toBe(
+      requests[0]?.filters[0]?.since,
+    );
+    expect(requests.every((request) => request.bytes > 0)).toBe(true);
+
+    const returnedEvents = entries.filter(
+      (entry) => entry.type === "event-returned",
+    );
+    expect(returnedEvents.map((entry) => entry.eventId)).toEqual([
+      rootEvent.id,
+      replyEvent.id,
+    ]);
+    expect(returnedEvents.every((entry) => entry.bytes > 0)).toBe(true);
+
+    const requestIds = requests.map((request) => request.subscriptionId).sort();
+    expect(
+      entries
+        .filter((entry) => entry.type === "eose")
+        .map((entry) => entry.subscriptionId)
+        .sort(),
+    ).toEqual(requestIds);
+    expect(
+      entries
+        .filter((entry) => entry.type === "close")
+        .map((entry) => entry.subscriptionId)
+        .sort(),
+    ).toEqual(requestIds);
   });
 });

--- a/src/nostr/testing/notification-enrichment-transcript.test.ts
+++ b/src/nostr/testing/notification-enrichment-transcript.test.ts
@@ -54,7 +54,9 @@ function driveNotifications(request: RelayRequestController, delayMs = 0): void 
   const [filter] = request.filters;
   if (filter?.authors) {
     request.sendEvent(localAuthored, delayMs);
-    request.sendEvent(authoredReaction, delayMs);
+    if (filter.kinds?.includes(7)) {
+      request.sendEvent(authoredReaction, delayMs);
+    }
   } else if (filter?.["#p"]) {
     request.sendEvent(localAuthored, delayMs);
     request.sendEvent(taggedMention, delayMs);
@@ -141,7 +143,7 @@ describe("notification and enrichment relay transcripts", () => {
       workflow.complete();
 
       expect([...receivedIds].sort()).toEqual(
-        [localAuthored.id, authoredReaction.id, taggedMention.id].sort(),
+        [localAuthored.id, taggedMention.id].sort(),
       );
       const summary = session.summary(workflow);
       expect(summary).toMatchObject({
@@ -149,7 +151,7 @@ describe("notification and enrichment relay transcripts", () => {
         requests: 4,
         closes: 4,
         eose: 4,
-        returnedEvents: 8,
+        returnedEvents: 6,
         repeatedOperations: 2,
         relayFanout: 2,
       });
@@ -163,7 +165,7 @@ describe("notification and enrichment relay transcripts", () => {
       ]))).toEqual(new Map([
         [JSON.stringify([{
           authors: [localAuthored.pubkey],
-          kinds: [1, 7],
+          kinds: [1],
           limit: 25,
         }]), 2],
         [JSON.stringify([{
@@ -226,11 +228,11 @@ describe("notification and enrichment relay transcripts", () => {
     handle.close();
     workflow.complete();
     expect([...receivedIds].sort()).toEqual(
-      [localAuthored.id, authoredReaction.id, taggedMention.id].sort(),
+      [localAuthored.id, taggedMention.id].sort(),
     );
     expect(session.summary(workflow)).toMatchObject({
       requests: 4,
-      returnedEvents: 4,
+      returnedEvents: 3,
       eose: 2,
       relayFanout: 2,
     });
@@ -460,26 +462,25 @@ describe("notification and enrichment relay transcripts", () => {
       );
       await session.waitFor(() => completedIds.size === 2);
       await session.waitFor((entries) =>
-        entries.filter((entry) => entry.type === "close").length === (run + 1) * 6
+        entries.filter((entry) => entry.type === "close").length === (run + 1) * 5
       );
       handle.close();
       workflow.complete();
 
       expect(receivedIds).toEqual(new Set([fallbackQuote.id, hintedQuote.id]));
       expect(session.summary(workflow)).toMatchObject({
-        requests: 6,
-        closes: 6,
-        eose: 6,
-        returnedEvents: 4,
-        repeatedOperations: 4,
+        requests: 5,
+        closes: 5,
+        eose: 5,
+        returnedEvents: 3,
+        repeatedOperations: 3,
         relayFanout: 3,
       });
       const entries = workflowEntries(session, workflow);
       const hintedRequests = entries
         .filter((entry) => entry.type === "request")
         .filter((entry) => entry.relayUrl === hintedRelay.url);
-      expect(hintedRequests).toHaveLength(2);
-      expect(hintedRequests[0]?.filters).toEqual(hintedRequests[1]?.filters);
+      expect(hintedRequests).toHaveLength(1);
       expectExactQuoteFilters(entries);
       expectExactFiniteCompletion(entries);
       completionLatencies.push(session.summary(workflow).completionLatencyMs);

--- a/src/nostr/testing/notification-enrichment-transcript.test.ts
+++ b/src/nostr/testing/notification-enrichment-transcript.test.ts
@@ -69,6 +69,32 @@ function workflowEntries(
   return session.entries.slice(workflow.startIndex, workflow.completedIndex);
 }
 
+function expectExactFiniteCompletion(entries: readonly RelayTranscriptEntry[]): void {
+  const requestIds = entries
+    .flatMap((entry) => entry.type === "request" ? [entry.subscriptionId] : [])
+    .sort();
+  const idsFor = (type: "eose" | "close") => entries
+    .flatMap((entry) => entry.type === type ? [entry.subscriptionId] : [])
+    .sort();
+
+  expect(idsFor("eose")).toEqual(requestIds);
+  expect(idsFor("close")).toEqual(requestIds);
+}
+
+function expectExactQuoteFilters(entries: readonly RelayTranscriptEntry[]): void {
+  entries
+    .filter((entry) => entry.type === "request")
+    .forEach((request) => {
+      const ids = request.filters[0]?.ids;
+      expect(ids).toHaveLength(1);
+      expect(request.filters).toEqual([{
+        ids,
+        kinds: [1, 1068],
+        limit: 1,
+      }]);
+    });
+}
+
 describe("notification and enrichment relay transcripts", () => {
   const harnesses: RelayTranscriptHarness[] = [];
 
@@ -146,6 +172,7 @@ describe("notification and enrichment relay transcripts", () => {
           limit: 50,
         }]), 2],
       ]));
+      expectExactFiniteCompletion(workflowEntries(session, workflow));
       completionLatencies.push(summary.completionLatencyMs);
       evidenceEntries = workflowEntries(session, workflow);
     }
@@ -229,49 +256,74 @@ describe("notification and enrichment relay transcripts", () => {
     const newerRelay = await listen("newer", 2_000_000_020);
     harnesses.push(olderRelay, newerRelay);
     const relayUrls = [olderRelay.url, newerRelay.url];
-    const workflow = session.beginWorkflow("profiles-batched-newest-inputs");
-    const profiles = new Map<string, { name: string; createdAt: number }>();
-    let completed = false;
-    const handle = await subProfilesOnce(
-      [localAuthored.pubkey, taggedMention.pubkey],
-      (event) => {
-        const name = (JSON.parse(event.content) as { name: string }).name;
-        const existing = profiles.get(event.pubkey);
-        if (!existing || existing.createdAt < event.created_at) {
-          profiles.set(event.pubkey, { name, createdAt: event.created_at });
-        }
-      },
-      () => {
-        completed = true;
-      },
-      { relayUrls },
-    );
-    await session.waitFor(() => completed);
-    await session.waitFor((entries) =>
-      entries.filter((entry) => entry.type === "close").length === 2
-    );
-    handle.close();
-    workflow.complete();
+    const completionLatencies: number[] = [];
+    let evidenceEntries: readonly RelayTranscriptEntry[] = [];
+    for (let run = 0; run < auditSampleCount(); run += 1) {
+      const workflow = session.beginWorkflow(`profiles-batched-${run + 1}`);
+      const profiles = new Map<string, { name: string; createdAt: number }>();
+      let completed = false;
+      const handle = await subProfilesOnce(
+        [localAuthored.pubkey, taggedMention.pubkey],
+        (event) => {
+          const name = (JSON.parse(event.content) as { name: string }).name;
+          const existing = profiles.get(event.pubkey);
+          if (!existing || existing.createdAt < event.created_at) {
+            profiles.set(event.pubkey, { name, createdAt: event.created_at });
+          }
+        },
+        () => {
+          completed = true;
+        },
+        { relayUrls },
+      );
+      await session.waitFor(() => completed);
+      await session.waitFor((entries) =>
+        entries.filter((entry) => entry.type === "close").length === (run + 1) * 2
+      );
+      handle.close();
+      workflow.complete();
 
-    expect([...profiles.values()].map((profile) => profile.name).sort()).toEqual([
-      "newer-0",
-      "newer-1",
-    ]);
-    expect(session.summary(workflow)).toMatchObject({
-      openedConnections: 2,
-      requests: 2,
-      closes: 2,
-      eose: 2,
-      returnedEvents: 4,
-      relayFanout: 2,
+      expect([...profiles.values()].map((profile) => profile.name).sort()).toEqual([
+        "newer-0",
+        "newer-1",
+      ]);
+      expect(session.summary(workflow)).toMatchObject({
+        requests: 2,
+        closes: 2,
+        eose: 2,
+        returnedEvents: 4,
+        relayFanout: 2,
+      });
+      const entries = workflowEntries(session, workflow);
+      const requests = entries.filter((entry) => entry.type === "request");
+      expect(requests.every((request) =>
+        JSON.stringify(request.filters) === JSON.stringify([{
+          authors: [localAuthored.pubkey, taggedMention.pubkey],
+          kinds: [0],
+          limit: 2,
+        }])
+      )).toBe(true);
+      expectExactFiniteCompletion(entries);
+      completionLatencies.push(session.summary(workflow).completionLatencyMs);
+      evidenceEntries = entries;
+    }
+
+    emitAuditMeasurement({
+      scenario: "wired-browser-profiles-local-fixture",
+      samples: completionLatencies.length,
+      completionLatencyMs: summarizeSamples(completionLatencies),
+      evidence: {
+        requestBytes: evidenceEntries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.bytes),
+        returnedEventBytes: evidenceEntries
+          .filter((entry) => entry.type === "event-returned")
+          .map((entry) => entry.bytes),
+        subscriptionLifetimesMs: evidenceEntries
+          .filter((entry) => entry.type === "close")
+          .map((entry) => entry.lifetimeMs),
+      },
     });
-    const requests = workflowEntries(session, workflow)
-      .filter((entry) => entry.type === "request");
-    expect(requests.every((request) =>
-      request.filters[0]?.authors?.length === 2 &&
-      request.filters[0]?.kinds?.[0] === 0 &&
-      request.filters[0]?.limit === 2
-    )).toBe(true);
   });
 
   it("captures fallback quotes, a delayed extra hint, stale hints, and missing results", async () => {
@@ -343,6 +395,8 @@ describe("notification and enrichment relay transcripts", () => {
     });
     const requests = workflowEntries(session, workflow)
       .filter((entry) => entry.type === "request");
+    expectExactQuoteFilters(workflowEntries(session, workflow));
+    expectExactFiniteCompletion(workflowEntries(session, workflow));
     expect(requests.filter((request) =>
       request.filters[0]?.ids?.includes(hintedQuote.id)
     )).toHaveLength(3);
@@ -350,60 +404,103 @@ describe("notification and enrichment relay transcripts", () => {
       .toBe(false);
   });
 
-  it("records duplicate quote lookup when an extra hint is already connected", async () => {
+  it("measures fallback and preconnected-hint quote enrichment", async () => {
     const session = new RelayTranscriptSession();
-    const quoted = finalizeEvent({
+    const fallbackQuote = finalizeEvent({
       created_at: 2_000_000_040,
       kind: 1,
       tags: [],
-      content: "already-connected hint",
+      content: "normal fallback quote",
     }, new Uint8Array(32).fill(84));
-    const fallbackRelay = await RelayTranscriptHarness.listen({
-      session,
-      onRequest(request) {
-        request.sendEose();
-      },
-    });
+    const hintedQuote = finalizeEvent({
+      created_at: 2_000_000_041,
+      kind: 1068,
+      tags: [],
+      content: "already-connected hint",
+    }, new Uint8Array(32).fill(85));
+    const fallbackDriver = (request: RelayRequestController) => {
+      if (request.filters[0]?.ids?.includes(fallbackQuote.id)) {
+        request.sendEvent(fallbackQuote, 5);
+      }
+      request.sendEose(10);
+    };
+    const fallbackRelays = [
+      await RelayTranscriptHarness.listen({ session, onRequest: fallbackDriver }),
+      await RelayTranscriptHarness.listen({ session, onRequest: fallbackDriver }),
+    ];
     const hintedRelay = await RelayTranscriptHarness.listen({
       session,
       onRequest(request) {
-        request.sendEvent(quoted);
-        request.sendEose();
+        if (request.filters[0]?.ids?.includes(hintedQuote.id)) {
+          request.sendEvent(hintedQuote, 15);
+        }
+        request.sendEose(20);
       },
     });
-    harnesses.push(fallbackRelay, hintedRelay);
-    await ensureRelaysConnected([fallbackRelay.url, hintedRelay.url]);
-    const workflow = session.beginWorkflow("quote-preconnected-hint-duplicate");
-    const receivedIds = new Set<string>();
-    let completed = false;
-    const handle = await subQuotedEventsOnce(
-      [{ id: quoted.id, relays: [hintedRelay.url] }],
-      (event) => receivedIds.add(event.id),
-      () => {
-        completed = true;
-      },
-      { fallbackRelayUrls: [fallbackRelay.url] },
-    );
-    await session.waitFor(() => completed);
-    await session.waitFor((entries) =>
-      entries.filter((entry) => entry.type === "close").length === 3
-    );
-    handle.close();
-    workflow.complete();
+    harnesses.push(...fallbackRelays, hintedRelay);
+    await ensureRelaysConnected([
+      ...fallbackRelays.map((relay) => relay.url),
+      hintedRelay.url,
+    ]);
+    const completionLatencies: number[] = [];
+    let evidenceEntries: readonly RelayTranscriptEntry[] = [];
 
-    expect(receivedIds).toEqual(new Set([quoted.id]));
-    expect(session.summary(workflow)).toMatchObject({
-      requests: 3,
-      closes: 3,
-      eose: 3,
-      returnedEvents: 2,
-      repeatedOperations: 2,
-      relayFanout: 2,
+    for (let run = 0; run < auditSampleCount(); run += 1) {
+      const workflow = session.beginWorkflow(`quotes-normal-${run + 1}`);
+      const receivedIds = new Set<string>();
+      const completedIds = new Set<string>();
+      const handle = await subQuotedEventsOnce(
+        [
+          { id: fallbackQuote.id, relays: [] },
+          { id: hintedQuote.id, relays: [hintedRelay.url] },
+        ],
+        (event) => receivedIds.add(event.id),
+        (id) => completedIds.add(id),
+        { fallbackRelayUrls: fallbackRelays.map((relay) => relay.url) },
+      );
+      await session.waitFor(() => completedIds.size === 2);
+      await session.waitFor((entries) =>
+        entries.filter((entry) => entry.type === "close").length === (run + 1) * 6
+      );
+      handle.close();
+      workflow.complete();
+
+      expect(receivedIds).toEqual(new Set([fallbackQuote.id, hintedQuote.id]));
+      expect(session.summary(workflow)).toMatchObject({
+        requests: 6,
+        closes: 6,
+        eose: 6,
+        returnedEvents: 4,
+        repeatedOperations: 4,
+        relayFanout: 3,
+      });
+      const entries = workflowEntries(session, workflow);
+      const hintedRequests = entries
+        .filter((entry) => entry.type === "request")
+        .filter((entry) => entry.relayUrl === hintedRelay.url);
+      expect(hintedRequests).toHaveLength(2);
+      expect(hintedRequests[0]?.filters).toEqual(hintedRequests[1]?.filters);
+      expectExactQuoteFilters(entries);
+      expectExactFiniteCompletion(entries);
+      completionLatencies.push(session.summary(workflow).completionLatencyMs);
+      evidenceEntries = entries;
+    }
+
+    emitAuditMeasurement({
+      scenario: "wired-browser-quotes-local-fixture",
+      samples: completionLatencies.length,
+      completionLatencyMs: summarizeSamples(completionLatencies),
+      evidence: {
+        requestBytes: evidenceEntries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.bytes),
+        returnedEventBytes: evidenceEntries
+          .filter((entry) => entry.type === "event-returned")
+          .map((entry) => entry.bytes),
+        subscriptionLifetimesMs: evidenceEntries
+          .filter((entry) => entry.type === "close")
+          .map((entry) => entry.lifetimeMs),
+      },
     });
-    const hintedRequests = workflowEntries(session, workflow)
-      .filter((entry) => entry.type === "request")
-      .filter((entry) => entry.relayUrl === hintedRelay.url);
-    expect(hintedRequests).toHaveLength(2);
-    expect(hintedRequests[0]?.filters).toEqual(hintedRequests[1]?.filters);
   });
 });

--- a/src/nostr/testing/notification-enrichment-transcript.test.ts
+++ b/src/nostr/testing/notification-enrichment-transcript.test.ts
@@ -1,0 +1,409 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  finalizeEvent,
+  useWebSocketImplementation as configureWebSocketImplementation,
+} from "nostr-tools";
+import { WebSocket } from "ws";
+import { ensureRelaysConnected } from "../client";
+import {
+  subNotifications,
+  subProfilesOnce,
+  subQuotedEventsOnce,
+} from "../subscriptions";
+import {
+  auditSampleCount,
+  emitAuditMeasurement,
+  summarizeSamples,
+} from "./audit-metrics";
+import {
+  RelayTranscriptHarness,
+  RelayTranscriptSession,
+  type RelayRequestController,
+  type RelayTranscriptEntry,
+} from "./relay-transcript";
+
+configureWebSocketImplementation(WebSocket);
+
+const localPubkeyKey = new Uint8Array(32).fill(80);
+const otherKey = new Uint8Array(32).fill(81);
+const localAuthored = finalizeEvent({
+  created_at: 2_000_000_000,
+  kind: 1,
+  tags: [["p", finalizeEvent({
+    created_at: 1,
+    kind: 1,
+    tags: [],
+    content: "pubkey seed",
+  }, localPubkeyKey).pubkey]],
+  content: "authored and tagged",
+}, localPubkeyKey);
+const authoredReaction = finalizeEvent({
+  created_at: 2_000_000_001,
+  kind: 7,
+  tags: [["e", localAuthored.id]],
+  content: "+",
+}, localPubkeyKey);
+const taggedMention = finalizeEvent({
+  created_at: 2_000_000_002,
+  kind: 1,
+  tags: [["p", localAuthored.pubkey]],
+  content: "mention",
+}, otherKey);
+
+function driveNotifications(request: RelayRequestController, delayMs = 0): void {
+  const [filter] = request.filters;
+  if (filter?.authors) {
+    request.sendEvent(localAuthored, delayMs);
+    request.sendEvent(authoredReaction, delayMs);
+  } else if (filter?.["#p"]) {
+    request.sendEvent(localAuthored, delayMs);
+    request.sendEvent(taggedMention, delayMs);
+  }
+  request.sendEose(delayMs);
+}
+
+function workflowEntries(
+  session: RelayTranscriptSession,
+  workflow: { startIndex: number; completedIndex?: number },
+): readonly RelayTranscriptEntry[] {
+  return session.entries.slice(workflow.startIndex, workflow.completedIndex);
+}
+
+describe("notification and enrichment relay transcripts", () => {
+  const harnesses: RelayTranscriptHarness[] = [];
+
+  afterEach(async () => {
+    await Promise.all(harnesses.splice(0).map((harness) => harness.close()));
+  });
+
+  it("captures authored/tagged notification duplicates and finite completion", async () => {
+    const completionLatencies: number[] = [];
+    let evidenceEntries: readonly RelayTranscriptEntry[] = [];
+
+    for (let run = 0; run < auditSampleCount(); run += 1) {
+      const session = new RelayTranscriptSession();
+      const runHarnesses = [
+        await RelayTranscriptHarness.listen({
+          session,
+          onRequest: (request) => driveNotifications(request, 5),
+        }),
+        await RelayTranscriptHarness.listen({
+          session,
+          onRequest: (request) => driveNotifications(request, 5),
+        }),
+      ];
+      harnesses.push(...runHarnesses);
+      const relayUrls = runHarnesses.map((harness) => harness.url);
+      await ensureRelaysConnected(relayUrls);
+      const workflow = session.beginWorkflow(`notifications-${run + 1}`);
+      const receivedIds = new Set<string>();
+      let completed = false;
+      const handle = subNotifications(
+        [localAuthored.pubkey],
+        (event) => receivedIds.add(event.id),
+        () => {
+          completed = true;
+        },
+        { relayUrls },
+      );
+
+      await session.waitFor(() => completed);
+      await session.waitFor((entries) =>
+        entries.filter((entry) => entry.type === "close").length === 4
+      );
+      handle.close();
+      workflow.complete();
+
+      expect([...receivedIds].sort()).toEqual(
+        [localAuthored.id, authoredReaction.id, taggedMention.id].sort(),
+      );
+      const summary = session.summary(workflow);
+      expect(summary).toMatchObject({
+        openedConnections: 0,
+        requests: 4,
+        closes: 4,
+        eose: 4,
+        returnedEvents: 8,
+        repeatedOperations: 2,
+        relayFanout: 2,
+      });
+      const requests = workflowEntries(session, workflow)
+        .filter((entry) => entry.type === "request");
+      expect(new Map(requests.map((request) => [
+        JSON.stringify(request.filters),
+        requests.filter((candidate) =>
+          JSON.stringify(candidate.filters) === JSON.stringify(request.filters)
+        ).length,
+      ]))).toEqual(new Map([
+        [JSON.stringify([{
+          authors: [localAuthored.pubkey],
+          kinds: [1, 7],
+          limit: 25,
+        }]), 2],
+        [JSON.stringify([{
+          "#p": [localAuthored.pubkey],
+          kinds: [1],
+          limit: 50,
+        }]), 2],
+      ]));
+      completionLatencies.push(summary.completionLatencyMs);
+      evidenceEntries = workflowEntries(session, workflow);
+    }
+
+    emitAuditMeasurement({
+      scenario: "wired-browser-notifications-local-fixture",
+      samples: completionLatencies.length,
+      completionLatencyMs: summarizeSamples(completionLatencies),
+      evidence: {
+        requestBytes: evidenceEntries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.bytes),
+        returnedEventBytes: evidenceEntries
+          .filter((entry) => entry.type === "event-returned")
+          .map((entry) => entry.bytes),
+        subscriptionLifetimesMs: evidenceEntries
+          .filter((entry) => entry.type === "close")
+          .map((entry) => entry.lifetimeMs),
+      },
+    });
+  });
+
+  it("retains exact notifications when a peer relay disconnects", async () => {
+    const session = new RelayTranscriptSession();
+    const healthyRelay = await RelayTranscriptHarness.listen({
+      session,
+      onRequest: (request) => driveNotifications(request, 5),
+    });
+    const disconnectedRelay = await RelayTranscriptHarness.listen({
+      session,
+      onRequest(request) {
+        request.closeConnection(1);
+      },
+    });
+    harnesses.push(healthyRelay, disconnectedRelay);
+    const relayUrls = [healthyRelay.url, disconnectedRelay.url];
+    await ensureRelaysConnected(relayUrls);
+    const workflow = session.beginWorkflow("notifications-peer-disconnect");
+    const receivedIds = new Set<string>();
+    let completed = false;
+    const handle = subNotifications(
+      [localAuthored.pubkey],
+      (event) => receivedIds.add(event.id),
+      () => {
+        completed = true;
+      },
+      { relayUrls },
+    );
+
+    await session.waitFor(() => completed);
+    handle.close();
+    workflow.complete();
+    expect([...receivedIds].sort()).toEqual(
+      [localAuthored.id, authoredReaction.id, taggedMention.id].sort(),
+    );
+    expect(session.summary(workflow)).toMatchObject({
+      requests: 4,
+      returnedEvents: 4,
+      eose: 2,
+      relayFanout: 2,
+    });
+  });
+
+  it("captures batched profiles and deterministic newest metadata inputs", async () => {
+    const session = new RelayTranscriptSession();
+    const profileKeys = [localPubkeyKey, otherKey];
+    const listen = async (name: string, createdAt: number) =>
+      RelayTranscriptHarness.listen({
+        session,
+        onRequest(request) {
+          profileKeys.forEach((key, index) => request.sendEvent(finalizeEvent({
+            created_at: createdAt,
+            kind: 0,
+            tags: [],
+            content: JSON.stringify({ name: `${name}-${index}` }),
+          }, key)));
+          request.sendEose();
+        },
+      });
+    const olderRelay = await listen("older", 2_000_000_010);
+    const newerRelay = await listen("newer", 2_000_000_020);
+    harnesses.push(olderRelay, newerRelay);
+    const relayUrls = [olderRelay.url, newerRelay.url];
+    const workflow = session.beginWorkflow("profiles-batched-newest-inputs");
+    const profiles = new Map<string, { name: string; createdAt: number }>();
+    let completed = false;
+    const handle = await subProfilesOnce(
+      [localAuthored.pubkey, taggedMention.pubkey],
+      (event) => {
+        const name = (JSON.parse(event.content) as { name: string }).name;
+        const existing = profiles.get(event.pubkey);
+        if (!existing || existing.createdAt < event.created_at) {
+          profiles.set(event.pubkey, { name, createdAt: event.created_at });
+        }
+      },
+      () => {
+        completed = true;
+      },
+      { relayUrls },
+    );
+    await session.waitFor(() => completed);
+    await session.waitFor((entries) =>
+      entries.filter((entry) => entry.type === "close").length === 2
+    );
+    handle.close();
+    workflow.complete();
+
+    expect([...profiles.values()].map((profile) => profile.name).sort()).toEqual([
+      "newer-0",
+      "newer-1",
+    ]);
+    expect(session.summary(workflow)).toMatchObject({
+      openedConnections: 2,
+      requests: 2,
+      closes: 2,
+      eose: 2,
+      returnedEvents: 4,
+      relayFanout: 2,
+    });
+    const requests = workflowEntries(session, workflow)
+      .filter((entry) => entry.type === "request");
+    expect(requests.every((request) =>
+      request.filters[0]?.authors?.length === 2 &&
+      request.filters[0]?.kinds?.[0] === 0 &&
+      request.filters[0]?.limit === 2
+    )).toBe(true);
+  });
+
+  it("captures fallback quotes, a delayed extra hint, stale hints, and missing results", async () => {
+    const session = new RelayTranscriptSession();
+    const fallbackQuote = finalizeEvent({
+      created_at: 2_000_000_030,
+      kind: 1,
+      tags: [],
+      content: "fallback quote",
+    }, new Uint8Array(32).fill(82));
+    const hintedQuote = finalizeEvent({
+      created_at: 2_000_000_031,
+      kind: 1068,
+      tags: [],
+      content: "hinted quote",
+    }, new Uint8Array(32).fill(83));
+    const missingId = "f".repeat(64);
+    const fallbackDriver = (request: RelayRequestController) => {
+      if (request.filters[0]?.ids?.includes(fallbackQuote.id)) {
+        request.sendEvent(fallbackQuote, 5);
+      }
+      request.sendEose(10);
+    };
+    const fallbackRelays = [
+      await RelayTranscriptHarness.listen({ session, onRequest: fallbackDriver }),
+      await RelayTranscriptHarness.listen({ session, onRequest: fallbackDriver }),
+    ];
+    const hintedRelay = await RelayTranscriptHarness.listen({
+      session,
+      onRequest(request) {
+        if (request.filters[0]?.ids?.includes(hintedQuote.id)) {
+          request.sendEvent(hintedQuote, 20);
+        }
+        request.sendEose(25);
+      },
+    });
+    harnesses.push(...fallbackRelays, hintedRelay);
+    const workflow = session.beginWorkflow("quoted-fallback-hint-missing");
+    const receivedIds = new Set<string>();
+    const completedIds = new Set<string>();
+    const handle = await subQuotedEventsOnce(
+      [
+        { id: fallbackQuote.id, relays: [] },
+        { id: hintedQuote.id, relays: [hintedRelay.url] },
+        { id: missingId, relays: ["ws://127.0.0.1:9"] },
+      ],
+      (event) => receivedIds.add(event.id),
+      (id) => completedIds.add(id),
+      { fallbackRelayUrls: fallbackRelays.map((relay) => relay.url) },
+    );
+    await session.waitFor(() => completedIds.size === 3);
+    await session.waitFor((entries) =>
+      entries.filter((entry) => entry.type === "close").length === 7
+    );
+    handle.close();
+    workflow.complete();
+
+    expect([...receivedIds].sort()).toEqual([fallbackQuote.id, hintedQuote.id].sort());
+    expect(completedIds).toEqual(new Set([fallbackQuote.id, hintedQuote.id, missingId]));
+    const summary = session.summary(workflow);
+    expect(summary).toMatchObject({
+      openedConnections: 3,
+      requests: 7,
+      closes: 7,
+      eose: 7,
+      returnedEvents: 3,
+      repeatedOperations: 4,
+      relayFanout: 3,
+    });
+    const requests = workflowEntries(session, workflow)
+      .filter((entry) => entry.type === "request");
+    expect(requests.filter((request) =>
+      request.filters[0]?.ids?.includes(hintedQuote.id)
+    )).toHaveLength(3);
+    expect(requests.some((request) => request.relayUrl === "ws://127.0.0.1:9"))
+      .toBe(false);
+  });
+
+  it("records duplicate quote lookup when an extra hint is already connected", async () => {
+    const session = new RelayTranscriptSession();
+    const quoted = finalizeEvent({
+      created_at: 2_000_000_040,
+      kind: 1,
+      tags: [],
+      content: "already-connected hint",
+    }, new Uint8Array(32).fill(84));
+    const fallbackRelay = await RelayTranscriptHarness.listen({
+      session,
+      onRequest(request) {
+        request.sendEose();
+      },
+    });
+    const hintedRelay = await RelayTranscriptHarness.listen({
+      session,
+      onRequest(request) {
+        request.sendEvent(quoted);
+        request.sendEose();
+      },
+    });
+    harnesses.push(fallbackRelay, hintedRelay);
+    await ensureRelaysConnected([fallbackRelay.url, hintedRelay.url]);
+    const workflow = session.beginWorkflow("quote-preconnected-hint-duplicate");
+    const receivedIds = new Set<string>();
+    let completed = false;
+    const handle = await subQuotedEventsOnce(
+      [{ id: quoted.id, relays: [hintedRelay.url] }],
+      (event) => receivedIds.add(event.id),
+      () => {
+        completed = true;
+      },
+      { fallbackRelayUrls: [fallbackRelay.url] },
+    );
+    await session.waitFor(() => completed);
+    await session.waitFor((entries) =>
+      entries.filter((entry) => entry.type === "close").length === 3
+    );
+    handle.close();
+    workflow.complete();
+
+    expect(receivedIds).toEqual(new Set([quoted.id]));
+    expect(session.summary(workflow)).toMatchObject({
+      requests: 3,
+      closes: 3,
+      eose: 3,
+      returnedEvents: 2,
+      repeatedOperations: 2,
+      relayFanout: 2,
+    });
+    const hintedRequests = workflowEntries(session, workflow)
+      .filter((entry) => entry.type === "request")
+      .filter((entry) => entry.relayUrl === hintedRelay.url);
+    expect(hintedRequests).toHaveLength(2);
+    expect(hintedRequests[0]?.filters).toEqual(hintedRequests[1]?.filters);
+  });
+});

--- a/src/nostr/testing/publish-transcript.test.ts
+++ b/src/nostr/testing/publish-transcript.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  finalizeEvent,
+  useWebSocketImplementation as configureWebSocketImplementation,
+} from "nostr-tools";
+import { WebSocket } from "ws";
+import { RelayPool } from "../relay-pool";
+import {
+  auditSampleCount,
+  emitAuditMeasurement,
+  summarizeSamples,
+} from "./audit-metrics";
+import {
+  RelayTranscriptHarness,
+  RelayTranscriptSession,
+  type RelayPublishController,
+  type RelayTranscriptEntry,
+} from "./relay-transcript";
+
+configureWebSocketImplementation(WebSocket);
+
+const event = finalizeEvent({
+  created_at: 2_000_000_000,
+  kind: 1,
+  tags: [],
+  content: "browser publish transcript",
+}, new Uint8Array(32).fill(90));
+
+function workflowEntries(
+  session: RelayTranscriptSession,
+  workflow: { startIndex: number; completedIndex?: number },
+): readonly RelayTranscriptEntry[] {
+  return session.entries.slice(workflow.startIndex, workflow.completedIndex);
+}
+
+describe("browser publish relay transcript", () => {
+  const harnesses: RelayTranscriptHarness[] = [];
+
+  afterEach(async () => {
+    await Promise.all(harnesses.splice(0).map((harness) => harness.close()));
+  });
+
+  it("measures full/partial acknowledgement with pooled connection reuse", async () => {
+    const session = new RelayTranscriptSession();
+    const accept = (publish: RelayPublishController) => publish.acknowledge(true, "", 5);
+    const reject = (publish: RelayPublishController) =>
+      publish.acknowledge(false, "blocked", 5);
+    const runHarnesses = [
+      await RelayTranscriptHarness.listen({ session, onPublish: accept }),
+      await RelayTranscriptHarness.listen({ session, onPublish: accept }),
+      await RelayTranscriptHarness.listen({ session, onPublish: reject }),
+    ];
+    harnesses.push(...runHarnesses);
+    const pool = new RelayPool();
+    await pool.connect(runHarnesses.map((harness) => harness.url));
+    const completionLatencies: number[] = [];
+    let evidenceEntries: readonly RelayTranscriptEntry[] = [];
+
+    for (let run = 0; run < auditSampleCount(); run += 1) {
+      const workflow = session.beginWorkflow(`browser-publish-partial-${run + 1}`);
+      const accepted = await pool.publish(event);
+      workflow.complete();
+
+      expect(accepted).toEqual(new Set(runHarnesses.slice(0, 2).map((relay) => relay.url)));
+      const summary = session.summary(workflow);
+      expect(summary).toMatchObject({
+        openedConnections: 0,
+        publishes: 3,
+        acknowledgements: 2,
+        rejections: 1,
+        retries: 0,
+        relayFanout: 3,
+      });
+      const entries = workflowEntries(session, workflow);
+      expect(entries
+        .filter((entry) => entry.type === "publish")
+        .every((entry) => entry.eventId === event.id)).toBe(true);
+      completionLatencies.push(summary.completionLatencyMs);
+      evidenceEntries = entries;
+    }
+
+    emitAuditMeasurement({
+      scenario: "wired-browser-publish-partial-local-fixture",
+      samples: completionLatencies.length,
+      completionLatencyMs: summarizeSamples(completionLatencies),
+      evidence: {
+        publishedEventBytes: evidenceEntries
+          .filter((entry) => entry.type === "publish")
+          .map((entry) => entry.bytes),
+      },
+    });
+  });
+
+  it("reports full rejection and survives a disconnected peer", async () => {
+    const session = new RelayTranscriptSession();
+    const rejectedRelay = await RelayTranscriptHarness.listen({
+      session,
+      onPublish(publish) {
+        publish.acknowledge(false, "rejected");
+      },
+    });
+    const disconnectedRelay = await RelayTranscriptHarness.listen({
+      session,
+      onPublish(publish) {
+        publish.closeConnection(1);
+      },
+    });
+    harnesses.push(rejectedRelay, disconnectedRelay);
+    const pool = new RelayPool();
+    await pool.connect([rejectedRelay.url, disconnectedRelay.url]);
+    const workflow = session.beginWorkflow("browser-publish-reject-disconnect");
+    expect(await pool.publish(event)).toEqual(new Set());
+    workflow.complete();
+
+    expect(session.summary(workflow)).toMatchObject({
+      publishes: 2,
+      acknowledgements: 0,
+      rejections: 1,
+      relayFanout: 2,
+    });
+  });
+
+  it("does not complete an unacknowledged publish until the relay disconnects", async () => {
+    const session = new RelayTranscriptSession();
+    const acceptedRelay = await RelayTranscriptHarness.listen({
+      session,
+      onPublish(publish) {
+        publish.acknowledge(true, "", 5);
+      },
+    });
+    const silentRelay = await RelayTranscriptHarness.listen({
+      session,
+      onPublish() {},
+    });
+    harnesses.push(acceptedRelay, silentRelay);
+    const pool = new RelayPool();
+    await pool.connect([acceptedRelay.url, silentRelay.url]);
+    const workflow = session.beginWorkflow("browser-publish-silent-relay");
+    const publish = pool.publish(event);
+    const outcome = await Promise.race([
+      publish.then(() => "completed" as const),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 50)),
+    ]);
+    expect(outcome).toBe("pending");
+    await silentRelay.close();
+    expect(await publish).toEqual(new Set([acceptedRelay.url]));
+    workflow.complete();
+
+    expect(session.summary(workflow)).toMatchObject({
+      publishes: 2,
+      acknowledgements: 1,
+      rejections: 0,
+      relayFanout: 2,
+    });
+  });
+
+  it("coalesces concurrent publishes of the same event", async () => {
+    const session = new RelayTranscriptSession();
+    const runHarnesses = [
+      await RelayTranscriptHarness.listen({
+        session,
+        onPublish(publish) {
+          publish.acknowledge(true);
+        },
+      }),
+      await RelayTranscriptHarness.listen({
+        session,
+        onPublish(publish) {
+          publish.acknowledge(true);
+        },
+      }),
+    ];
+    harnesses.push(...runHarnesses);
+    const pool = new RelayPool();
+    await pool.connect(runHarnesses.map((harness) => harness.url));
+    const workflow = session.beginWorkflow("browser-publish-duplicate-invocation");
+    const first = pool.publish(event);
+    const duplicate = pool.publish(event);
+    const results = await Promise.all([first, duplicate]);
+    workflow.complete();
+
+    expect(results).toEqual([
+      new Set(runHarnesses.map((relay) => relay.url)),
+      new Set(runHarnesses.map((relay) => relay.url)),
+    ]);
+    expect(session.summary(workflow)).toMatchObject({
+      openedConnections: 0,
+      connectionReuseCount: 0,
+      publishes: 2,
+      acknowledgements: 2,
+      repeatedOperations: 1,
+      relayFanout: 2,
+    });
+
+    const retryWorkflow = session.beginWorkflow("browser-publish-post-settlement-retry");
+    const retry = await pool.publish(event);
+    retryWorkflow.complete();
+
+    expect(retry).toEqual(new Set(runHarnesses.map((relay) => relay.url)));
+    expect(retry).not.toBe(results[0]);
+    expect(session.summary(retryWorkflow)).toMatchObject({
+      publishes: 2,
+      acknowledgements: 2,
+      repeatedOperations: 1,
+      relayFanout: 2,
+    });
+  });
+});

--- a/src/nostr/testing/relay-transcript.ts
+++ b/src/nostr/testing/relay-transcript.ts
@@ -42,7 +42,8 @@ export type RelayTranscriptEntry =
       eventId: string;
       accepted: boolean;
       reason: string;
-    });
+    })
+  | { type: "retry"; at: number; operationId: string };
 
 export type RelayRequestController = {
   connectionId: number;
@@ -61,6 +62,7 @@ export type RelayPublishController = {
 };
 
 type RelayTranscriptHarnessOptions = {
+  session?: RelayTranscriptSession;
   onRequest?: (request: RelayRequestController) => void;
   onPublish?: (publish: RelayPublishController) => void;
 };
@@ -70,7 +72,9 @@ export type RelayWorkflowCapture = {
   startedAt: number;
   startIndex: number;
   completedAt?: number;
+  completedIndex?: number;
   complete: () => void;
+  recordRetry: (operationId: string) => void;
 };
 
 export type RelayTranscriptSummary = {
@@ -88,6 +92,7 @@ export type RelayTranscriptSummary = {
   acknowledgements: number;
   rejections: number;
   retries: number;
+  repeatedOperations: number;
   relayFanout: number;
   subscriptionLifetimesMs: number[];
   completionLatencyMs: number;
@@ -104,46 +109,10 @@ function messageBytes(message: string): number {
   return Buffer.byteLength(message, "utf8");
 }
 
-function schedule(action: () => void, delayMs = 0): void {
-  if (delayMs <= 0) {
-    action();
-    return;
-  }
-  setTimeout(action, delayMs);
-}
-
-export class RelayTranscriptHarness {
-  readonly url: string;
-
+export class RelayTranscriptSession {
   private readonly transcript: RelayTranscriptEntry[] = [];
-  private readonly sockets = new Set<WebSocket>();
   private readonly waiters = new Set<Waiter>();
   private nextConnectionId = 0;
-
-  private constructor(
-    private readonly server: WebSocketServer,
-    private readonly options: RelayTranscriptHarnessOptions,
-    port: number,
-  ) {
-    this.url = `ws://127.0.0.1:${port}`;
-    this.server.on("connection", (socket) => this.accept(socket));
-  }
-
-  static async listen(
-    options: RelayTranscriptHarnessOptions = {},
-  ): Promise<RelayTranscriptHarness> {
-    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
-    await new Promise<void>((resolve, reject) => {
-      server.once("listening", resolve);
-      server.once("error", reject);
-    });
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      server.close();
-      throw new Error("Relay transcript harness did not bind a TCP port");
-    }
-    return new RelayTranscriptHarness(server, options, address.port);
-  }
 
   get entries(): readonly RelayTranscriptEntry[] {
     return this.transcript;
@@ -155,17 +124,25 @@ export class RelayTranscriptHarness {
       startedAt: Date.now(),
       startIndex: this.transcript.length,
       complete: () => {
-        capture.completedAt ??= Date.now();
+        if (capture.completedAt !== undefined) return;
+        capture.completedAt = Date.now();
+        capture.completedIndex = this.transcript.length;
+      },
+      recordRetry: (operationId) => {
+        this.record({ type: "retry", at: Date.now(), operationId });
       },
     };
     return capture;
   }
 
   summary(workflow: RelayWorkflowCapture): RelayTranscriptSummary {
-    const entries = this.transcript.slice(workflow.startIndex);
+    const entries = this.transcript.slice(
+      workflow.startIndex,
+      workflow.completedIndex ?? this.transcript.length,
+    );
     const operationsByConnection = new Map<number, number>();
     const operationSignatures = new Set<string>();
-    let retries = 0;
+    let repeatedOperations = 0;
 
     for (const entry of entries) {
       if (entry.type !== "request" && entry.type !== "publish") continue;
@@ -177,7 +154,7 @@ export class RelayTranscriptHarness {
         entry.type === "request"
           ? `REQ:${JSON.stringify(entry.filters)}`
           : `EVENT:${entry.eventId}`;
-      if (operationSignatures.has(signature)) retries += 1;
+      if (operationSignatures.has(signature)) repeatedOperations += 1;
       operationSignatures.add(signature);
     }
 
@@ -215,7 +192,8 @@ export class RelayTranscriptHarness {
       rejections: entries.filter(
         (entry) => entry.type === "acknowledgement" && !entry.accepted,
       ).length,
-      retries,
+      retries: entries.filter((entry) => entry.type === "retry").length,
+      repeatedOperations,
       relayFanout: relayUrls.size,
       subscriptionLifetimesMs: entries
         .filter((entry) => entry.type === "close")
@@ -243,20 +221,100 @@ export class RelayTranscriptHarness {
     });
   }
 
-  async close(): Promise<void> {
-    for (const socket of this.sockets) socket.terminate();
-    for (const waiter of this.waiters) {
+  record(entry: RelayTranscriptEntry): void {
+    this.transcript.push(entry);
+    for (const waiter of [...this.waiters]) {
+      if (!waiter.predicate(this.transcript)) continue;
       clearTimeout(waiter.timeout);
-      waiter.reject(new Error("Relay transcript harness closed"));
+      this.waiters.delete(waiter);
+      waiter.resolve();
     }
-    this.waiters.clear();
+  }
+
+  allocateConnectionId(): number {
+    this.nextConnectionId += 1;
+    return this.nextConnectionId;
+  }
+}
+
+export class RelayTranscriptHarness {
+  readonly url: string;
+  readonly session: RelayTranscriptSession;
+
+  private readonly sockets = new Set<WebSocket>();
+  private readonly scheduledActions = new Set<ReturnType<typeof setTimeout>>();
+  private closed = false;
+
+  private constructor(
+    private readonly server: WebSocketServer,
+    private readonly options: RelayTranscriptHarnessOptions,
+    port: number,
+  ) {
+    this.url = `ws://127.0.0.1:${port}`;
+    this.session = options.session ?? new RelayTranscriptSession();
+    this.server.on("connection", (socket) => this.accept(socket));
+  }
+
+  static async listen(
+    options: RelayTranscriptHarnessOptions = {},
+  ): Promise<RelayTranscriptHarness> {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await new Promise<void>((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("Relay transcript harness did not bind a TCP port");
+    }
+    return new RelayTranscriptHarness(server, options, address.port);
+  }
+
+  get entries(): readonly RelayTranscriptEntry[] {
+    return this.session.entries;
+  }
+
+  beginWorkflow(name: string): RelayWorkflowCapture {
+    return this.session.beginWorkflow(name);
+  }
+
+  summary(workflow: RelayWorkflowCapture): RelayTranscriptSummary {
+    return this.session.summary(workflow);
+  }
+
+  waitFor(
+    predicate: (entries: readonly RelayTranscriptEntry[]) => boolean,
+    timeoutMs = 2_000,
+  ): Promise<void> {
+    return this.session.waitFor(predicate, timeoutMs);
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    for (const timeout of this.scheduledActions) clearTimeout(timeout);
+    this.scheduledActions.clear();
+    for (const socket of this.sockets) socket.terminate();
     await new Promise<void>((resolve) => this.server.close(() => resolve()));
   }
 
+  private schedule(action: () => void, delayMs = 0): void {
+    if (this.closed) return;
+    if (delayMs <= 0) {
+      action();
+      return;
+    }
+    const timeout = setTimeout(() => {
+      this.scheduledActions.delete(timeout);
+      if (!this.closed) action();
+    }, delayMs);
+    this.scheduledActions.add(timeout);
+  }
+
   private accept(socket: WebSocket): void {
-    const connectionId = ++this.nextConnectionId;
+    const connectionId = this.session.allocateConnectionId();
     this.sockets.add(socket);
-    this.record({
+    this.session.record({
       type: "connection-opened",
       at: Date.now(),
       connectionId,
@@ -269,7 +327,7 @@ export class RelayTranscriptHarness {
     });
     socket.on("close", () => {
       this.sockets.delete(socket);
-      this.record({
+      this.session.record({
         type: "connection-closed",
         at: Date.now(),
         connectionId,
@@ -297,7 +355,7 @@ export class RelayTranscriptHarness {
       const subscriptionId = message[1];
       const filters = message.slice(2) as Filter[];
       requestStartedAt.set(subscriptionId, Date.now());
-      this.record({
+      this.session.record({
         type: "request",
         at: Date.now(),
         connectionId,
@@ -311,10 +369,10 @@ export class RelayTranscriptHarness {
         subscriptionId,
         filters,
         sendEvent: (event, delayMs) =>
-          schedule(() => {
+          this.schedule(() => {
             const outgoing = JSON.stringify(["EVENT", subscriptionId, event]);
             socket.send(outgoing);
-            this.record({
+            this.session.record({
               type: "event-returned",
               at: Date.now(),
               connectionId,
@@ -325,9 +383,9 @@ export class RelayTranscriptHarness {
             });
           }, delayMs),
         sendEose: (delayMs) =>
-          schedule(() => {
+          this.schedule(() => {
             socket.send(JSON.stringify(["EOSE", subscriptionId]));
-            this.record({
+            this.session.record({
               type: "eose",
               at: Date.now(),
               connectionId,
@@ -335,7 +393,7 @@ export class RelayTranscriptHarness {
               subscriptionId,
             });
           }, delayMs),
-        closeConnection: (delayMs) => schedule(() => socket.close(), delayMs),
+        closeConnection: (delayMs) => this.schedule(() => socket.close(), delayMs),
       });
       return;
     }
@@ -343,7 +401,7 @@ export class RelayTranscriptHarness {
     if (message[0] === "CLOSE" && typeof message[1] === "string") {
       const subscriptionId = message[1];
       const now = Date.now();
-      this.record({
+      this.session.record({
         type: "close",
         at: now,
         connectionId,
@@ -357,7 +415,7 @@ export class RelayTranscriptHarness {
 
     if (message[0] === "EVENT" && message[1] && typeof message[1] === "object") {
       const event = message[1] as Event;
-      this.record({
+      this.session.record({
         type: "publish",
         at: Date.now(),
         connectionId,
@@ -369,9 +427,9 @@ export class RelayTranscriptHarness {
         connectionId,
         event,
         acknowledge: (accepted, reason = "", delayMs) =>
-          schedule(() => {
+          this.schedule(() => {
             socket.send(JSON.stringify(["OK", event.id, accepted, reason]));
-            this.record({
+            this.session.record({
               type: "acknowledgement",
               at: Date.now(),
               connectionId,
@@ -381,18 +439,8 @@ export class RelayTranscriptHarness {
               reason,
             });
           }, delayMs),
-        closeConnection: (delayMs) => schedule(() => socket.close(), delayMs),
+        closeConnection: (delayMs) => this.schedule(() => socket.close(), delayMs),
       });
-    }
-  }
-
-  private record(entry: RelayTranscriptEntry): void {
-    this.transcript.push(entry);
-    for (const waiter of [...this.waiters]) {
-      if (!waiter.predicate(this.transcript)) continue;
-      clearTimeout(waiter.timeout);
-      this.waiters.delete(waiter);
-      waiter.resolve();
     }
   }
 }

--- a/src/nostr/testing/relay-transcript.ts
+++ b/src/nostr/testing/relay-transcript.ts
@@ -1,0 +1,398 @@
+import type { Event, Filter } from "nostr-tools";
+import {
+  WebSocketServer,
+  type RawData,
+  type WebSocket,
+} from "ws";
+
+type TranscriptBase = {
+  at: number;
+  connectionId: number;
+  relayUrl: string;
+};
+
+export type RelayTranscriptEntry =
+  | (TranscriptBase & { type: "connection-opened" })
+  | (TranscriptBase & { type: "connection-closed" })
+  | (TranscriptBase & {
+      type: "request";
+      subscriptionId: string;
+      filters: Filter[];
+      bytes: number;
+    })
+  | (TranscriptBase & {
+      type: "event-returned";
+      subscriptionId: string;
+      eventId: string;
+      bytes: number;
+    })
+  | (TranscriptBase & { type: "eose"; subscriptionId: string })
+  | (TranscriptBase & {
+      type: "close";
+      subscriptionId: string;
+      lifetimeMs: number;
+    })
+  | (TranscriptBase & {
+      type: "publish";
+      eventId: string;
+      bytes: number;
+    })
+  | (TranscriptBase & {
+      type: "acknowledgement";
+      eventId: string;
+      accepted: boolean;
+      reason: string;
+    });
+
+export type RelayRequestController = {
+  connectionId: number;
+  filters: Filter[];
+  subscriptionId: string;
+  sendEvent: (event: Event, delayMs?: number) => void;
+  sendEose: (delayMs?: number) => void;
+  closeConnection: (delayMs?: number) => void;
+};
+
+export type RelayPublishController = {
+  connectionId: number;
+  event: Event;
+  acknowledge: (accepted: boolean, reason?: string, delayMs?: number) => void;
+  closeConnection: (delayMs?: number) => void;
+};
+
+type RelayTranscriptHarnessOptions = {
+  onRequest?: (request: RelayRequestController) => void;
+  onPublish?: (publish: RelayPublishController) => void;
+};
+
+export type RelayWorkflowCapture = {
+  name: string;
+  startedAt: number;
+  startIndex: number;
+  completedAt?: number;
+  complete: () => void;
+};
+
+export type RelayTranscriptSummary = {
+  workflow: string;
+  openedConnections: number;
+  closedConnections: number;
+  connectionReuseCount: number;
+  requests: number;
+  closes: number;
+  returnedEvents: number;
+  returnedEventBytes: number;
+  eose: number;
+  publishes: number;
+  publishedEventBytes: number;
+  acknowledgements: number;
+  rejections: number;
+  retries: number;
+  relayFanout: number;
+  subscriptionLifetimesMs: number[];
+  completionLatencyMs: number;
+};
+
+type Waiter = {
+  predicate: (entries: readonly RelayTranscriptEntry[]) => boolean;
+  resolve: () => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+function messageBytes(message: string): number {
+  return Buffer.byteLength(message, "utf8");
+}
+
+function schedule(action: () => void, delayMs = 0): void {
+  if (delayMs <= 0) {
+    action();
+    return;
+  }
+  setTimeout(action, delayMs);
+}
+
+export class RelayTranscriptHarness {
+  readonly url: string;
+
+  private readonly transcript: RelayTranscriptEntry[] = [];
+  private readonly sockets = new Set<WebSocket>();
+  private readonly waiters = new Set<Waiter>();
+  private nextConnectionId = 0;
+
+  private constructor(
+    private readonly server: WebSocketServer,
+    private readonly options: RelayTranscriptHarnessOptions,
+    port: number,
+  ) {
+    this.url = `ws://127.0.0.1:${port}`;
+    this.server.on("connection", (socket) => this.accept(socket));
+  }
+
+  static async listen(
+    options: RelayTranscriptHarnessOptions = {},
+  ): Promise<RelayTranscriptHarness> {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await new Promise<void>((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("Relay transcript harness did not bind a TCP port");
+    }
+    return new RelayTranscriptHarness(server, options, address.port);
+  }
+
+  get entries(): readonly RelayTranscriptEntry[] {
+    return this.transcript;
+  }
+
+  beginWorkflow(name: string): RelayWorkflowCapture {
+    const capture: RelayWorkflowCapture = {
+      name,
+      startedAt: Date.now(),
+      startIndex: this.transcript.length,
+      complete: () => {
+        capture.completedAt ??= Date.now();
+      },
+    };
+    return capture;
+  }
+
+  summary(workflow: RelayWorkflowCapture): RelayTranscriptSummary {
+    const entries = this.transcript.slice(workflow.startIndex);
+    const operationsByConnection = new Map<number, number>();
+    const operationSignatures = new Set<string>();
+    let retries = 0;
+
+    for (const entry of entries) {
+      if (entry.type !== "request" && entry.type !== "publish") continue;
+      operationsByConnection.set(
+        entry.connectionId,
+        (operationsByConnection.get(entry.connectionId) ?? 0) + 1,
+      );
+      const signature =
+        entry.type === "request"
+          ? `REQ:${JSON.stringify(entry.filters)}`
+          : `EVENT:${entry.eventId}`;
+      if (operationSignatures.has(signature)) retries += 1;
+      operationSignatures.add(signature);
+    }
+
+    const completedAt = workflow.completedAt ?? Date.now();
+    const relayUrls = new Set(
+      entries
+        .filter((entry) => entry.type === "request" || entry.type === "publish")
+        .map((entry) => entry.relayUrl),
+    );
+
+    return {
+      workflow: workflow.name,
+      openedConnections: entries.filter((entry) => entry.type === "connection-opened")
+        .length,
+      closedConnections: entries.filter((entry) => entry.type === "connection-closed")
+        .length,
+      connectionReuseCount: [...operationsByConnection.values()].reduce(
+        (total, operations) => total + Math.max(0, operations - 1),
+        0,
+      ),
+      requests: entries.filter((entry) => entry.type === "request").length,
+      closes: entries.filter((entry) => entry.type === "close").length,
+      returnedEvents: entries.filter((entry) => entry.type === "event-returned").length,
+      returnedEventBytes: entries
+        .filter((entry) => entry.type === "event-returned")
+        .reduce((total, entry) => total + entry.bytes, 0),
+      eose: entries.filter((entry) => entry.type === "eose").length,
+      publishes: entries.filter((entry) => entry.type === "publish").length,
+      publishedEventBytes: entries
+        .filter((entry) => entry.type === "publish")
+        .reduce((total, entry) => total + entry.bytes, 0),
+      acknowledgements: entries.filter(
+        (entry) => entry.type === "acknowledgement" && entry.accepted,
+      ).length,
+      rejections: entries.filter(
+        (entry) => entry.type === "acknowledgement" && !entry.accepted,
+      ).length,
+      retries,
+      relayFanout: relayUrls.size,
+      subscriptionLifetimesMs: entries
+        .filter((entry) => entry.type === "close")
+        .map((entry) => entry.lifetimeMs),
+      completionLatencyMs: Math.max(0, completedAt - workflow.startedAt),
+    };
+  }
+
+  async waitFor(
+    predicate: (entries: readonly RelayTranscriptEntry[]) => boolean,
+    timeoutMs = 2_000,
+  ): Promise<void> {
+    if (predicate(this.transcript)) return;
+    await new Promise<void>((resolve, reject) => {
+      const waiter: Waiter = {
+        predicate,
+        resolve,
+        reject,
+        timeout: setTimeout(() => {
+          this.waiters.delete(waiter);
+          reject(new Error(`Relay transcript condition timed out after ${timeoutMs}ms`));
+        }, timeoutMs),
+      };
+      this.waiters.add(waiter);
+    });
+  }
+
+  async close(): Promise<void> {
+    for (const socket of this.sockets) socket.terminate();
+    for (const waiter of this.waiters) {
+      clearTimeout(waiter.timeout);
+      waiter.reject(new Error("Relay transcript harness closed"));
+    }
+    this.waiters.clear();
+    await new Promise<void>((resolve) => this.server.close(() => resolve()));
+  }
+
+  private accept(socket: WebSocket): void {
+    const connectionId = ++this.nextConnectionId;
+    this.sockets.add(socket);
+    this.record({
+      type: "connection-opened",
+      at: Date.now(),
+      connectionId,
+      relayUrl: this.url,
+    });
+    const requestStartedAt = new Map<string, number>();
+
+    socket.on("message", (data) => {
+      this.receive(socket, connectionId, requestStartedAt, data);
+    });
+    socket.on("close", () => {
+      this.sockets.delete(socket);
+      this.record({
+        type: "connection-closed",
+        at: Date.now(),
+        connectionId,
+        relayUrl: this.url,
+      });
+    });
+  }
+
+  private receive(
+    socket: WebSocket,
+    connectionId: number,
+    requestStartedAt: Map<string, number>,
+    data: RawData,
+  ): void {
+    const raw = data.toString();
+    let message: unknown;
+    try {
+      message = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (!Array.isArray(message) || typeof message[0] !== "string") return;
+
+    if (message[0] === "REQ" && typeof message[1] === "string") {
+      const subscriptionId = message[1];
+      const filters = message.slice(2) as Filter[];
+      requestStartedAt.set(subscriptionId, Date.now());
+      this.record({
+        type: "request",
+        at: Date.now(),
+        connectionId,
+        relayUrl: this.url,
+        subscriptionId,
+        filters,
+        bytes: messageBytes(raw),
+      });
+      this.options.onRequest?.({
+        connectionId,
+        subscriptionId,
+        filters,
+        sendEvent: (event, delayMs) =>
+          schedule(() => {
+            const outgoing = JSON.stringify(["EVENT", subscriptionId, event]);
+            socket.send(outgoing);
+            this.record({
+              type: "event-returned",
+              at: Date.now(),
+              connectionId,
+              relayUrl: this.url,
+              subscriptionId,
+              eventId: event.id,
+              bytes: messageBytes(outgoing),
+            });
+          }, delayMs),
+        sendEose: (delayMs) =>
+          schedule(() => {
+            socket.send(JSON.stringify(["EOSE", subscriptionId]));
+            this.record({
+              type: "eose",
+              at: Date.now(),
+              connectionId,
+              relayUrl: this.url,
+              subscriptionId,
+            });
+          }, delayMs),
+        closeConnection: (delayMs) => schedule(() => socket.close(), delayMs),
+      });
+      return;
+    }
+
+    if (message[0] === "CLOSE" && typeof message[1] === "string") {
+      const subscriptionId = message[1];
+      const now = Date.now();
+      this.record({
+        type: "close",
+        at: now,
+        connectionId,
+        relayUrl: this.url,
+        subscriptionId,
+        lifetimeMs: Math.max(0, now - (requestStartedAt.get(subscriptionId) ?? now)),
+      });
+      requestStartedAt.delete(subscriptionId);
+      return;
+    }
+
+    if (message[0] === "EVENT" && message[1] && typeof message[1] === "object") {
+      const event = message[1] as Event;
+      this.record({
+        type: "publish",
+        at: Date.now(),
+        connectionId,
+        relayUrl: this.url,
+        eventId: event.id,
+        bytes: messageBytes(raw),
+      });
+      this.options.onPublish?.({
+        connectionId,
+        event,
+        acknowledge: (accepted, reason = "", delayMs) =>
+          schedule(() => {
+            socket.send(JSON.stringify(["OK", event.id, accepted, reason]));
+            this.record({
+              type: "acknowledgement",
+              at: Date.now(),
+              connectionId,
+              relayUrl: this.url,
+              eventId: event.id,
+              accepted,
+              reason,
+            });
+          }, delayMs),
+        closeConnection: (delayMs) => schedule(() => socket.close(), delayMs),
+      });
+    }
+  }
+
+  private record(entry: RelayTranscriptEntry): void {
+    this.transcript.push(entry);
+    for (const waiter of [...this.waiters]) {
+      if (!waiter.predicate(this.transcript)) continue;
+      clearTimeout(waiter.timeout);
+      this.waiters.delete(waiter);
+      waiter.resolve();
+    }
+  }
+}

--- a/src/nostr/testing/thread-preview-transcript.test.ts
+++ b/src/nostr/testing/thread-preview-transcript.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  finalizeEvent,
+  useWebSocketImplementation as configureWebSocketImplementation,
+} from "nostr-tools";
+import { WebSocket } from "ws";
+import {
+  fetchThreadEventsFromRelays,
+  resolveThreadPreview,
+} from "../../../lib/threadPreview";
+import {
+  RelayTranscriptHarness,
+  RelayTranscriptSession,
+  type RelayRequestController,
+} from "./relay-transcript";
+
+configureWebSocketImplementation(WebSocket);
+
+const secretKey = new Uint8Array(32).fill(5);
+const root = finalizeEvent({
+  created_at: 2_000_000_000,
+  kind: 1,
+  tags: [],
+  content: "preview root",
+}, secretKey);
+const reply = finalizeEvent({
+  created_at: root.created_at + 1,
+  kind: 1,
+  tags: [["e", root.id, "", "reply"]],
+  content: "reply",
+}, secretKey);
+const nestedReply = finalizeEvent({
+  created_at: reply.created_at + 1,
+  kind: 1,
+  tags: [
+    ["e", root.id, "", "root"],
+    ["e", reply.id, "", "reply"],
+  ],
+  content: "nested reply",
+}, secretKey);
+
+function returnCompleteThread(request: RelayRequestController, delayMs = 0): void {
+  request.sendEvent(root, delayMs);
+  request.sendEvent(reply, delayMs);
+  request.sendEvent(nestedReply, delayMs);
+  request.sendEose(delayMs);
+}
+
+describe("thread preview relay transcript", () => {
+  const harnesses: RelayTranscriptHarness[] = [];
+
+  afterEach(async () => {
+    await Promise.all(harnesses.splice(0).map((harness) => harness.close()));
+  });
+
+  it("deduplicates complete preview results across hinted relays", async () => {
+    const session = new RelayTranscriptSession();
+    harnesses.push(
+      await RelayTranscriptHarness.listen({
+        session,
+        onRequest: returnCompleteThread,
+      }),
+      await RelayTranscriptHarness.listen({
+        session,
+        onRequest: returnCompleteThread,
+      }),
+    );
+    const relayUrls = harnesses.map((harness) => harness.url);
+    const completionLatencies: number[] = [];
+
+    for (let run = 0; run < 20; run += 1) {
+      const workflow = session.beginWorkflow(`thread-preview-${run + 1}`);
+      const preview = await resolveThreadPreview(root.id, {
+        origin: "https://wiredsignal.online",
+        fetchImpl: async () => new Response(null, { status: 404 }),
+        relayFallback: (eventId, relayHints) =>
+          fetchThreadEventsFromRelays(eventId, relayHints, { relayUrls }),
+      });
+      await session.waitFor(
+        (entries) =>
+          entries.filter((entry) => entry.type === "connection-closed").length ===
+          (run + 1) * 2,
+      );
+      workflow.complete();
+
+      expect(preview).toMatchObject({
+        eventId: root.id,
+        excerpt: "preview root",
+        replyCount: 2,
+      });
+      const summary = session.summary(workflow);
+      expect(summary).toMatchObject({
+        openedConnections: 2,
+        closedConnections: 2,
+        requests: 2,
+        closes: 2,
+        returnedEvents: 6,
+        eose: 2,
+        repeatedOperations: 1,
+        relayFanout: 2,
+      });
+      completionLatencies.push(summary.completionLatencyMs);
+    }
+
+    if (process.env.RELAY_AUDIT_OUTPUT === "1") {
+      const sorted = [...completionLatencies].sort((a, b) => a - b);
+      const percentile = (value: number) =>
+        sorted[Math.ceil((value / 100) * sorted.length) - 1] ?? 0;
+      console.info(JSON.stringify({
+        scenario: "thread-preview-local-fixture",
+        samples: sorted.length,
+        completionLatencyMs: {
+          p50: percentile(50),
+          p95: percentile(95),
+          samples: completionLatencies,
+        },
+      }));
+    }
+  });
+
+  it("completes from one delayed relay when another relay disconnects", async () => {
+    const session = new RelayTranscriptSession();
+    harnesses.push(
+      await RelayTranscriptHarness.listen({
+        session,
+        onRequest(request) {
+          returnCompleteThread(request, 10);
+        },
+      }),
+      await RelayTranscriptHarness.listen({
+        session,
+        onRequest(request) {
+          request.closeConnection();
+        },
+      }),
+    );
+    const workflow = session.beginWorkflow("thread-preview-degraded-relay");
+    const preview = await resolveThreadPreview(root.id, {
+      origin: "https://wiredsignal.online",
+      fetchImpl: async () => new Response(null, { status: 404 }),
+      relayFallback: (eventId, relayHints) =>
+        fetchThreadEventsFromRelays(eventId, relayHints, {
+          relayUrls: harnesses.map((harness) => harness.url),
+        }),
+    });
+    workflow.complete();
+
+    expect(preview?.replyCount).toBe(2);
+    const summary = session.summary(workflow);
+    expect(summary).toMatchObject({
+      requests: 2,
+      returnedEvents: 3,
+      eose: 1,
+      relayFanout: 2,
+    });
+    if (process.env.RELAY_AUDIT_OUTPUT === "1") {
+      console.info(JSON.stringify({
+        scenario: "thread-preview-degraded-relay-local-fixture",
+        samples: 1,
+        completionLatencyMs: summary.completionLatencyMs,
+      }));
+    }
+  });
+});

--- a/src/nostr/testing/thread-preview-transcript.test.ts
+++ b/src/nostr/testing/thread-preview-transcript.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   finalizeEvent,
+  matchFilters,
+  nip19,
   useWebSocketImplementation as configureWebSocketImplementation,
 } from "nostr-tools";
 import { WebSocket } from "ws";
@@ -9,9 +11,15 @@ import {
   resolveThreadPreview,
 } from "../../../lib/threadPreview";
 import {
+  auditSampleCount,
+  emitAuditMeasurement,
+  summarizeSamples,
+} from "./audit-metrics";
+import {
   RelayTranscriptHarness,
   RelayTranscriptSession,
   type RelayRequestController,
+  type RelayTranscriptEntry,
 } from "./relay-transcript";
 
 configureWebSocketImplementation(WebSocket);
@@ -40,10 +48,33 @@ const nestedReply = finalizeEvent({
 }, secretKey);
 
 function returnCompleteThread(request: RelayRequestController, delayMs = 0): void {
+  expect(request.filters).toEqual([
+    { ids: [root.id], kinds: [1], limit: 1 },
+    { "#e": [root.id], kinds: [1], limit: 500 },
+  ]);
   request.sendEvent(root, delayMs);
   request.sendEvent(reply, delayMs);
   request.sendEvent(nestedReply, delayMs);
   request.sendEose(delayMs);
+}
+
+function expectMatchingCompletion(entries: readonly RelayTranscriptEntry[]): void {
+  const requestIds = entries
+    .filter((entry) => entry.type === "request")
+    .map((entry) => entry.subscriptionId)
+    .sort();
+  expect(
+    entries
+      .filter((entry) => entry.type === "eose")
+      .map((entry) => entry.subscriptionId)
+      .sort(),
+  ).toEqual(requestIds);
+  expect(
+    entries
+      .filter((entry) => entry.type === "close")
+      .map((entry) => entry.subscriptionId)
+      .sort(),
+  ).toEqual(requestIds);
 }
 
 describe("thread preview relay transcript", () => {
@@ -53,28 +84,32 @@ describe("thread preview relay transcript", () => {
     await Promise.all(harnesses.splice(0).map((harness) => harness.close()));
   });
 
-  it("deduplicates complete preview results across hinted relays", async () => {
+  it("unions an encoded event hint with configured coverage and deduplicates results", async () => {
     const session = new RelayTranscriptSession();
-    harnesses.push(
-      await RelayTranscriptHarness.listen({
-        session,
-        onRequest: returnCompleteThread,
-      }),
-      await RelayTranscriptHarness.listen({
-        session,
-        onRequest: returnCompleteThread,
-      }),
-    );
-    const relayUrls = harnesses.map((harness) => harness.url);
+    const configuredHarness = await RelayTranscriptHarness.listen({
+      session,
+      onRequest: returnCompleteThread,
+    });
+    const hintedHarness = await RelayTranscriptHarness.listen({
+      session,
+      onRequest: returnCompleteThread,
+    });
+    harnesses.push(configuredHarness, hintedHarness);
+    const ref = nip19.neventEncode({ id: root.id, relays: [hintedHarness.url] });
     const completionLatencies: number[] = [];
+    let evidenceEntries: readonly RelayTranscriptEntry[] = [];
 
-    for (let run = 0; run < 20; run += 1) {
+    for (let run = 0; run < auditSampleCount(); run += 1) {
       const workflow = session.beginWorkflow(`thread-preview-${run + 1}`);
-      const preview = await resolveThreadPreview(root.id, {
+      const preview = await resolveThreadPreview(ref, {
         origin: "https://wiredsignal.online",
         fetchImpl: async () => new Response(null, { status: 404 }),
-        relayFallback: (eventId, relayHints) =>
-          fetchThreadEventsFromRelays(eventId, relayHints, { relayUrls }),
+        relayFallback: (eventId, relayHints) => {
+          expect(relayHints).toEqual([hintedHarness.url]);
+          return fetchThreadEventsFromRelays(eventId, relayHints, {
+            configuredRelayUrls: [configuredHarness.url],
+          });
+        },
       });
       await session.waitFor(
         (entries) =>
@@ -99,26 +134,75 @@ describe("thread preview relay transcript", () => {
         repeatedOperations: 1,
         relayFanout: 2,
       });
+      const entries = session.entries.slice(
+        workflow.startIndex,
+        workflow.completedIndex,
+      );
+      expectMatchingCompletion(entries);
+      expect(
+        entries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.relayUrl)
+          .sort(),
+      ).toEqual([configuredHarness.url, hintedHarness.url].sort());
       completionLatencies.push(summary.completionLatencyMs);
+      evidenceEntries = entries;
     }
 
-    if (process.env.RELAY_AUDIT_OUTPUT === "1") {
-      const sorted = [...completionLatencies].sort((a, b) => a - b);
-      const percentile = (value: number) =>
-        sorted[Math.ceil((value / 100) * sorted.length) - 1] ?? 0;
-      console.info(JSON.stringify({
-        scenario: "thread-preview-local-fixture",
-        samples: sorted.length,
-        completionLatencyMs: {
-          p50: percentile(50),
-          p95: percentile(95),
-          samples: completionLatencies,
-        },
-      }));
-    }
+    emitAuditMeasurement({
+      scenario: "thread-preview-local-fixture",
+      samples: completionLatencies.length,
+      completionLatencyMs: summarizeSamples(completionLatencies),
+      evidence: {
+        filters: evidenceEntries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.filters),
+        requestBytes: evidenceEntries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.bytes),
+        returnedEventBytes: evidenceEntries
+          .filter((entry) => entry.type === "event-returned")
+          .map((entry) => entry.bytes),
+        subscriptionLifetimesMs: evidenceEntries
+          .filter((entry) => entry.type === "close")
+          .map((entry) => entry.lifetimeMs),
+      },
+    });
   });
 
-  it("completes from one delayed relay when another relay disconnects", async () => {
+  it("records the legacy descendant that root-only preview filters cannot reach", async () => {
+    const session = new RelayTranscriptSession();
+    const legacyNestedReply = finalizeEvent({
+      created_at: reply.created_at + 1,
+      kind: 1,
+      tags: [["e", reply.id, "", "reply"]],
+      content: "legacy nested reply",
+    }, secretKey);
+    harnesses.push(await RelayTranscriptHarness.listen({
+      session,
+      onRequest(request) {
+        [root, reply, legacyNestedReply]
+          .filter((event) => matchFilters(request.filters, event))
+          .forEach((event) => request.sendEvent(event));
+        request.sendEose();
+      },
+    }));
+    const workflow = session.beginWorkflow("thread-preview-legacy-descendant");
+    const events = await fetchThreadEventsFromRelays(root.id, [], {
+      configuredRelayUrls: [harnesses[0]!.url],
+    });
+    workflow.complete();
+
+    expect(events.map((event) => event.id)).toEqual([root.id, reply.id]);
+    expect(events).not.toContainEqual(legacyNestedReply);
+    expect(session.summary(workflow)).toMatchObject({
+      requests: 1,
+      returnedEvents: 2,
+      relayFanout: 1,
+    });
+  });
+
+  it("retains complete output but reaches the deadline after a relay disconnects", async () => {
     const session = new RelayTranscriptSession();
     harnesses.push(
       await RelayTranscriptHarness.listen({
@@ -140,7 +224,8 @@ describe("thread preview relay transcript", () => {
       fetchImpl: async () => new Response(null, { status: 404 }),
       relayFallback: (eventId, relayHints) =>
         fetchThreadEventsFromRelays(eventId, relayHints, {
-          relayUrls: harnesses.map((harness) => harness.url),
+          configuredRelayUrls: harnesses.map((harness) => harness.url),
+          timeoutMs: process.env.RELAY_AUDIT_OUTPUT === "1" ? 2_500 : 50,
         }),
     });
     workflow.complete();
@@ -153,12 +238,10 @@ describe("thread preview relay transcript", () => {
       eose: 1,
       relayFanout: 2,
     });
-    if (process.env.RELAY_AUDIT_OUTPUT === "1") {
-      console.info(JSON.stringify({
-        scenario: "thread-preview-degraded-relay-local-fixture",
-        samples: 1,
-        completionLatencyMs: summary.completionLatencyMs,
-      }));
-    }
+    emitAuditMeasurement({
+      scenario: "thread-preview-degraded-relay-local-fixture",
+      samples: 1,
+      completionLatencyMs: summary.completionLatencyMs,
+    });
   });
 });

--- a/src/nostr/testing/thread-preview-transcript.test.ts
+++ b/src/nostr/testing/thread-preview-transcript.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   finalizeEvent,
   matchFilters,
   nip19,
+  Relay,
   useWebSocketImplementation as configureWebSocketImplementation,
 } from "nostr-tools";
 import { WebSocket } from "ws";
@@ -238,10 +239,28 @@ describe("thread preview relay transcript", () => {
       eose: 1,
       relayFanout: 2,
     });
+    expect(summary.completionLatencyMs).toBeLessThan(40);
     emitAuditMeasurement({
       scenario: "thread-preview-degraded-relay-local-fixture",
       samples: 1,
       completionLatencyMs: summary.completionLatencyMs,
     });
+  });
+
+  it("closes a connection that arrives after the connection deadline", async () => {
+    const lateRelay = new Relay("ws://late-relay.invalid");
+    const close = vi.spyOn(lateRelay, "close");
+
+    expect(await fetchThreadEventsFromRelays(root.id, [], {
+      configuredRelayUrls: [lateRelay.url],
+      connectRelay: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return lateRelay;
+      },
+      timeoutMs: 5,
+    })).toEqual([]);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/src/nostr/testing/thread-preview-transcript.test.ts
+++ b/src/nostr/testing/thread-preview-transcript.test.ts
@@ -4,6 +4,7 @@ import {
   matchFilters,
   nip19,
   Relay,
+  type Subscription,
   useWebSocketImplementation as configureWebSocketImplementation,
 } from "nostr-tools";
 import { WebSocket } from "ws";
@@ -239,7 +240,6 @@ describe("thread preview relay transcript", () => {
       eose: 1,
       relayFanout: 2,
     });
-    expect(summary.completionLatencyMs).toBeLessThan(40);
     emitAuditMeasurement({
       scenario: "thread-preview-degraded-relay-local-fixture",
       samples: 1,
@@ -247,20 +247,59 @@ describe("thread preview relay transcript", () => {
     });
   });
 
+  it("settles a terminal subscription close and clears its EOSE timer", async () => {
+    vi.useFakeTimers();
+    try {
+      const completedRelay = new Relay("ws://completed-relay.invalid");
+      const closedRelay = new Relay("ws://closed-relay.invalid");
+      const closedSubscription = {
+        close: vi.fn(),
+        receivedEose: vi.fn(),
+      } as unknown as Subscription;
+      vi.spyOn(completedRelay, "subscribe").mockImplementation((_filters, params) => {
+        queueMicrotask(() => params.oneose?.());
+        return { close: vi.fn() } as unknown as Subscription;
+      });
+      vi.spyOn(closedRelay, "subscribe").mockImplementation((_filters, params) => {
+        queueMicrotask(() => params.onclose?.("relay connection closed"));
+        return closedSubscription;
+      });
+
+      expect(await fetchThreadEventsFromRelays(root.id, [], {
+        configuredRelayUrls: [completedRelay.url, closedRelay.url],
+        connectRelay: async (url) =>
+          url.includes("completed-relay") ? completedRelay : closedRelay,
+        timeoutMs: 2_500,
+      })).toEqual([]);
+
+      expect(closedSubscription.receivedEose).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("closes a connection that arrives after the connection deadline", async () => {
-    const lateRelay = new Relay("ws://late-relay.invalid");
-    const close = vi.spyOn(lateRelay, "close");
+    vi.useFakeTimers();
+    try {
+      const lateRelay = new Relay("ws://late-relay.invalid");
+      const close = vi.spyOn(lateRelay, "close");
+      const result = fetchThreadEventsFromRelays(root.id, [], {
+        configuredRelayUrls: [lateRelay.url],
+        connectRelay: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          return lateRelay;
+        },
+        timeoutMs: 5,
+      });
 
-    expect(await fetchThreadEventsFromRelays(root.id, [], {
-      configuredRelayUrls: [lateRelay.url],
-      connectRelay: async () => {
-        await new Promise((resolve) => setTimeout(resolve, 20));
-        return lateRelay;
-      },
-      timeoutMs: 5,
-    })).toEqual([]);
-    await new Promise((resolve) => setTimeout(resolve, 25));
-
-    expect(close).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(5);
+      expect(await result).toEqual([]);
+      expect(close).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(15);
+      expect(close).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/nostr/testing/thread-transcript.test.ts
+++ b/src/nostr/testing/thread-transcript.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  finalizeEvent,
+  useWebSocketImplementation as configureWebSocketImplementation,
+} from "nostr-tools";
+import { WebSocket } from "ws";
+import { ensureRelaysConnected } from "../client";
+import { subNote } from "../subscriptions/thread";
+import {
+  RelayTranscriptHarness,
+  RelayTranscriptSession,
+  type RelayRequestController,
+} from "./relay-transcript";
+
+configureWebSocketImplementation(WebSocket);
+
+const secretKey = new Uint8Array(32).fill(4);
+const root = finalizeEvent({
+  created_at: 2_000_000_000,
+  kind: 1,
+  tags: [],
+  content: "root",
+}, secretKey);
+const reply = finalizeEvent({
+  created_at: root.created_at + 1,
+  kind: 1,
+  tags: [["e", root.id, "", "reply"]],
+  content: "reply",
+}, secretKey);
+const nestedReply = finalizeEvent({
+  created_at: reply.created_at + 1,
+  kind: 1,
+  tags: [["e", reply.id, "", "reply"]],
+  content: "nested reply with only its immediate parent",
+}, secretKey);
+
+function driveThreadRequest(request: RelayRequestController): void {
+  const [filter] = request.filters;
+  if (filter?.ids?.includes(root.id)) {
+    request.sendEvent(root);
+  } else if (filter?.["#e"]?.includes(reply.id)) {
+    request.sendEvent(reply);
+    request.sendEvent(nestedReply);
+  } else if (filter?.["#e"]?.includes(root.id)) {
+    request.sendEvent(reply);
+  }
+  request.sendEose();
+}
+
+describe("thread relay transcript", () => {
+  const harnesses: RelayTranscriptHarness[] = [];
+
+  afterEach(async () => {
+    await Promise.all(harnesses.splice(0).map((harness) => harness.close()));
+  });
+
+  it("captures hinted-relay duplicates, recursive replacement, and navigation cleanup", async () => {
+    const session = new RelayTranscriptSession();
+    harnesses.push(
+      await RelayTranscriptHarness.listen({ session, onRequest: driveThreadRequest }),
+      await RelayTranscriptHarness.listen({ session, onRequest: driveThreadRequest }),
+    );
+    const relayUrls = harnesses.map((harness) => harness.url);
+    await ensureRelaysConnected(relayUrls);
+
+    const completionLatencies: number[] = [];
+    for (let run = 0; run < 20; run += 1) {
+      const workflow = session.beginWorkflow(`thread-navigation-${run + 1}`);
+      const receivedIds = new Set<string>();
+      const handle = subNote(
+        root.id,
+        (event) => receivedIds.add(event.id),
+        relayUrls,
+      );
+
+      await session.waitFor(() => receivedIds.has(nestedReply.id));
+      handle.close();
+      await session.waitFor(
+        (entries) => entries.filter((entry) => entry.type === "close").length ===
+          (run + 1) * 8,
+      );
+      workflow.complete();
+
+      expect([...receivedIds].sort()).toEqual(
+        [root.id, reply.id, nestedReply.id].sort(),
+      );
+      const summary = session.summary(workflow);
+      expect(summary).toMatchObject({
+        openedConnections: 0,
+        requests: 8,
+        closes: 8,
+        returnedEvents: 12,
+        retries: 0,
+        repeatedOperations: 4,
+        relayFanout: 2,
+      });
+      expect(summary.connectionReuseCount).toBe(6);
+      expect(summary.subscriptionLifetimesMs).toHaveLength(8);
+      completionLatencies.push(summary.completionLatencyMs);
+    }
+
+    const replyRequests = session.entries
+      .filter((entry) => entry.type === "request")
+      .filter((entry) => entry.filters[0]?.["#e"]);
+    expect(
+      [...new Set(replyRequests.map((entry) => entry.filters[0]?.["#e"]?.length))],
+    ).toEqual([1, 2, 3]);
+    if (process.env.RELAY_AUDIT_OUTPUT === "1") {
+      const sorted = [...completionLatencies].sort((a, b) => a - b);
+      const percentile = (value: number) =>
+        sorted[Math.ceil((value / 100) * sorted.length) - 1] ?? 0;
+      console.info(JSON.stringify({
+        scenario: "thread-navigation-local-fixture",
+        samples: sorted.length,
+        completionLatencyMs: {
+          p50: percentile(50),
+          p95: percentile(95),
+          samples: completionLatencies,
+        },
+      }));
+    }
+  });
+});

--- a/src/nostr/testing/thread-transcript.test.ts
+++ b/src/nostr/testing/thread-transcript.test.ts
@@ -5,11 +5,18 @@ import {
 } from "nostr-tools";
 import { WebSocket } from "ws";
 import { ensureRelaysConnected } from "../client";
+import { subNotesOnce } from "../subscriptions";
 import { subNote } from "../subscriptions/thread";
+import {
+  auditSampleCount,
+  emitAuditMeasurement,
+  summarizeSamples,
+} from "./audit-metrics";
 import {
   RelayTranscriptHarness,
   RelayTranscriptSession,
   type RelayRequestController,
+  type RelayTranscriptEntry,
 } from "./relay-transcript";
 
 configureWebSocketImplementation(WebSocket);
@@ -33,6 +40,7 @@ const nestedReply = finalizeEvent({
   tags: [["e", reply.id, "", "reply"]],
   content: "nested reply with only its immediate parent",
 }, secretKey);
+const missingContextId = "f".repeat(64);
 
 function driveThreadRequest(request: RelayRequestController): void {
   const [filter] = request.filters;
@@ -47,6 +55,33 @@ function driveThreadRequest(request: RelayRequestController): void {
   request.sendEose();
 }
 
+function workflowEntries(
+  session: RelayTranscriptSession,
+  startIndex: number,
+  completedIndex: number | undefined,
+): readonly RelayTranscriptEntry[] {
+  return session.entries.slice(startIndex, completedIndex);
+}
+
+function expectMatchingProtocolCompletion(entries: readonly RelayTranscriptEntry[]): void {
+  const requestIds = entries
+    .filter((entry) => entry.type === "request")
+    .map((entry) => entry.subscriptionId)
+    .sort();
+  expect(
+    entries
+      .filter((entry) => entry.type === "eose")
+      .map((entry) => entry.subscriptionId)
+      .sort(),
+  ).toEqual(requestIds);
+  expect(
+    entries
+      .filter((entry) => entry.type === "close")
+      .map((entry) => entry.subscriptionId)
+      .sort(),
+  ).toEqual(requestIds);
+}
+
 describe("thread relay transcript", () => {
   const harnesses: RelayTranscriptHarness[] = [];
 
@@ -54,30 +89,35 @@ describe("thread relay transcript", () => {
     await Promise.all(harnesses.splice(0).map((harness) => harness.close()));
   });
 
-  it("captures hinted-relay duplicates, recursive replacement, and navigation cleanup", async () => {
-    const session = new RelayTranscriptSession();
-    harnesses.push(
-      await RelayTranscriptHarness.listen({ session, onRequest: driveThreadRequest }),
-      await RelayTranscriptHarness.listen({ session, onRequest: driveThreadRequest }),
-    );
-    const relayUrls = harnesses.map((harness) => harness.url);
-    await ensureRelaysConnected(relayUrls);
-
+  it("captures cold connection, duplicates, recursive replacement, and navigation cleanup", async () => {
     const completionLatencies: number[] = [];
-    for (let run = 0; run < 20; run += 1) {
+    const initialContentLatencies: number[] = [];
+    let evidenceEntries: readonly RelayTranscriptEntry[] = [];
+
+    for (let run = 0; run < auditSampleCount(); run += 1) {
+      const session = new RelayTranscriptSession();
+      const runHarnesses = [
+        await RelayTranscriptHarness.listen({ session, onRequest: driveThreadRequest }),
+        await RelayTranscriptHarness.listen({ session, onRequest: driveThreadRequest }),
+      ];
+      harnesses.push(...runHarnesses);
+      const relayUrls = runHarnesses.map((harness) => harness.url);
       const workflow = session.beginWorkflow(`thread-navigation-${run + 1}`);
       const receivedIds = new Set<string>();
-      const handle = subNote(
-        root.id,
-        (event) => receivedIds.add(event.id),
-        relayUrls,
-      );
+      let initialContentLatencyMs: number | undefined;
+
+      await ensureRelaysConnected(relayUrls);
+      const handle = subNote(root.id, (event) => {
+        if (event.id === root.id && initialContentLatencyMs === undefined) {
+          initialContentLatencyMs = Date.now() - workflow.startedAt;
+        }
+        receivedIds.add(event.id);
+      }, relayUrls);
 
       await session.waitFor(() => receivedIds.has(nestedReply.id));
       handle.close();
       await session.waitFor(
-        (entries) => entries.filter((entry) => entry.type === "close").length ===
-          (run + 1) * 8,
+        (entries) => entries.filter((entry) => entry.type === "close").length === 8,
       );
       workflow.complete();
 
@@ -86,7 +126,7 @@ describe("thread relay transcript", () => {
       );
       const summary = session.summary(workflow);
       expect(summary).toMatchObject({
-        openedConnections: 0,
+        openedConnections: 2,
         requests: 8,
         closes: 8,
         returnedEvents: 12,
@@ -96,28 +136,134 @@ describe("thread relay transcript", () => {
       });
       expect(summary.connectionReuseCount).toBe(6);
       expect(summary.subscriptionLifetimesMs).toHaveLength(8);
+
+      const entries = workflowEntries(session, workflow.startIndex, workflow.completedIndex);
+      const requestFilters = entries
+        .filter((entry) => entry.type === "request")
+        .map((entry) => entry.filters);
+      const filterCounts = new Map<string, number>();
+      requestFilters.forEach((filters) => {
+        const key = JSON.stringify(filters);
+        filterCounts.set(key, (filterCounts.get(key) ?? 0) + 1);
+      });
+      expect(filterCounts).toEqual(new Map([
+        [JSON.stringify([{ ids: [root.id], kinds: [1, 1068], limit: 1 }]), 2],
+        [JSON.stringify([{ "#e": [root.id], kinds: [1], limit: 100 }]), 2],
+        [JSON.stringify([{
+          "#e": [root.id, reply.id],
+          kinds: [1],
+          limit: 100,
+        }]), 2],
+        [JSON.stringify([{
+          "#e": [root.id, reply.id, nestedReply.id],
+          kinds: [1],
+          limit: 100,
+        }]), 2],
+      ]));
+      expectMatchingProtocolCompletion(entries);
+
       completionLatencies.push(summary.completionLatencyMs);
+      initialContentLatencies.push(initialContentLatencyMs ?? summary.completionLatencyMs);
+      evidenceEntries = entries;
     }
 
-    const replyRequests = session.entries
-      .filter((entry) => entry.type === "request")
-      .filter((entry) => entry.filters[0]?.["#e"]);
-    expect(
-      [...new Set(replyRequests.map((entry) => entry.filters[0]?.["#e"]?.length))],
-    ).toEqual([1, 2, 3]);
-    if (process.env.RELAY_AUDIT_OUTPUT === "1") {
-      const sorted = [...completionLatencies].sort((a, b) => a - b);
-      const percentile = (value: number) =>
-        sorted[Math.ceil((value / 100) * sorted.length) - 1] ?? 0;
-      console.info(JSON.stringify({
-        scenario: "thread-navigation-local-fixture",
-        samples: sorted.length,
-        completionLatencyMs: {
-          p50: percentile(50),
-          p95: percentile(95),
-          samples: completionLatencies,
+    emitAuditMeasurement({
+      scenario: "thread-navigation-cold-local-fixture",
+      samples: completionLatencies.length,
+      initialContentLatencyMs: summarizeSamples(initialContentLatencies),
+      completionLatencyMs: summarizeSamples(completionLatencies),
+      evidence: {
+        requestBytes: evidenceEntries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.bytes),
+        returnedEventBytes: evidenceEntries
+          .filter((entry) => entry.type === "event-returned")
+          .map((entry) => entry.bytes),
+        subscriptionLifetimesMs: evidenceEntries
+          .filter((entry) => entry.type === "close")
+          .map((entry) => entry.lifetimeMs),
+      },
+    });
+  });
+
+  it("batches referenced context and completes missing IDs at EOSE", async () => {
+    const session = new RelayTranscriptSession();
+    harnesses.push(
+      await RelayTranscriptHarness.listen({
+        session,
+        onRequest(request) {
+          request.sendEvent(root, 10);
+          request.sendEose(10);
         },
-      }));
+      }),
+      await RelayTranscriptHarness.listen({
+        session,
+        onRequest(request) {
+          request.sendEose();
+        },
+      }),
+    );
+    const relayUrls = harnesses.map((harness) => harness.url);
+    await ensureRelaysConnected(relayUrls);
+    const completionLatencies: number[] = [];
+    let evidenceEntries: readonly RelayTranscriptEntry[] = [];
+    for (let run = 0; run < auditSampleCount(); run += 1) {
+      const workflow = session.beginWorkflow(`thread-referenced-context-${run + 1}`);
+      const receivedIds = new Set<string>();
+      const handle = subNotesOnce(
+        [root.id, missingContextId],
+        (event) => receivedIds.add(event.id),
+        relayUrls,
+      );
+      await session.waitFor(
+        (entries) => entries.filter((entry) => entry.type === "close").length ===
+          (run + 1) * 2,
+      );
+      handle.close();
+      workflow.complete();
+
+      expect([...receivedIds]).toEqual([root.id]);
+      const entries = workflowEntries(session, workflow.startIndex, workflow.completedIndex);
+      const requests = entries.filter((entry) => entry.type === "request");
+      expect(requests).toHaveLength(2);
+      expect(requests.every((entry) => entry.filters.length === 1)).toBe(true);
+      expect(requests[0]?.filters).toEqual([{
+        ids: [root.id, missingContextId],
+        kinds: [1],
+        limit: 2,
+      }]);
+      expect(requests[1]?.filters).toEqual(requests[0]?.filters);
+      expectMatchingProtocolCompletion(entries);
+      const summary = session.summary(workflow);
+      expect(summary).toMatchObject({
+        openedConnections: 0,
+        requests: 2,
+        closes: 2,
+        returnedEvents: 1,
+        eose: 2,
+        relayFanout: 2,
+      });
+      completionLatencies.push(summary.completionLatencyMs);
+      evidenceEntries = entries;
     }
+    emitAuditMeasurement({
+      scenario: "thread-referenced-context-warm-local-fixture",
+      samples: completionLatencies.length,
+      completionLatencyMs: summarizeSamples(completionLatencies),
+      evidence: {
+        filters: evidenceEntries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.filters),
+        requestBytes: evidenceEntries
+          .filter((entry) => entry.type === "request")
+          .map((entry) => entry.bytes),
+        returnedEventBytes: evidenceEntries
+          .filter((entry) => entry.type === "event-returned")
+          .map((entry) => entry.bytes),
+        subscriptionLifetimesMs: evidenceEntries
+          .filter((entry) => entry.type === "close")
+          .map((entry) => entry.lifetimeMs),
+      },
+    });
   });
 });

--- a/src/shared/hooks/useProfiles.test.tsx
+++ b/src/shared/hooks/useProfiles.test.tsx
@@ -3,6 +3,7 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Event } from "nostr-tools";
 
 const mocks = vi.hoisted(() => ({
   subProfilesOnce: vi.fn(),
@@ -18,8 +19,20 @@ import { useProfile } from "./useProfiles";
   .IS_REACT_ACT_ENVIRONMENT = true;
 
 function Probe({ pubkey }: { pubkey: string }) {
-  useProfile(pubkey);
-  return null;
+  const profile = useProfile(pubkey);
+  return <span data-pubkey={pubkey}>{profile?.name}</span>;
+}
+
+function profileEvent(pubkey: string, name: string, createdAt: number, id: string): Event {
+  return {
+    id,
+    pubkey,
+    created_at: createdAt,
+    kind: 0,
+    tags: [],
+    content: JSON.stringify({ name }),
+    sig: "c".repeat(128),
+  };
 }
 
 describe("useProfiles batching", () => {
@@ -64,6 +77,52 @@ describe("useProfiles batching", () => {
 
     expect(mocks.subProfilesOnce).toHaveBeenCalledTimes(2);
     expect(mocks.subProfilesOnce.mock.calls[1]?.[0]).toEqual([pubkey]);
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps the newest competing profile and serves later consumers from cache", async () => {
+    const close = vi.fn();
+    mocks.subProfilesOnce.mockResolvedValue({ id: "profiles", close });
+    const pubkey = "b".repeat(64);
+    const container = document.createElement("div");
+    document.body.append(container);
+    containers.push(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<Probe pubkey={pubkey} />);
+      await Promise.resolve();
+    });
+    expect(mocks.subProfilesOnce).toHaveBeenCalledTimes(1);
+
+    const onEvent = mocks.subProfilesOnce.mock.calls[0]?.[1] as
+      | ((event: Event) => void)
+      | undefined;
+    const onEose = mocks.subProfilesOnce.mock.calls[0]?.[2] as
+      | (() => void)
+      | undefined;
+    expect(onEvent).toBeDefined();
+    await act(async () => {
+      onEvent?.(profileEvent(pubkey, "older", 10, "1".repeat(64)));
+      onEvent?.(profileEvent(pubkey, "newest", 20, "2".repeat(64)));
+      onEvent?.(profileEvent(pubkey, "stale", 15, "3".repeat(64)));
+      onEose?.();
+    });
+    expect(container.textContent).toBe("newest");
+    expect(close).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root.render(
+        <>
+          <Probe pubkey={pubkey} />
+          <Probe pubkey={pubkey} />
+        </>,
+      );
+      await Promise.resolve();
+    });
+    expect(container.textContent).toBe("newestnewest");
+    expect(mocks.subProfilesOnce).toHaveBeenCalledTimes(1);
 
     await act(async () => root.unmount());
   });

--- a/src/shared/hooks/useProfiles.test.tsx
+++ b/src/shared/hooks/useProfiles.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  subProfilesOnce: vi.fn(),
+}));
+
+vi.mock("../../nostr/subscriptions", () => ({
+  subProfilesOnce: mocks.subProfilesOnce,
+}));
+
+import { useProfile } from "./useProfiles";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+function Probe({ pubkey }: { pubkey: string }) {
+  useProfile(pubkey);
+  return null;
+}
+
+describe("useProfiles batching", () => {
+  const containers: HTMLDivElement[] = [];
+
+  afterEach(() => {
+    containers.splice(0).forEach((container) => container.remove());
+    mocks.subProfilesOnce.mockReset();
+  });
+
+  it("batches same-task consumers but re-queries a pubkey mounted while its request is live", async () => {
+    mocks.subProfilesOnce.mockResolvedValue({ id: "profiles", close: vi.fn() });
+    const pubkey = "a".repeat(64);
+    const container = document.createElement("div");
+    document.body.append(container);
+    containers.push(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <>
+          <Probe pubkey={pubkey} />
+          <Probe pubkey={pubkey} />
+        </>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(mocks.subProfilesOnce).toHaveBeenCalledTimes(1);
+    expect(mocks.subProfilesOnce.mock.calls[0]?.[0]).toEqual([pubkey]);
+
+    await act(async () => {
+      root.render(
+        <>
+          <Probe pubkey={pubkey} />
+          <Probe pubkey={pubkey} />
+          <Probe pubkey={pubkey} />
+        </>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(mocks.subProfilesOnce).toHaveBeenCalledTimes(2);
+    expect(mocks.subProfilesOnce.mock.calls[1]?.[0]).toEqual([pubkey]);
+
+    await act(async () => root.unmount());
+  });
+});

--- a/src/shared/hooks/useQuotedEvents.test.tsx
+++ b/src/shared/hooks/useQuotedEvents.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { Event } from "nostr-tools";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  refs: [] as Array<{ id: string; relays: string[] }>,
+  loadFeedBootstrapSnapshot: vi.fn(),
+  seedProfiles: vi.fn(),
+  snapshotEventById: vi.fn(),
+  subQuotedEventsOnce: vi.fn(),
+}));
+
+vi.mock("@lib/quotedEvents", () => ({
+  extractQuotedRefs: () => mocks.refs,
+}));
+
+vi.mock("../lib/feedBootstrapClient", () => ({
+  loadFeedBootstrapSnapshot: mocks.loadFeedBootstrapSnapshot,
+  snapshotEventById: mocks.snapshotEventById,
+}));
+
+vi.mock("./useProfiles", () => ({
+  seedProfiles: mocks.seedProfiles,
+}));
+
+vi.mock("../../nostr/subscriptions", () => ({
+  subQuotedEventsOnce: mocks.subQuotedEventsOnce,
+}));
+
+import { useQuotedEvents } from "./useQuotedEvents";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const hostEvent = (id: string): Event => ({
+  id,
+  pubkey: "a".repeat(64),
+  created_at: 1,
+  kind: 1,
+  tags: [],
+  content: "host",
+  sig: "b".repeat(128),
+});
+
+function Probe({ event }: { event: Event }) {
+  const state = useQuotedEvents(event);
+  return (
+    <output
+      data-quoted={state.quotedEvents.map((item) => item.id).join(",")}
+      data-pending={state.pendingRefs.map((item) => item.id).join(",")}
+      data-failed={state.failedRefs.map((item) => item.id).join(",")}
+    />
+  );
+}
+
+describe("useQuotedEvents snapshot and relay ownership", () => {
+  const roots: ReturnType<typeof createRoot>[] = [];
+  const containers: HTMLDivElement[] = [];
+
+  beforeEach(() => {
+    mocks.refs = [];
+    mocks.loadFeedBootstrapSnapshot.mockReset();
+    mocks.seedProfiles.mockReset();
+    mocks.snapshotEventById.mockReset();
+    mocks.subQuotedEventsOnce.mockReset();
+  });
+
+  afterEach(async () => {
+    await act(async () => roots.splice(0).forEach((root) => root.unmount()));
+    containers.splice(0).forEach((container) => container.remove());
+  });
+
+  async function renderProbe() {
+    const container = document.createElement("div");
+    document.body.append(container);
+    containers.push(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => {
+      root.render(<Probe event={hostEvent("9".repeat(64))} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    return { container, root };
+  }
+
+  it("serves a snapshot hit with zero relay subscriptions", async () => {
+    const quoted = hostEvent("1".repeat(64));
+    mocks.refs = [{ id: quoted.id, relays: ["wss://hint.example"] }];
+    mocks.loadFeedBootstrapSnapshot.mockResolvedValue({ profiles: {} });
+    mocks.snapshotEventById.mockReturnValue(new Map([[quoted.id, quoted]]));
+
+    const { container } = await renderProbe();
+
+    expect(container.querySelector("output")?.dataset).toMatchObject({
+      quoted: quoted.id,
+      pending: "",
+      failed: "",
+    });
+    expect(mocks.subQuotedEventsOnce).not.toHaveBeenCalled();
+  });
+
+  it("falls through on a snapshot miss and marks only completed missing refs failed", async () => {
+    const quoted = hostEvent("2".repeat(64));
+    const missingId = "3".repeat(64);
+    mocks.refs = [
+      { id: quoted.id, relays: ["wss://hint.example"] },
+      { id: missingId, relays: [] },
+    ];
+    mocks.loadFeedBootstrapSnapshot.mockResolvedValue({ profiles: {} });
+    mocks.snapshotEventById.mockReturnValue(new Map());
+    const close = vi.fn();
+    mocks.subQuotedEventsOnce.mockResolvedValue({ id: "quotes", close });
+
+    const { container } = await renderProbe();
+    expect(mocks.subQuotedEventsOnce).toHaveBeenCalledTimes(1);
+    expect(mocks.subQuotedEventsOnce.mock.calls[0]?.[0]).toEqual(mocks.refs);
+    const onEvent = mocks.subQuotedEventsOnce.mock.calls[0]?.[1] as
+      | ((event: Event) => void)
+      | undefined;
+    const onEose = mocks.subQuotedEventsOnce.mock.calls[0]?.[2] as
+      | ((id: string) => void)
+      | undefined;
+
+    await act(async () => {
+      onEvent?.(quoted);
+      onEose?.(quoted.id);
+      onEose?.(missingId);
+    });
+    expect(container.querySelector("output")?.dataset).toMatchObject({
+      quoted: quoted.id,
+      pending: "",
+      failed: missingId,
+    });
+  });
+
+  it("falls through when the snapshot request errors", async () => {
+    const quoted = hostEvent("4".repeat(64));
+    mocks.refs = [{ id: quoted.id, relays: [] }];
+    mocks.loadFeedBootstrapSnapshot.mockRejectedValue(new Error("offline"));
+    mocks.subQuotedEventsOnce.mockResolvedValue({ id: "quotes", close: vi.fn() });
+
+    await renderProbe();
+
+    expect(mocks.subQuotedEventsOnce).toHaveBeenCalledTimes(1);
+    expect(mocks.subQuotedEventsOnce.mock.calls[0]?.[0]).toEqual(mocks.refs);
+  });
+
+  it("closes a relay handle that resolves after unmount", async () => {
+    const quoted = hostEvent("5".repeat(64));
+    mocks.refs = [{ id: quoted.id, relays: ["wss://slow.example"] }];
+    mocks.loadFeedBootstrapSnapshot.mockResolvedValue({ profiles: {} });
+    mocks.snapshotEventById.mockReturnValue(new Map());
+    let resolveHandle: ((handle: { id: string; close(): void }) => void) | undefined;
+    mocks.subQuotedEventsOnce.mockReturnValue(new Promise((resolve) => {
+      resolveHandle = resolve;
+    }));
+    const close = vi.fn();
+
+    const { root } = await renderProbe();
+    await act(async () => root.unmount());
+    roots.splice(roots.indexOf(root), 1);
+    await act(async () => {
+      resolveHandle?.({ id: "late", close });
+      await Promise.resolve();
+    });
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/src/shared/hooks/useSubmitForm.test.tsx
+++ b/src/shared/hooks/useSubmitForm.test.tsx
@@ -300,6 +300,38 @@ describe("useSubmitForm", () => {
     expect(mocks.appendKey).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the compose state publishing until relay settlement is visible", async () => {
+    let settlePublish!: (accepted: Set<string>) => void;
+    mocks.publish.mockReturnValue(new Promise<Set<string>>((resolve) => {
+      settlePublish = resolve;
+    }));
+
+    act(() => {
+      root.render(<Probe onState={(nextState) => (state = nextState)} />);
+    });
+    await submitForm();
+    const startedAt = performance.now();
+
+    act(() => {
+      mockWorkers[0].emit({ type: "found", event: minedEvent });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(state.submitStatus).toBe("publishing");
+    expect(state.signedPoWEvent).toBeUndefined();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      settlePublish(new Set(["wss://relay.example"]));
+    });
+
+    expect(performance.now() - startedAt).toBeGreaterThanOrEqual(20);
+    expect(state.submitStatus).toBe("published");
+    expect(state.acceptedRelays).toEqual(["wss://relay.example"]);
+    expect((state.signedPoWEvent as Event | undefined)?.content).toBe("test reply");
+  });
+
   it("enrolls a revenue-tagged browser event before relay publication", async () => {
     mocks.publish.mockResolvedValue(new Set<string>(["wss://relay.example"]));
 

--- a/src/shared/lib/feedBootstrapClient.test.ts
+++ b/src/shared/lib/feedBootstrapClient.test.ts
@@ -4,6 +4,7 @@ import {
   eventsFromSnapshot,
   feedBootstrapUrls,
   fetchFeedBootstrapSnapshot,
+  loadFeedBootstrapSnapshot,
   processedEventsFromSnapshot,
   relayHintsFromSnapshot,
   resetFeedBootstrapSnapshotCache,
@@ -293,5 +294,27 @@ describe("fetchFeedBootstrapSnapshot", () => {
     await expect(
       fetchFeedBootstrapSnapshot(fetcher, "https://snapshot.example/feed.json"),
     ).resolves.toBeNull();
+  });
+});
+
+describe("loadFeedBootstrapSnapshot", () => {
+  it("coalesces a cache miss and serves the subsequent cache hit without I/O", async () => {
+    resetFeedBootstrapSnapshotCache();
+    let resolveFetch: ((response: Response) => void) | undefined;
+    const fetcher = vi.fn(() => new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    }));
+
+    const first = loadFeedBootstrapSnapshot(fetcher, null);
+    const coalesced = loadFeedBootstrapSnapshot(fetcher, null);
+    expect(coalesced).toBe(first);
+    expect(fetcher).toHaveBeenCalledOnce();
+
+    resolveFetch?.(new Response(JSON.stringify(snapshot()), {
+      headers: { "content-type": "application/json" },
+    }));
+    await expect(first).resolves.toEqual(snapshot());
+    await expect(loadFeedBootstrapSnapshot(fetcher, null)).resolves.toEqual(snapshot());
+    expect(fetcher).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## What changed

- adds deterministic local relay transcripts for threads, previews, feeds, notifications, enrichment, and publishing
- removes duplicate quote-hint and discarded notification retrieval without reducing visible results
- makes terminal relay subscriptions settle promptly and avoids duplicate browser relay scheduler ownership
- coalesces concurrent publication of the same event ID, preventing duplicate EVENT fan-out and a caller completion hang
- preserves complete reply, context, metadata, relay-hint, and accepted-relay behavior

## Evidence

- all fixtures use loopback relays; no public relay load is inferred
- publishing partial-accept p95: 9 ms before and after in the controlled fixture
- concurrent same-ID publish: 4 to 2 EVENT frames across two relays; both callers now complete
- exact before/after audit data and recommendation records are linked from wired-admin PR #79

## Validation

- 67 test files / 334 tests passed
- TypeScript typecheck passed
- ESLint: 0 errors; 3 pre-existing Fast Refresh warnings
- two-axis review: zero remaining spec or standards findings

Tracks smolgrrr/wired-admin#72 through #76