### PR TITLE
Gate Wired note media on moderation verdicts

### DIFF
--- a/docs/staging-preview.md
+++ b/docs/staging-preview.md
@@ -24,6 +24,7 @@ The client uses it for:
 - Wired account status and high-PoW post submission
 - private Lightning-address validation and revenue enrollment
 - Wired NIP-57 routing configuration
+- local media-safety verdicts for note/reply images and videos
 
 Production uses `https://relay.wiredsignal.online` for the Wired account API
 via `VITE_WIRED_ACCOUNT_API_BASE`.
@@ -31,5 +32,21 @@ via `VITE_WIRED_ACCOUNT_API_BASE`.
 Revenue requests use `VITE_REVENUE_API_BASE`. The staging backend begins with
 FakeWallet, so `creator@fake.invalid` can exercise the complete simulated flow
 without creating or spending real Lightning funds.
+
+Media moderation preview variables:
+
+```sh
+VITE_MEDIA_MODERATION_API_BASE=https://staging.wiredsignal.online
+VITE_MEDIA_MODERATION_MODE=shadow
+VITE_MEDIA_MODERATION_SURFACES=image,video
+VITE_MEDIA_MODERATION_COHORT_PERCENT=100
+```
+
+`shadow` records decisions without hiding media. For a later enforcement
+canary, use `enforce` with a small stable cohort percentage. The server mode is
+an independent kill switch: an enforcing client will not enforce when Wired
+Admin returns `shadow`. Set the client mode to `off` for immediate rollback.
+Audio, avatars/profile metadata, emoji, and link previews are not sent for
+classification.
 
 Do not commit local `.env*` files.

--- a/docs/staging.env.example
+++ b/docs/staging.env.example
@@ -5,3 +5,7 @@ VITE_ENRICHMENT_RELAYS=wss://staging.wiredsignal.online,wss://relay.damus.io,wss
 VITE_CONFESS_API_BASE=https://staging.wiredsignal.online
 VITE_WIRED_ACCOUNT_API_BASE=https://staging.wiredsignal.online
 VITE_REVENUE_API_BASE=https://staging.wiredsignal.online
+VITE_MEDIA_MODERATION_API_BASE=https://staging.wiredsignal.online
+VITE_MEDIA_MODERATION_MODE=shadow
+VITE_MEDIA_MODERATION_SURFACES=image,video
+VITE_MEDIA_MODERATION_COHORT_PERCENT=100

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from "
 import { closeAllSubscriptions, initNostr, isNostrReady } from "../nostr/client";
 import { FeedStatusIndicatorProvider } from "./FeedStatusIndicatorProvider";
 import { SettingsProvider } from "./settings";
+import { MediaModerationProvider } from "../shared/hooks/useMediaModeration";
 
 type NostrContextValue = {
   ready: boolean;
@@ -42,7 +43,9 @@ export function AppProviders({ children }: { children: ReactNode }) {
   return (
     <SettingsProvider>
       <FeedStatusIndicatorProvider>
-        <NostrProvider>{children}</NostrProvider>
+        <MediaModerationProvider>
+          <NostrProvider>{children}</NostrProvider>
+        </MediaModerationProvider>
       </FeedStatusIndicatorProvider>
     </SettingsProvider>
   );

--- a/src/config.ts
+++ b/src/config.ts
@@ -104,3 +104,34 @@ export const REVENUE_API_BASE = (
 )
   .trim()
   .replace(/\/+$/, "");
+
+export const MEDIA_MODERATION_API_BASE = (
+  configuredEnv("VITE_MEDIA_MODERATION_API_BASE") || WIRED_ACCOUNT_API_BASE
+)
+  .trim()
+  .replace(/\/+$/, "");
+
+const configuredMediaModerationMode = (
+  configuredEnv("VITE_MEDIA_MODERATION_MODE") || "off"
+).toLowerCase();
+
+export const MEDIA_MODERATION_MODE =
+  configuredMediaModerationMode === "shadow" ||
+  configuredMediaModerationMode === "enforce"
+    ? configuredMediaModerationMode
+    : "off";
+
+export const MEDIA_MODERATION_SURFACES = new Set(
+  (configuredEnv("VITE_MEDIA_MODERATION_SURFACES") || "image,video")
+    .split(",")
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value === "image" || value === "video"),
+);
+
+export const MEDIA_MODERATION_COHORT_PERCENT = Math.max(
+  0,
+  Math.min(
+    100,
+    Number(configuredEnv("VITE_MEDIA_MODERATION_COHORT_PERCENT") || 100) || 0,
+  ),
+);

--- a/src/shared/hooks/useMediaModeration.tsx
+++ b/src/shared/hooks/useMediaModeration.tsx
@@ -82,35 +82,46 @@ export function useMediaModeration(event: Event, items: MediaItem[]) {
   const itemKey = moderatedItems
     .map((item) => `${item.type}:${item.url}:${item.sha256 || ""}`)
     .join("|");
-  const [verdicts, setVerdicts] = useState<Map<string, MediaPresentationVerdict>>(
-    () =>
-      new Map(
-        moderatedItems.map((item) => [item.url, ALLOWED_MEDIA_VERDICT] as const),
-      ),
+  const moderationKey = `${event.id}|${itemKey}`;
+  const initialVerdicts = useMemo(
+    () => new Map(
+      moderatedItems.map((item) => [
+        item.url,
+        client?.initialVerdict(item) ?? ALLOWED_MEDIA_VERDICT,
+      ] as const),
+    ),
+    // itemKey represents every moderation-relevant item field.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [client, moderationKey],
   );
+  const [verdictState, setVerdictState] = useState<{
+    key: string;
+    verdicts: Map<string, MediaPresentationVerdict>;
+  }>(() => ({ key: moderationKey, verdicts: initialVerdicts }));
+  const verdicts = verdictState.key === moderationKey
+    ? verdictState.verdicts
+    : initialVerdicts;
 
   useEffect(() => {
+    setVerdictState({ key: moderationKey, verdicts: initialVerdicts });
     if (!client) {
-      setVerdicts(
-        new Map(
-          moderatedItems.map((item) => [item.url, ALLOWED_MEDIA_VERDICT] as const),
-        ),
-      );
       return;
     }
     const stops = moderatedItems.map((item) =>
       client.watch(event, item, (verdict) => {
-        setVerdicts((current) => {
-          const next = new Map(current);
+        setVerdictState((current) => {
+          const next = new Map(
+            current.key === moderationKey ? current.verdicts : initialVerdicts,
+          );
           next.set(item.url, verdict);
-          return next;
+          return { key: moderationKey, verdicts: next };
         });
       }),
     );
     return () => stops.forEach((stop) => stop());
     // itemKey represents every moderation-relevant item field.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [client, event.id, itemKey]);
+  }, [client, event.id, initialVerdicts, itemKey, moderationKey]);
 
   const blocked = [...verdicts.values()].some(
     (verdict) => verdict.enforced && verdict.status === "blocked",

--- a/src/shared/hooks/useMediaModeration.tsx
+++ b/src/shared/hooks/useMediaModeration.tsx
@@ -1,0 +1,119 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import type { Event } from "nostr-tools";
+import {
+  MEDIA_MODERATION_API_BASE,
+  MEDIA_MODERATION_COHORT_PERCENT,
+  MEDIA_MODERATION_MODE,
+  MEDIA_MODERATION_SURFACES,
+} from "../../config";
+import {
+  createMediaModerationClient,
+  type MediaModerationClient,
+} from "../lib/mediaModerationClient";
+import {
+  ALLOWED_MEDIA_VERDICT,
+  type MediaPresentationVerdict,
+} from "../lib/mediaModeration";
+import type { MediaItem } from "../lib/mediaUtils";
+
+const MediaModerationContext = createContext<MediaModerationClient | null>(null);
+const COHORT_STORAGE_KEY = "wiredMediaModerationCohort";
+
+function selectedForMediaModerationCohort(): boolean {
+  if (MEDIA_MODERATION_COHORT_PERCENT >= 100) return true;
+  if (MEDIA_MODERATION_COHORT_PERCENT <= 0) return false;
+  try {
+    const existing = Number(window.localStorage.getItem(COHORT_STORAGE_KEY));
+    const bucket = Number.isInteger(existing) && existing >= 0 && existing < 100
+      ? existing
+      : Math.floor(Math.random() * 100);
+    window.localStorage.setItem(COHORT_STORAGE_KEY, String(bucket));
+    return bucket < MEDIA_MODERATION_COHORT_PERCENT;
+  } catch {
+    return false;
+  }
+}
+
+export function MediaModerationProvider({
+  children,
+  client,
+}: {
+  children: ReactNode;
+  client?: MediaModerationClient;
+}) {
+  const ownedClient = useMemo(
+    () =>
+      client ??
+      createMediaModerationClient({
+        baseUrl: MEDIA_MODERATION_API_BASE,
+        mode: selectedForMediaModerationCohort() ? MEDIA_MODERATION_MODE : "off",
+        enabledMediaTypes: MEDIA_MODERATION_SURFACES,
+      }),
+    [client],
+  );
+
+  useEffect(
+    () => () => {
+      if (!client) ownedClient.close();
+    },
+    [client, ownedClient],
+  );
+
+  return (
+    <MediaModerationContext.Provider value={ownedClient}>
+      {children}
+    </MediaModerationContext.Provider>
+  );
+}
+
+export function useMediaModeration(event: Event, items: MediaItem[]) {
+  const client = useContext(MediaModerationContext);
+  const moderatedItems = useMemo(
+    () => items.filter((item) => item.type === "image" || item.type === "video"),
+    [items],
+  );
+  const itemKey = moderatedItems
+    .map((item) => `${item.type}:${item.url}:${item.sha256 || ""}`)
+    .join("|");
+  const [verdicts, setVerdicts] = useState<Map<string, MediaPresentationVerdict>>(
+    () =>
+      new Map(
+        moderatedItems.map((item) => [item.url, ALLOWED_MEDIA_VERDICT] as const),
+      ),
+  );
+
+  useEffect(() => {
+    if (!client) {
+      setVerdicts(
+        new Map(
+          moderatedItems.map((item) => [item.url, ALLOWED_MEDIA_VERDICT] as const),
+        ),
+      );
+      return;
+    }
+    const stops = moderatedItems.map((item) =>
+      client.watch(event, item, (verdict) => {
+        setVerdicts((current) => {
+          const next = new Map(current);
+          next.set(item.url, verdict);
+          return next;
+        });
+      }),
+    );
+    return () => stops.forEach((stop) => stop());
+    // itemKey represents every moderation-relevant item field.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, event.id, itemKey]);
+
+  const blocked = [...verdicts.values()].some(
+    (verdict) => verdict.enforced && verdict.status === "blocked",
+  );
+  return { blocked, verdicts };
+}

--- a/src/shared/lib/mediaModeration.ts
+++ b/src/shared/lib/mediaModeration.ts
@@ -1,0 +1,26 @@
+export type MediaVerdictStatus =
+  | "allowed"
+  | "blocked"
+  | "pending"
+  | "review-required"
+  | "unavailable"
+  | "stale";
+
+export type MediaPresentationVerdict = {
+  status: MediaVerdictStatus;
+  reason: string;
+  enforced: boolean;
+  expiresAt?: number | null;
+  sha256?: string;
+  perceptualHash?: string;
+};
+
+export const ALLOWED_MEDIA_VERDICT: MediaPresentationVerdict = {
+  status: "allowed",
+  reason: "moderation_disabled",
+  enforced: false,
+};
+
+export function isMediaCovered(verdict?: MediaPresentationVerdict): boolean {
+  return Boolean(verdict?.enforced && verdict.status !== "allowed");
+}

--- a/src/shared/lib/mediaModerationClient.test.ts
+++ b/src/shared/lib/mediaModerationClient.test.ts
@@ -13,6 +13,24 @@ const event = (id: string): Event => ({
 });
 
 describe("media moderation client", () => {
+  it("starts moderated video covered before any effect or request runs", () => {
+    const client = createMediaModerationClient({
+      baseUrl: "https://admin.example",
+      mode: "enforce",
+      fetcher: vi.fn(),
+    });
+
+    expect(client.initialVerdict({
+      url: "https://cdn.example/first-frame.mp4",
+      type: "video",
+    })).toEqual({
+      status: "pending",
+      reason: "verdict_requested",
+      enforced: true,
+    });
+    client.close();
+  });
+
   it("coalesces attachment watches into one bounded batch", async () => {
     const fetcher = vi.fn(async (
       _url: Parameters<typeof fetch>[0],
@@ -147,7 +165,7 @@ describe("media moderation client", () => {
             url: item.url,
             mediaType: "image",
             status: "blocked",
-            reason: "explicit_media_policy",
+            reason: "configured_hash_block",
             expiresAt: Date.now() + 60_000,
           })),
         }), { status: 200, headers: { "Content-Type": "application/json" } });
@@ -191,7 +209,7 @@ describe("media moderation client", () => {
             url: item.url,
             mediaType: "image",
             status: requests === 1 ? "blocked" : "allowed",
-            reason: requests === 1 ? "explicit_media_policy" : "admin_allow_override",
+            reason: requests === 1 ? "configured_hash_block" : "admin_allow_override",
             expiresAt: Date.now() + 60_000,
           })),
         }), { status: 200, headers: { "Content-Type": "application/json" } });

--- a/src/shared/lib/mediaModerationClient.test.ts
+++ b/src/shared/lib/mediaModerationClient.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Event } from "nostr-tools";
+import { createMediaModerationClient } from "./mediaModerationClient";
+
+const event = (id: string): Event => ({
+  id,
+  pubkey: "a".repeat(64),
+  created_at: 1,
+  kind: 1,
+  tags: [],
+  content: "",
+  sig: "b".repeat(128),
+});
+
+describe("media moderation client", () => {
+  it("coalesces attachment watches into one bounded batch", async () => {
+    const fetcher = vi.fn(async (
+      _url: Parameters<typeof fetch>[0],
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body)) as {
+        items: Array<{ requestId: string; event: Event; url: string }>;
+      };
+      return new Response(
+        JSON.stringify({
+          mode: "enforce",
+          policyVersion: "wired-media-v1",
+          verdicts: request.items.map((item) => ({
+            requestId: item.requestId,
+            eventId: item.event.id,
+            url: item.url,
+            mediaType: "image",
+            status: "allowed",
+            reason: "policy_allowed",
+            expiresAt: Date.now() + 60_000,
+          })),
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const client = createMediaModerationClient({
+      baseUrl: "https://admin.example",
+      mode: "enforce",
+      fetcher,
+      batchDelayMs: 0,
+    });
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const stopFirst = client.watch(
+      event("1".repeat(64)),
+      { url: "https://cdn.example/one.jpg", type: "image" },
+      first,
+    );
+    const stopSecond = client.watch(
+      event("2".repeat(64)),
+      { url: "https://cdn.example/two.jpg", type: "image" },
+      second,
+    );
+    await client.waitForIdle();
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body)) as {
+      items: unknown[];
+    };
+    expect(body.items).toHaveLength(2);
+    expect(first).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: "allowed", enforced: true }),
+    );
+    expect(second).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: "allowed", enforced: true }),
+    );
+
+    stopFirst();
+    stopSecond();
+    client.close();
+  });
+
+  it("keeps failures covered in enforcement mode", async () => {
+    const client = createMediaModerationClient({
+      baseUrl: "https://admin.example",
+      mode: "enforce",
+      fetcher: vi.fn(async () => {
+        throw new Error("offline");
+      }),
+      batchDelayMs: 0,
+      retryBaseMs: 60_000,
+    });
+    const listener = vi.fn();
+    const stop = client.watch(
+      event("3".repeat(64)),
+      { url: "https://cdn.example/failure.jpg", type: "image" },
+      listener,
+    );
+    await client.waitForIdle();
+
+    expect(listener).toHaveBeenLastCalledWith({
+      status: "unavailable",
+      reason: "verdict_api_unavailable",
+      enforced: true,
+    });
+    stop();
+    client.close();
+  });
+
+  it("leaves disabled media surfaces unmoderated without calling the API", () => {
+    const fetcher = vi.fn();
+    const client = createMediaModerationClient({
+      baseUrl: "https://admin.example",
+      mode: "enforce",
+      fetcher,
+      enabledMediaTypes: new Set(["image"]),
+    });
+    const listener = vi.fn();
+
+    const stop = client.watch(
+      event("4".repeat(64)),
+      { url: "https://cdn.example/video.mp4", type: "video" },
+      listener,
+    );
+
+    expect(listener).toHaveBeenCalledWith({
+      status: "allowed",
+      reason: "moderation_disabled",
+      enforced: false,
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+    stop();
+    client.close();
+  });
+
+  it("does not enforce verdicts while the server remains in shadow mode", async () => {
+    const client = createMediaModerationClient({
+      baseUrl: "https://admin.example",
+      mode: "enforce",
+      batchDelayMs: 0,
+      fetcher: vi.fn(async (_url, init) => {
+        const request = JSON.parse(String(init?.body)) as {
+          items: Array<{ requestId: string; event: Event; url: string }>;
+        };
+        return new Response(JSON.stringify({
+          mode: "shadow",
+          policyVersion: "wired-media-v1",
+          verdicts: request.items.map((item) => ({
+            requestId: item.requestId,
+            eventId: item.event.id,
+            url: item.url,
+            mediaType: "image",
+            status: "blocked",
+            reason: "explicit_media_policy",
+            expiresAt: Date.now() + 60_000,
+          })),
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }),
+    });
+    const listener = vi.fn();
+    const stop = client.watch(
+      event("5".repeat(64)),
+      { url: "https://cdn.example/shadow.jpg", type: "image" },
+      listener,
+    );
+
+    await client.waitForIdle();
+
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({
+      status: "blocked",
+      enforced: false,
+    }));
+    stop();
+    client.close();
+  });
+
+  it("refreshes terminal verdicts so an admin allow override can restore media", async () => {
+    let requests = 0;
+    const client = createMediaModerationClient({
+      baseUrl: "https://admin.example",
+      mode: "enforce",
+      batchDelayMs: 0,
+      terminalRefreshMs: 5,
+      fetcher: vi.fn(async (_url, init) => {
+        requests += 1;
+        const request = JSON.parse(String(init?.body)) as {
+          items: Array<{ requestId: string; event: Event; url: string }>;
+        };
+        return new Response(JSON.stringify({
+          mode: "enforce",
+          policyVersion: "wired-media-v1",
+          verdicts: request.items.map((item) => ({
+            requestId: item.requestId,
+            eventId: item.event.id,
+            url: item.url,
+            mediaType: "image",
+            status: requests === 1 ? "blocked" : "allowed",
+            reason: requests === 1 ? "explicit_media_policy" : "admin_allow_override",
+            expiresAt: Date.now() + 60_000,
+          })),
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }),
+    });
+    const listener = vi.fn();
+    const stop = client.watch(
+      event("6".repeat(64)),
+      { url: "https://cdn.example/overridden.jpg", type: "image" },
+      listener,
+    );
+
+    await vi.waitFor(() => {
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+        status: "allowed",
+        reason: "admin_allow_override",
+      }));
+    });
+
+    expect(requests).toBeGreaterThanOrEqual(2);
+    stop();
+    client.close();
+  });
+});

--- a/src/shared/lib/mediaModerationClient.ts
+++ b/src/shared/lib/mediaModerationClient.ts
@@ -250,6 +250,22 @@ export function createMediaModerationClient({
     };
   }
 
+  function initialVerdict(item: MediaItem): MediaPresentationVerdict {
+    if (
+      item.type === "audio" ||
+      !enabledMediaTypes.has(item.type) ||
+      mode === "off" ||
+      !normalizedBaseUrl
+    ) {
+      return disabledVerdict();
+    }
+    return {
+      status: "pending",
+      reason: "verdict_requested",
+      enforced: mode === "enforce",
+    };
+  }
+
   async function waitForIdle(timeoutMs = 2_000): Promise<boolean> {
     const deadline = Date.now() + timeoutMs;
     while (flushTimer || queued.size > 0 || activeRequests.size > 0) {
@@ -270,5 +286,5 @@ export function createMediaModerationClient({
     queued.clear();
   }
 
-  return { close, waitForIdle, watch };
+  return { close, initialVerdict, waitForIdle, watch };
 }

--- a/src/shared/lib/mediaModerationClient.ts
+++ b/src/shared/lib/mediaModerationClient.ts
@@ -1,0 +1,274 @@
+import type { Event } from "nostr-tools";
+import type { MediaItem } from "./mediaUtils";
+import type {
+  MediaPresentationVerdict,
+  MediaVerdictStatus,
+} from "./mediaModeration";
+
+export type MediaModerationMode = "off" | "shadow" | "enforce";
+type VerdictListener = (verdict: MediaPresentationVerdict) => void;
+
+type ServerVerdict = {
+  requestId: string;
+  eventId: string;
+  url: string;
+  mediaType: "image" | "video";
+  status: MediaVerdictStatus;
+  reason: string;
+  expiresAt: number | null;
+  sha256?: string;
+  perceptualHash?: string;
+};
+
+type ServerResponse = {
+  mode: MediaModerationMode;
+  policyVersion: string;
+  verdicts: ServerVerdict[];
+};
+
+type Entry = {
+  key: string;
+  event: Event;
+  item: MediaItem;
+  verdict: MediaPresentationVerdict;
+  listeners: Set<VerdictListener>;
+  retryAttempt: number;
+  retryTimer?: ReturnType<typeof setTimeout>;
+};
+
+type MediaModerationClientOptions = {
+  baseUrl: string;
+  mode: MediaModerationMode;
+  fetcher?: typeof fetch;
+  batchDelayMs?: number;
+  retryBaseMs?: number;
+  terminalRefreshMs?: number;
+  enabledMediaTypes?: ReadonlySet<"image" | "video">;
+};
+
+export type MediaModerationClient = ReturnType<typeof createMediaModerationClient>;
+
+function keyFor(event: Event, item: MediaItem): string {
+  return `${event.id}:${item.url}`;
+}
+
+function disabledVerdict(): MediaPresentationVerdict {
+  return { status: "allowed", reason: "moderation_disabled", enforced: false };
+}
+
+export function createMediaModerationClient({
+  baseUrl,
+  mode,
+  fetcher = fetch,
+  batchDelayMs = 8,
+  retryBaseMs = 1_000,
+  terminalRefreshMs = 15 * 60 * 1_000,
+  enabledMediaTypes = new Set(["image", "video"]),
+}: MediaModerationClientOptions) {
+  const normalizedBaseUrl = baseUrl.trim().replace(/\/+$/, "");
+  const entries = new Map<string, Entry>();
+  const queued = new Map<string, Entry>();
+  const activeRequests = new Set<Promise<void>>();
+  let flushTimer: ReturnType<typeof setTimeout> | undefined;
+  let closed = false;
+
+  function notify(entry: Entry, verdict: MediaPresentationVerdict): void {
+    entry.verdict = verdict;
+    for (const listener of entry.listeners) listener(verdict);
+  }
+
+  function scheduleRetry(entry: Entry): void {
+    if (closed || entry.listeners.size === 0 || entry.retryTimer) return;
+    const delay = Math.min(30_000, retryBaseMs * 2 ** entry.retryAttempt);
+    entry.retryAttempt += 1;
+    entry.retryTimer = setTimeout(() => {
+      entry.retryTimer = undefined;
+      queue(entry);
+    }, delay);
+  }
+
+  function scheduleTerminalRefresh(entry: Entry): void {
+    if (closed || entry.listeners.size === 0 || entry.retryTimer) return;
+    const untilExpiry = entry.verdict.expiresAt
+      ? Math.max(0, entry.verdict.expiresAt - Date.now())
+      : terminalRefreshMs;
+    const delay = Math.min(terminalRefreshMs, untilExpiry);
+    entry.retryTimer = setTimeout(() => {
+      entry.retryTimer = undefined;
+      notify(entry, {
+        status: "stale",
+        reason: "verdict_refreshing",
+        enforced: mode === "enforce",
+      });
+      queue(entry);
+    }, delay);
+  }
+
+  function queue(entry: Entry): void {
+    if (closed || mode === "off" || !normalizedBaseUrl) return;
+    queued.set(entry.key, entry);
+    if (flushTimer) return;
+    flushTimer = setTimeout(() => {
+      flushTimer = undefined;
+      flush();
+    }, batchDelayMs);
+  }
+
+  async function send(batch: Entry[]): Promise<void> {
+    try {
+      const response = await fetcher(
+        `${normalizedBaseUrl}/api/media-moderation/verdicts`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            items: batch.map((entry) => ({
+              requestId: entry.key,
+              event: entry.event,
+              mediaType: entry.item.type,
+              url: entry.item.url,
+              ...(entry.item.sha256 ? { claimedHash: entry.item.sha256 } : {}),
+            })),
+          }),
+        },
+      );
+      if (!response.ok) throw new Error(`verdict API returned ${response.status}`);
+      const payload = (await response.json()) as ServerResponse;
+      const verdicts = new Map(
+        payload.verdicts.map((verdict) => [verdict.requestId, verdict]),
+      );
+      for (const entry of batch) {
+        const serverVerdict = verdicts.get(entry.key);
+        if (!serverVerdict) {
+          notify(entry, {
+            status: "unavailable",
+            reason: "missing_batch_verdict",
+            enforced: mode === "enforce",
+          });
+          scheduleRetry(entry);
+          continue;
+        }
+        entry.retryAttempt = 0;
+        notify(entry, {
+          status: serverVerdict.status,
+          reason: serverVerdict.reason,
+          enforced: mode === "enforce" && payload.mode === "enforce",
+          expiresAt: serverVerdict.expiresAt,
+          ...(serverVerdict.sha256 ? { sha256: serverVerdict.sha256 } : {}),
+          ...(serverVerdict.perceptualHash
+            ? { perceptualHash: serverVerdict.perceptualHash }
+            : {}),
+        });
+        if (
+          serverVerdict.status === "pending" ||
+          serverVerdict.status === "unavailable" ||
+          serverVerdict.status === "stale"
+        ) {
+          scheduleRetry(entry);
+        } else {
+          scheduleTerminalRefresh(entry);
+        }
+      }
+    } catch {
+      for (const entry of batch) {
+        notify(entry, {
+          status: "unavailable",
+          reason: "verdict_api_unavailable",
+          enforced: mode === "enforce",
+        });
+        scheduleRetry(entry);
+      }
+    }
+  }
+
+  function flush(): void {
+    if (closed || queued.size === 0) return;
+    const batch = [...queued.values()].slice(0, 100);
+    for (const entry of batch) queued.delete(entry.key);
+    const request = send(batch).finally(() => {
+      activeRequests.delete(request);
+      if (queued.size > 0) queue([...queued.values()][0] as Entry);
+    });
+    activeRequests.add(request);
+  }
+
+  function watch(event: Event, item: MediaItem, listener: VerdictListener): () => void {
+    if (
+      item.type === "audio" ||
+      !enabledMediaTypes.has(item.type) ||
+      mode === "off" ||
+      !normalizedBaseUrl
+    ) {
+      listener(disabledVerdict());
+      return () => undefined;
+    }
+
+    const key = keyFor(event, item);
+    let entry = entries.get(key);
+    if (!entry) {
+      entry = {
+        key,
+        event,
+        item,
+        verdict: {
+          status: "pending",
+          reason: "verdict_requested",
+          enforced: mode === "enforce",
+        },
+        listeners: new Set(),
+        retryAttempt: 0,
+      };
+      entries.set(key, entry);
+      queue(entry);
+    } else if (
+      entry.verdict.expiresAt &&
+      entry.verdict.expiresAt <= Date.now()
+    ) {
+      notify(entry, {
+        status: "stale",
+        reason: "verdict_expired",
+        enforced: mode === "enforce",
+      });
+      queue(entry);
+    }
+    entry.listeners.add(listener);
+    listener(entry.verdict);
+    if (
+      entry.verdict.status !== "pending" &&
+      entry.verdict.status !== "unavailable" &&
+      entry.verdict.status !== "stale"
+    ) {
+      scheduleTerminalRefresh(entry);
+    }
+
+    return () => {
+      entry?.listeners.delete(listener);
+      if (entry?.listeners.size === 0 && entry.retryTimer) {
+        clearTimeout(entry.retryTimer);
+        entry.retryTimer = undefined;
+      }
+    };
+  }
+
+  async function waitForIdle(timeoutMs = 2_000): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (flushTimer || queued.size > 0 || activeRequests.size > 0) {
+      if (Date.now() >= deadline) return false;
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    return true;
+  }
+
+  function close(): void {
+    closed = true;
+    if (flushTimer) clearTimeout(flushTimer);
+    flushTimer = undefined;
+    for (const entry of entries.values()) {
+      if (entry.retryTimer) clearTimeout(entry.retryTimer);
+      entry.listeners.clear();
+    }
+    queued.clear();
+  }
+
+  return { close, waitForIdle, watch };
+}

--- a/src/shared/lib/mediaUtils.ts
+++ b/src/shared/lib/mediaUtils.ts
@@ -11,6 +11,7 @@ export type MediaItem = {
   width?: number;
   height?: number;
   posterUrl?: string;
+  sha256?: string;
 };
 
 const MEDIA_URL_PATTERN =
@@ -66,6 +67,7 @@ function parseImetaFields(tag: string[]): {
   width?: number;
   height?: number;
   posterUrl?: string;
+  sha256?: string;
 } {
   const fields: Record<string, string> = {};
 
@@ -84,6 +86,7 @@ function parseImetaFields(tag: string[]): {
     width: dim ? Number(dim[1]) : undefined,
     height: dim ? Number(dim[2]) : undefined,
     posterUrl: fields.image ?? fields.thumb,
+    sha256: fields.x,
   };
 }
 
@@ -93,7 +96,7 @@ export function parseImetaTags(tags: string[][]): MediaItem[] {
   for (const tag of tags) {
     if (tag[0] !== "imeta") continue;
 
-    const { url, mime, width, height, posterUrl } = parseImetaFields(tag);
+    const { url, mime, width, height, posterUrl, sha256 } = parseImetaFields(tag);
     if (!url) continue;
 
     const normalized = normalizeUrl(url);
@@ -110,6 +113,9 @@ export function parseImetaTags(tags: string[][]): MediaItem[] {
       ...(width ? { width } : {}),
       ...(height ? { height } : {}),
       ...(normalizedPosterUrl ? { posterUrl: normalizedPosterUrl } : {}),
+      ...(sha256 && /^[0-9a-f]{64}$/i.test(sha256)
+        ? { sha256: sha256.toLowerCase() }
+        : {}),
     });
   }
 

--- a/src/shared/ui/AttachmentStack.tsx
+++ b/src/shared/ui/AttachmentStack.tsx
@@ -2,15 +2,18 @@ import type { Attachment } from "@lib/content";
 import { segmentAttachments } from "@lib/attachmentSegments";
 import { LinkPreview } from "./LinkPreview";
 import { MediaAttachment, MediaGrid } from "./NoteMedia";
+import type { MediaPresentationVerdict } from "../lib/mediaModeration";
 
 export function AttachmentStack({
   attachments,
   compact,
   imagePriority = false,
+  mediaVerdicts,
 }: {
   attachments: Attachment[];
   compact?: boolean;
   imagePriority?: boolean;
+  mediaVerdicts?: ReadonlyMap<string, MediaPresentationVerdict>;
 }) {
   if (attachments.length === 0) return null;
 
@@ -32,6 +35,7 @@ export function AttachmentStack({
               hiddenCount={segment.hiddenCount}
               compact={compact}
               priority={imagePriority}
+              verdicts={mediaVerdicts}
             />
           );
         }
@@ -44,6 +48,7 @@ export function AttachmentStack({
               item={attachment.item}
               compact={compact}
               priority={imagePriority}
+              verdict={mediaVerdicts?.get(attachment.item.url)}
             />
           );
         }

--- a/src/shared/ui/NoteMedia.test.tsx
+++ b/src/shared/ui/NoteMedia.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MediaAttachment, MediaGrid, NoteMedia } from "./NoteMedia";
+import type { MediaPresentationVerdict } from "../lib/mediaModeration";
 
 (
   globalThis as typeof globalThis & {
@@ -349,5 +350,58 @@ describe("NoteMedia video previews", () => {
 
     expect(container.querySelector("video")).toBeNull();
     expect(container.textContent).toContain("signal lost");
+  });
+
+  it("preloads a pending image only behind an opaque moderation cover", () => {
+    const verdict: MediaPresentationVerdict = {
+      status: "pending",
+      reason: "analysis_queued",
+      enforced: true,
+    };
+    act(() => {
+      root.render(
+        <MediaAttachment
+          item={{ url: "https://example.com/pending.jpg", type: "image" }}
+          verdict={verdict}
+        />,
+      );
+    });
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      "https://example.com/pending.jpg",
+    );
+    const cover = container.querySelector("[data-media-cover='true']");
+    expect(cover).not.toBeNull();
+    expect(cover?.className).toContain("bg-surface");
+    expect(container.textContent).toContain("checking media");
+  });
+
+  it("does not assign a video source before an allowed verdict", () => {
+    act(() => {
+      root.render(
+        <MediaAttachment
+          item={{ url: "https://example.com/pending.mp4", type: "video" }}
+          verdict={{ status: "pending", reason: "analysis_queued", enforced: true }}
+        />,
+      );
+    });
+
+    expect(container.querySelector("video")).toBeNull();
+    expect(container.innerHTML).not.toContain("https://example.com/pending.mp4");
+    expect(container.textContent).toContain("checking media");
+  });
+
+  it("reveals media when enforcement is shadow-only", () => {
+    act(() => {
+      root.render(
+        <MediaAttachment
+          item={{ url: "https://example.com/shadow.jpg", type: "image" }}
+          verdict={{ status: "blocked", reason: "model", enforced: false }}
+        />,
+      );
+    });
+
+    expect(container.querySelector("img")).not.toBeNull();
+    expect(container.querySelector("[data-media-cover='true']")).toBeNull();
   });
 });

--- a/src/shared/ui/NoteMedia.tsx
+++ b/src/shared/ui/NoteMedia.tsx
@@ -6,12 +6,30 @@ import {
   pickOptimizedWidth,
 } from "@lib/optimizedImageUrl";
 import { useInView } from "../hooks/useInView";
+import {
+  isMediaCovered,
+  type MediaPresentationVerdict,
+} from "../lib/mediaModeration";
 
 function MediaFallback() {
   return (
     <p className="text-meta text-muted py-2" role="status">
       signal lost
     </p>
+  );
+}
+
+function ModerationCover({ verdict }: { verdict: MediaPresentationVerdict }) {
+  const label = verdict.status === "pending" ? "checking media" : "media unavailable";
+  return (
+    <div
+      data-media-cover="true"
+      className="absolute inset-0 z-10 flex items-center justify-center rounded border border-ghost bg-surface text-meta text-muted"
+      role="status"
+      aria-label={label}
+    >
+      {label}
+    </div>
   );
 }
 
@@ -146,6 +164,7 @@ function MediaImage({
       loading={priority ? "eager" : "lazy"}
       {...(priority ? { fetchpriority: "high" } : {})}
       decoding="async"
+      referrerPolicy="no-referrer"
       onError={() => {
         onError();
         if (!isOptimized) setFailed(true);
@@ -166,12 +185,14 @@ function GridImage({
   hiddenCount = 0,
   fillHeight = false,
   priority = false,
+  verdict,
 }: {
   item: MediaItem;
   compact?: boolean;
   hiddenCount?: number;
   fillHeight?: boolean;
   priority?: boolean;
+  verdict?: MediaPresentationVerdict;
 }) {
   const [failed, setFailed] = useState(false);
   const maxWidth = compact ? 384 : 640;
@@ -202,6 +223,7 @@ function GridImage({
         loading={priority ? "eager" : "lazy"}
         {...(priority ? { fetchpriority: "high" } : {})}
         decoding="async"
+        referrerPolicy="no-referrer"
         onError={() => {
           onError();
           if (!isOptimized) setFailed(true);
@@ -219,6 +241,7 @@ function GridImage({
           +{hiddenCount}
         </div>
       )}
+      {isMediaCovered(verdict) && verdict && <ModerationCover verdict={verdict} />}
     </div>
   );
 }
@@ -358,19 +381,47 @@ export function MediaAttachment({
   item,
   compact,
   priority = false,
+  verdict,
 }: {
   item: MediaItem;
   compact?: boolean;
   priority?: boolean;
+  verdict?: MediaPresentationVerdict;
 }) {
+  const covered = isMediaCovered(verdict);
+  if (covered && item.type === "video" && verdict) {
+    return (
+      <div
+        className={videoWrapperClasses(getOrientation(item.width, item.height), compact)}
+        style={{ aspectRatio: aspectRatioFromDimensions(item.width, item.height) }}
+      >
+        <ModerationCover verdict={verdict} />
+      </div>
+    );
+  }
+
+  let media;
   switch (item.type) {
     case "image":
-      return <MediaImage item={item} compact={compact} priority={priority} />;
+      media = <MediaImage item={item} compact={compact} priority={priority} />;
+      break;
     case "video":
-      return <MediaVideo item={item} compact={compact} priority={priority} />;
+      media = <MediaVideo item={item} compact={compact} priority={priority} />;
+      break;
     case "audio":
       return <MediaAudio item={item} />;
   }
+
+  if (!covered || !verdict) return media;
+  return (
+    <div
+      className="relative overflow-hidden rounded"
+      style={{ aspectRatio: aspectRatioFromDimensions(item.width, item.height) }}
+    >
+      {media}
+      <ModerationCover verdict={verdict} />
+    </div>
+  );
 }
 
 export function MediaGrid({
@@ -378,19 +429,21 @@ export function MediaGrid({
   hiddenCount = 0,
   compact,
   priority = false,
+  verdicts,
 }: {
   items: MediaItem[];
   hiddenCount?: number;
   compact?: boolean;
   priority?: boolean;
+  verdicts?: ReadonlyMap<string, MediaPresentationVerdict>;
 }) {
   if (items.length === 0) return null;
 
   if (items.length === 2) {
     return (
       <div className="grid grid-cols-2 gap-3">
-        <GridImage item={items[0]} compact={compact} priority={priority} />
-        <GridImage item={items[1]} compact={compact} />
+        <GridImage item={items[0]} compact={compact} priority={priority} verdict={verdicts?.get(items[0].url)} />
+        <GridImage item={items[1]} compact={compact} verdict={verdicts?.get(items[1].url)} />
       </div>
     );
   }
@@ -399,29 +452,36 @@ export function MediaGrid({
     return (
       <div className="grid grid-cols-2 grid-rows-2 gap-3">
         <div className="row-span-2 min-h-0">
-          <GridImage item={items[0]} compact={compact} fillHeight priority={priority} />
+          <GridImage item={items[0]} compact={compact} fillHeight priority={priority} verdict={verdicts?.get(items[0].url)} />
         </div>
-        <GridImage item={items[1]} compact={compact} />
-        <GridImage item={items[2]} compact={compact} />
+        <GridImage item={items[1]} compact={compact} verdict={verdicts?.get(items[1].url)} />
+        <GridImage item={items[2]} compact={compact} verdict={verdicts?.get(items[2].url)} />
       </div>
     );
   }
 
   return (
     <div className="grid grid-cols-2 gap-3">
-      <GridImage item={items[0]} compact={compact} priority={priority} />
-      <GridImage item={items[1]} compact={compact} />
-      <GridImage item={items[2]} compact={compact} />
+      <GridImage item={items[0]} compact={compact} priority={priority} verdict={verdicts?.get(items[0].url)} />
+      <GridImage item={items[1]} compact={compact} verdict={verdicts?.get(items[1].url)} />
+      <GridImage item={items[2]} compact={compact} verdict={verdicts?.get(items[2].url)} />
       <GridImage
         item={items[3]}
         compact={compact}
         hiddenCount={hiddenCount}
+        verdict={verdicts?.get(items[3].url)}
       />
     </div>
   );
 }
 
-export function NoteMedia({ items }: { items: MediaItem[] }) {
+export function NoteMedia({
+  items,
+  verdicts,
+}: {
+  items: MediaItem[];
+  verdicts?: ReadonlyMap<string, MediaPresentationVerdict>;
+}) {
   if (items.length === 0) return null;
 
   return (
@@ -430,7 +490,7 @@ export function NoteMedia({ items }: { items: MediaItem[] }) {
       aria-label={items.length > 1 ? `${items.length} attachments` : "attachment"}
     >
       {items.map((item) => (
-        <MediaAttachment key={item.url} item={item} />
+        <MediaAttachment key={item.url} item={item} verdict={verdicts?.get(item.url)} />
       ))}
     </div>
   );

--- a/src/shared/ui/PostCard.test.tsx
+++ b/src/shared/ui/PostCard.test.tsx
@@ -5,6 +5,8 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Event } from "nostr-tools";
 import { PostCard } from "./PostCard";
+import { MediaModerationProvider } from "../hooks/useMediaModeration";
+import { createMediaModerationClient } from "../lib/mediaModerationClient";
 
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
@@ -223,5 +225,54 @@ describe("PostCard thread opening", () => {
 
     expect(container.querySelector("button[aria-label='Share this thread']")).toBeNull();
     expect(container.textContent).not.toContain("wiredsignal.online");
+  });
+
+  it("hides the entire note when one attachment receives a blocked verdict", async () => {
+    const blockedEvent = event({
+      content: "photo https://example.com/blocked.jpg",
+    });
+    const client = createMediaModerationClient({
+      baseUrl: "https://admin.example",
+      mode: "enforce",
+      batchDelayMs: 0,
+      fetcher: vi.fn(async (_input, init) => {
+        const request = JSON.parse(String(init?.body)) as {
+          items: Array<{ requestId: string; url: string }>;
+        };
+        return new Response(
+          JSON.stringify({
+            mode: "enforce",
+            policyVersion: "wired-media-v1",
+            verdicts: request.items.map((item) => ({
+              requestId: item.requestId,
+              eventId: blockedEvent.id,
+              url: item.url,
+              mediaType: "image",
+              status: "blocked",
+              reason: "exact_hash_block",
+              expiresAt: Date.now() + 60_000,
+            })),
+          }),
+          { status: 200 },
+        );
+      }),
+    });
+
+    act(() => {
+      root.render(
+        <MediaModerationProvider client={client}>
+          <PostCard event={blockedEvent} replies={[]} totalWork={16} />
+        </MediaModerationProvider>,
+      );
+    });
+    expect(container.querySelector("article")).not.toBeNull();
+    expect(container.querySelector("[data-media-cover='true']")).not.toBeNull();
+
+    await act(async () => {
+      await client.waitForIdle();
+    });
+
+    expect(container.querySelector("article")).toBeNull();
+    client.close();
   });
 });

--- a/src/shared/ui/PostCard.tsx
+++ b/src/shared/ui/PostCard.tsx
@@ -12,6 +12,8 @@ import { useProfile } from "../hooks/useProfiles";
 import { useMemo, useCallback, type KeyboardEvent, type MouseEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { ShareControl } from "./ShareControl";
+import { extractMedia } from "../lib/mediaUtils";
+import { useMediaModeration } from "../hooks/useMediaModeration";
 
 interface PostCardProps {
   event: Event;
@@ -106,6 +108,8 @@ export function PostCard({
   onOpenThread,
 }: PostCardProps) {
   const navigate = useNavigate();
+  const mediaItems = useMemo(() => extractMedia(event), [event]);
+  const mediaModeration = useMediaModeration(event, mediaItems);
 
   const relatedEvents = useMemo(() => [event, ...(replies || [])], [event, replies]);
   const profile = useProfile(event.pubkey);
@@ -155,6 +159,8 @@ export function PostCard({
     ? `Open thread by ${authorLabel}, signal ${signal}, ${timestamp}`
     : `Post by ${authorLabel}, signal ${signal}, ${timestamp}`;
 
+  if (mediaModeration.blocked) return null;
+
   return (
     <article
       role={isNavigable ? "link" : "group"}
@@ -191,7 +197,11 @@ export function PostCard({
       </header>
 
       <div className="post-content flex flex-col gap-2 break-words">
-        <TextContent eventdata={event} imagePriority={imagePriority} />
+        <TextContent
+          eventdata={event}
+          imagePriority={imagePriority}
+          mediaVerdicts={mediaModeration.verdicts}
+        />
         {repliedTo && repliedTo.length > 0 && (
           <ReplyContext events={uniqBy(repliedTo, "pubkey")} />
         )}

--- a/src/shared/ui/QuotePreview.tsx
+++ b/src/shared/ui/QuotePreview.tsx
@@ -6,6 +6,7 @@ import { useProfile } from "../hooks/useProfiles";
 import { AttachmentStack } from "./AttachmentStack";
 import { LinkedBodyText } from "./LinkedBodyText";
 import { SignalAvatar } from "./SignalAvatar";
+import { useMediaModeration } from "../hooks/useMediaModeration";
 
 const PREVIEW_LENGTH = 280;
 
@@ -13,11 +14,17 @@ export function QuotePreview({ event }: { event: Event }) {
   const profile = useProfile(event.pubkey);
   const authorLabel = getDisplayName(profile, event.pubkey);
   const { comment, attachments } = parseContent(event);
+  const mediaItems = attachments.flatMap((attachment) =>
+    attachment.kind === "media" ? [attachment.item] : [],
+  );
+  const mediaModeration = useMediaModeration(event, mediaItems);
   const emojis = getBodyEmojis(event.tags);
   const preview =
     comment.length > PREVIEW_LENGTH
       ? `${comment.slice(0, PREVIEW_LENGTH)}…`
       : comment;
+
+  if (mediaModeration.blocked) return null;
 
   return (
     <div
@@ -40,7 +47,11 @@ export function QuotePreview({ event }: { event: Event }) {
       )}
       {attachments.length > 0 && (
         <div className="mt-2">
-          <AttachmentStack attachments={attachments} compact />
+          <AttachmentStack
+            attachments={attachments}
+            compact
+            mediaVerdicts={mediaModeration.verdicts}
+          />
         </div>
       )}
     </div>

--- a/src/shared/ui/TextContent.tsx
+++ b/src/shared/ui/TextContent.tsx
@@ -8,15 +8,18 @@ import { QuotePreview } from "./QuotePreview";
 import { QuotePreviewPlaceholder } from "./QuotePreviewPlaceholder";
 import { Button } from "./Button";
 import { LinkedBodyText } from "./LinkedBodyText";
+import type { MediaPresentationVerdict } from "../lib/mediaModeration";
 
 const COLLAPSED_LENGTH = 750;
 
 export function TextContent({
   eventdata,
   imagePriority = false,
+  mediaVerdicts,
 }: {
   eventdata: Event;
   imagePriority?: boolean;
+  mediaVerdicts?: ReadonlyMap<string, MediaPresentationVerdict>;
 }) {
   const { comment, attachments } = parseContent(eventdata);
   const emojis = getBodyEmojis(eventdata.tags);
@@ -42,7 +45,11 @@ export function TextContent({
         </Button>
       )}
       {attachments.length > 0 && (
-        <AttachmentStack attachments={attachments} imagePriority={imagePriority} />
+        <AttachmentStack
+          attachments={attachments}
+          imagePriority={imagePriority}
+          mediaVerdicts={mediaVerdicts}
+        />
       )}
       {quotedEvents.map((quoted) => (
         <QuotePreview key={quoted.id} event={quoted} />


### PR DESCRIPTION
## Summary

- batch and deduplicate image/video verdict requests across rendered notes and replies
- synchronously cover moderated media on the first render
- allow pending images to preload behind a fully opaque cover while withholding video and poster sources until allowed
- hide the whole note or reply for explicit blocked verdicts without hiding its parent thread
- keep audio, avatars/profile metadata, emoji, and link previews on their existing paths
- support off, shadow, enforce, media-surface, and stable cohort rollout controls
- retry unavailable/pending decisions and periodically refresh terminal decisions so admin overrides propagate

## Verification

- npm run lint (0 errors; existing Fast Refresh warnings only)
- npm run build
- npm test (312 tests)
- npm audit --omit=dev (0 vulnerabilities)
- required standards/spec review completed with no remaining critical/high findings

The Vercel preview is built in shadow mode against https://staging.wiredsignal.online. Existing upload and Blossom delivery behavior is unchanged.

Spec: https://github.com/smolgrrr/wired-admin/issues/51
Implementation tickets: https://github.com/smolgrrr/wired-admin/issues/52 and https://github.com/smolgrrr/wired-admin/issues/57