### PR TITLE
Add bounded browser relay evidence collection

### DIFF
--- a/src/contracts/relay-workflow-evidence.test-fixtures.ts
+++ b/src/contracts/relay-workflow-evidence.test-fixtures.ts
@@ -1,0 +1,34 @@
+import type { RelayWorkflowEvidence } from "./relay-workflow-evidence";
+
+export const validRelayWorkflowEvidence = {
+  query: {
+    schemaVersion: 1,
+    workflowOwner: "wired.browser.thread",
+    operation: "query",
+    outcome: "completed",
+    work: { attempts: 1, targets: 2 },
+    connections: { opened: 2, closed: 2, reused: 0, lateClosed: 0 },
+    relay: {
+      requestsSent: 4,
+      eventsPublished: 0,
+      eventsReceived: 6,
+      requestBytes: 512,
+      eventBytesSent: 0,
+      eventBytesReceived: 2_048,
+    },
+    results: { unique: 3, duplicates: 3, coalescedOperations: 0 },
+    terminal: {
+      eose: 4,
+      closed: 0,
+      connectFailed: 0,
+      timedOut: 0,
+      cancelled: 0,
+    },
+    publishing: {
+      acceptedCountBucket: "none",
+      rejected: 0,
+      ownerRetries: 0,
+    },
+    timingMs: { firstResult: 8, completion: 31 },
+  },
+} satisfies Record<string, RelayWorkflowEvidence>;

--- a/src/nostr/client.ts
+++ b/src/nostr/client.ts
@@ -6,20 +6,36 @@ import {
 } from "../config";
 import { RelayPool } from "./relay-pool";
 import { SubscriptionRegistry } from "./subscription-registry";
+import {
+  RelayWorkflowCollector,
+  type RelayWorkflowAggregate,
+} from "./evidence/relay-workflow-collector";
 
 export { THREAD_RELAYS } from "../config";
 
 let pool: RelayPool | null = null;
 let registry: SubscriptionRegistry | null = null;
 let connectPromise: Promise<void> | null = null;
+const workflowEvidence = new RelayWorkflowCollector();
 
 export const PROFILE_RELAYS = [...CONFIG_THREAD_RELAYS];
 
 function ensureNostrClient(): void {
   if (!pool) {
-    pool = new RelayPool();
+    pool = new RelayPool({ workflowEvidence });
     registry = new SubscriptionRegistry(pool);
   }
+}
+
+export function getRelayWorkflowEvidence(): RelayWorkflowAggregate[] {
+  return workflowEvidence.snapshot();
+}
+
+export function getRelayWorkflowEvidenceStatus(): {
+  pending: number;
+  dropped: number;
+} {
+  return pool?.workflowEvidenceStatus ?? { pending: 0, dropped: 0 };
 }
 
 export function initNostr(): Promise<void> {

--- a/src/nostr/evidence/relay-workflow-collector.test.ts
+++ b/src/nostr/evidence/relay-workflow-collector.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { validRelayWorkflowEvidence } from "../../contracts/relay-workflow-evidence.test-fixtures";
+import { RelayWorkflowCollector } from "./relay-workflow-collector";
+
+describe("RelayWorkflowCollector", () => {
+  it("aggregates approved fields into fixed buckets", () => {
+    const collector = new RelayWorkflowCollector();
+
+    collector.record(validRelayWorkflowEvidence.query);
+    collector.record(validRelayWorkflowEvidence.query);
+
+    expect(collector.snapshot()).toEqual([expect.objectContaining({
+      schemaVersion: 1,
+      workflowOwner: "wired.browser.thread",
+      operation: "query",
+      outcome: "completed",
+      samples: 2,
+      totals: expect.objectContaining({
+        targets: 4,
+        requestsSent: 8,
+        uniqueResults: 6,
+      }),
+      completionMs: { "50": 2 },
+    })]);
+  });
+
+  it("saturates counters and ignores invalid evidence", () => {
+    const collector = new RelayWorkflowCollector({ counterLimit: 2 });
+
+    collector.record(validRelayWorkflowEvidence.query);
+    collector.record(validRelayWorkflowEvidence.query);
+    collector.record(validRelayWorkflowEvidence.query);
+    collector.record({ ...validRelayWorkflowEvidence.query, eventId: "forbidden" });
+
+    expect(collector.snapshot()[0]).toMatchObject({ samples: 2, overflowed: 1 });
+    expect(collector.invalidCount).toBe(1);
+  });
+
+  it("normalizes invalid counter limits", () => {
+    const collector = new RelayWorkflowCollector({ counterLimit: Number.NaN });
+    collector.record(validRelayWorkflowEvidence.query);
+
+    expect(collector.snapshot()[0]?.samples).toBe(1);
+  });
+});

--- a/src/nostr/evidence/relay-workflow-collector.ts
+++ b/src/nostr/evidence/relay-workflow-collector.ts
@@ -1,0 +1,149 @@
+import {
+  RELAY_ACCEPTED_COUNT_BUCKETS,
+  RELAY_EVIDENCE_LIMITS,
+  isRelayWorkflowEvidence,
+  type RelayWorkflowEvidence,
+} from "../../contracts/relay-workflow-evidence";
+
+const DURATION_BUCKETS_MS = [
+  10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 60_000, 3_600_000,
+] as const;
+
+type CounterGroup = Record<string, number>;
+
+export type RelayWorkflowAggregate = {
+  schemaVersion: 1;
+  workflowOwner: RelayWorkflowEvidence["workflowOwner"];
+  operation: RelayWorkflowEvidence["operation"];
+  outcome: RelayWorkflowEvidence["outcome"];
+  samples: number;
+  overflowed: number;
+  totals: CounterGroup;
+  acceptedCountBuckets: CounterGroup;
+  firstResultMs: CounterGroup;
+  completionMs: CounterGroup;
+};
+
+type MutableAggregate = RelayWorkflowAggregate;
+
+export type RelayWorkflowEvidenceRecorder = {
+  record(evidence: unknown): void;
+};
+
+export class RelayWorkflowCollector implements RelayWorkflowEvidenceRecorder {
+  private readonly aggregates = new Map<string, MutableAggregate>();
+  private readonly counterLimit: number;
+  private invalid = 0;
+
+  constructor(options: { counterLimit?: number } = {}) {
+    const requestedLimit = options.counterLimit;
+    this.counterLimit = typeof requestedLimit === "number" &&
+      Number.isFinite(requestedLimit) && Number.isInteger(requestedLimit) &&
+      requestedLimit > 0
+      ? Math.min(requestedLimit, RELAY_EVIDENCE_LIMITS.count)
+      : RELAY_EVIDENCE_LIMITS.count;
+  }
+
+  get invalidCount(): number {
+    return this.invalid;
+  }
+
+  record(evidence: unknown): void {
+    if (!isRelayWorkflowEvidence(evidence)) {
+      this.invalid = this.add(this.invalid, 1);
+      return;
+    }
+
+    const key = [
+      evidence.workflowOwner,
+      evidence.operation,
+      evidence.outcome,
+    ].join("|");
+    const aggregate = this.aggregates.get(key) ?? this.createAggregate(evidence);
+    if (aggregate.samples >= this.counterLimit) {
+      aggregate.overflowed = this.add(aggregate.overflowed, 1);
+      this.aggregates.set(key, aggregate);
+      return;
+    }
+
+    aggregate.samples = this.add(aggregate.samples, 1);
+    const totals = {
+      attempts: evidence.work.attempts,
+      targets: evidence.work.targets,
+      connectionsOpened: evidence.connections.opened,
+      connectionsClosed: evidence.connections.closed,
+      connectionsReused: evidence.connections.reused,
+      lateConnectionsClosed: evidence.connections.lateClosed,
+      requestsSent: evidence.relay.requestsSent,
+      eventsPublished: evidence.relay.eventsPublished,
+      eventsReceived: evidence.relay.eventsReceived,
+      requestBytes: evidence.relay.requestBytes,
+      eventBytesSent: evidence.relay.eventBytesSent,
+      eventBytesReceived: evidence.relay.eventBytesReceived,
+      uniqueResults: evidence.results.unique,
+      duplicates: evidence.results.duplicates,
+      coalescedOperations: evidence.results.coalescedOperations,
+      eose: evidence.terminal.eose,
+      terminalClosed: evidence.terminal.closed,
+      connectFailed: evidence.terminal.connectFailed,
+      timedOut: evidence.terminal.timedOut,
+      cancelled: evidence.terminal.cancelled,
+      rejected: evidence.publishing.rejected,
+      ownerRetries: evidence.publishing.ownerRetries,
+    };
+    Object.entries(totals).forEach(([name, value]) => {
+      aggregate.totals[name] = this.add(aggregate.totals[name] ?? 0, value);
+    });
+    aggregate.acceptedCountBuckets[evidence.publishing.acceptedCountBucket] =
+      this.add(
+        aggregate.acceptedCountBuckets[evidence.publishing.acceptedCountBucket] ?? 0,
+        1,
+      );
+    if (evidence.timingMs.firstResult === null) {
+      aggregate.firstResultMs.none = this.add(aggregate.firstResultMs.none ?? 0, 1);
+    } else {
+      this.addDuration(aggregate.firstResultMs, evidence.timingMs.firstResult);
+    }
+    this.addDuration(aggregate.completionMs, evidence.timingMs.completion);
+    this.aggregates.set(key, aggregate);
+  }
+
+  snapshot(): RelayWorkflowAggregate[] {
+    return [...this.aggregates.values()]
+      .sort((left, right) =>
+        [left.workflowOwner, left.operation, left.outcome].join("|")
+          .localeCompare([right.workflowOwner, right.operation, right.outcome].join("|"))
+      )
+      .map((aggregate) => structuredClone(aggregate));
+  }
+
+  private createAggregate(
+    evidence: RelayWorkflowEvidence,
+  ): MutableAggregate {
+    return {
+      schemaVersion: 1,
+      workflowOwner: evidence.workflowOwner,
+      operation: evidence.operation,
+      outcome: evidence.outcome,
+      samples: 0,
+      overflowed: 0,
+      totals: {},
+      acceptedCountBuckets: Object.fromEntries(
+        RELAY_ACCEPTED_COUNT_BUCKETS.map((bucket) => [bucket, 0]),
+      ),
+      firstResultMs: {},
+      completionMs: {},
+    };
+  }
+
+  private addDuration(group: CounterGroup, durationMs: number): void {
+    const bucket = DURATION_BUCKETS_MS.find((upperBound) =>
+      durationMs <= upperBound
+    ) ?? DURATION_BUCKETS_MS.at(-1)!;
+    group[String(bucket)] = this.add(group[String(bucket)] ?? 0, 1);
+  }
+
+  private add(current: number, increment: number): number {
+    return Math.min(this.counterLimit, current + increment);
+  }
+}

--- a/src/nostr/relay-pool.test.ts
+++ b/src/nostr/relay-pool.test.ts
@@ -71,4 +71,166 @@ describe("RelayPool", () => {
     expect(subscription.receivedEose).toHaveBeenCalledOnce();
     expect(pool.connectedUrls).toEqual([]);
   });
+
+  it("records browser publishing without changing accepted relays", async () => {
+    const recorder = { record: vi.fn() };
+    const acceptedRelay = relay("wss://accepted.example");
+    acceptedRelay.publish.mockResolvedValue("accepted");
+    mocks.connect.mockImplementation((url: string) =>
+      url === acceptedRelay.url
+        ? Promise.resolve(acceptedRelay)
+        : Promise.reject(new Error("offline"))
+    );
+    const pool = new RelayPool({ workflowEvidence: recorder });
+
+    await pool.connect([acceptedRelay.url, "wss://offline.example"]);
+    const accepted = await pool.publish({
+      id: "1".repeat(64),
+      pubkey: "2".repeat(64),
+      sig: "3".repeat(128),
+      kind: 1,
+      created_at: 1,
+      tags: [],
+      content: "not exported",
+    });
+
+    expect(accepted).toEqual(new Set([acceptedRelay.url]));
+    await vi.waitFor(() => expect(recorder.record).toHaveBeenCalledOnce());
+    expect(recorder.record).toHaveBeenCalledWith(expect.objectContaining({
+      workflowOwner: "wired.browser.publish",
+      operation: "publish",
+      outcome: "partial",
+      work: { attempts: 1, targets: 2 },
+      connections: expect.objectContaining({ reused: 1 }),
+      publishing: expect.objectContaining({ acceptedCountBucket: "one" }),
+      timingMs: { firstResult: null, completion: expect.any(Number) },
+    }));
+    expect(JSON.stringify(recorder.record.mock.calls)).not.toContain("not exported");
+    expect(JSON.stringify(recorder.record.mock.calls)).not.toContain(acceptedRelay.url);
+  });
+
+  it("does not let a failing recorder affect browser publication", async () => {
+    const connectedRelay = relay("wss://accepted.example");
+    connectedRelay.publish.mockResolvedValue("accepted");
+    mocks.connect.mockResolvedValue(connectedRelay);
+    let evidenceTask: (() => void) | undefined;
+    const recorder = { record: vi.fn(() => { throw new Error("collector full"); }) };
+    const pool = new RelayPool({
+      workflowEvidence: recorder,
+      scheduleEvidence(task) { evidenceTask = task; },
+    });
+
+    await pool.connect([connectedRelay.url]);
+
+    await expect(pool.publish({
+      id: "1".repeat(64),
+      pubkey: "2".repeat(64),
+      sig: "3".repeat(128),
+      kind: 1,
+      created_at: 1,
+      tags: [],
+      content: "event",
+    })).resolves.toEqual(new Set([connectedRelay.url]));
+    expect(recorder.record).not.toHaveBeenCalled();
+    expect(() => evidenceTask?.()).not.toThrow();
+    expect(recorder.record).toHaveBeenCalledOnce();
+    expect(pool.workflowEvidenceStatus.dropped).toBe(1);
+  });
+
+  it("counts evidence discarded by a failing scheduler", async () => {
+    const connectedRelay = relay("wss://accepted.example");
+    connectedRelay.publish.mockResolvedValue("accepted");
+    mocks.connect.mockResolvedValue(connectedRelay);
+    const pool = new RelayPool({
+      workflowEvidence: { record: vi.fn() },
+      scheduleEvidence() { throw new Error("scheduler unavailable"); },
+    });
+    await pool.connect([connectedRelay.url]);
+
+    await expect(pool.publish({
+      id: "6".repeat(64), pubkey: "2".repeat(64), sig: "3".repeat(128),
+      kind: 1, created_at: 1, tags: [], content: "event",
+    })).resolves.toEqual(new Set([connectedRelay.url]));
+    expect(pool.workflowEvidenceStatus).toEqual({ pending: 0, dropped: 1 });
+  });
+
+  it("captures rejection state when each relay settles", async () => {
+    const rejectedRelay = relay("wss://rejected.example");
+    const delayedRelay = relay("wss://delayed.example");
+    rejectedRelay.publish.mockRejectedValue(new Error("blocked"));
+    let releaseDelayed: (() => void) | undefined;
+    delayedRelay.publish.mockImplementation(() => new Promise<string>((resolve) => {
+      releaseDelayed = () => resolve("accepted");
+    }));
+    mocks.connect.mockImplementation((url: string) =>
+      Promise.resolve(url === rejectedRelay.url ? rejectedRelay : delayedRelay)
+    );
+    let evidenceTask: (() => void) | undefined;
+    const recorder = { record: vi.fn() };
+    const pool = new RelayPool({
+      workflowEvidence: recorder,
+      scheduleEvidence(task) { evidenceTask = task; },
+    });
+    await pool.connect([rejectedRelay.url, delayedRelay.url]);
+
+    const publishing = pool.publish({
+      id: "4".repeat(64), pubkey: "2".repeat(64), sig: "3".repeat(128),
+      kind: 1, created_at: 1, tags: [], content: "event",
+    });
+    await vi.waitFor(() => expect(rejectedRelay.publish).toHaveBeenCalled());
+    rejectedRelay.connected = false;
+    releaseDelayed?.();
+    await publishing;
+    evidenceTask?.();
+
+    expect(recorder.record).toHaveBeenCalledWith(expect.objectContaining({
+      terminal: expect.objectContaining({ closed: 0 }),
+      publishing: expect.objectContaining({ rejected: 1 }),
+    }));
+  });
+
+  it("bounds deferred evidence and queues only immutable primitives", async () => {
+    const connectedRelay = relay("wss://accepted.example");
+    connectedRelay.publish.mockResolvedValue("accepted");
+    mocks.connect.mockResolvedValue(connectedRelay);
+    let flushEvidence: (() => void) | undefined;
+    const recorder = { record: vi.fn() };
+    const pool = new RelayPool({
+      workflowEvidence: recorder,
+      scheduleEvidence(task) { flushEvidence = task; },
+    });
+    await pool.connect([connectedRelay.url]);
+    const mutableEvent = {
+      id: "5".repeat(64), pubkey: "2".repeat(64), sig: "3".repeat(128),
+      kind: 1, created_at: 1, tags: [], content: "short",
+    };
+    const originalBytes = new TextEncoder().encode(
+      JSON.stringify(["EVENT", mutableEvent]),
+    ).byteLength;
+
+    await pool.publish(mutableEvent);
+    mutableEvent.content = "changed after settlement".repeat(1_000);
+    for (let index = 0; index < 99; index += 1) {
+      await pool.publish({ ...mutableEvent, id: index.toString(16).padStart(64, "0") });
+    }
+
+    expect(pool.workflowEvidenceStatus).toEqual({ pending: 100, dropped: 0 });
+    flushEvidence?.();
+    expect(recorder.record).toHaveBeenCalledTimes(100);
+    expect(recorder.record.mock.calls[0]?.[0]).toMatchObject({
+      relay: { eventBytesSent: originalBytes },
+    });
+
+    recorder.record.mockClear();
+    for (let index = 0; index < 101; index += 1) {
+      await pool.publish({
+        ...mutableEvent,
+        id: `a${index.toString(16)}`.padStart(64, "0"),
+      });
+    }
+    expect(pool.workflowEvidenceStatus).toEqual({ pending: 100, dropped: 1 });
+    flushEvidence?.();
+    expect(pool.workflowEvidenceStatus).toEqual({ pending: 0, dropped: 1 });
+    expect(recorder.record).toHaveBeenCalledTimes(100);
+  });
 });

--- a/src/nostr/relay-pool.ts
+++ b/src/nostr/relay-pool.ts
@@ -1,7 +1,15 @@
 import { Event, Filter, Relay, Subscription } from "nostr-tools";
 import type { SubCallback } from "./types";
+import {
+  RELAY_EVIDENCE_LIMITS,
+  relayAcceptedCountBucket,
+  relayWorkflowOutcome,
+  type RelayWorkflowEvidence,
+} from "../contracts/relay-workflow-evidence";
+import type { RelayWorkflowEvidenceRecorder } from "./evidence/relay-workflow-collector";
 
 const RELAY_CONNECT_TIMEOUT_MS = 4_000;
+const MAX_PENDING_EVIDENCE_TASKS = 100;
 
 export type SubscribeOptions = {
   closeOnEose?: boolean;
@@ -9,11 +17,35 @@ export type SubscribeOptions = {
   onEose?: () => void;
 };
 
+type RelayPoolOptions = {
+  workflowEvidence?: RelayWorkflowEvidenceRecorder;
+  scheduleEvidence?: (task: () => void) => void;
+};
+
+type InFlightPublish = {
+  promise: Promise<Set<string>>;
+  coalescedOperations: number;
+};
+
+type PublishSettlement = "accepted" | "rejected" | "closed";
+
 export class RelayPool {
   private readonly relays = new Map<string, Relay>();
   private readonly subscriptionsByRelay = new Map<string, Set<Subscription>>();
   private defaultRelayUrls = new Set<string>();
-  private readonly inFlightPublishes = new Map<string, Promise<Set<string>>>();
+  private readonly inFlightPublishes = new Map<string, InFlightPublish>();
+  private readonly workflowEvidence?: RelayWorkflowEvidenceRecorder;
+  private readonly scheduleEvidence: (task: () => void) => void;
+  private readonly evidenceTasks: Array<() => void> = [];
+  private evidenceFlushScheduled = false;
+  private droppedEvidenceTasks = 0;
+
+  constructor(options: RelayPoolOptions = {}) {
+    this.workflowEvidence = options.workflowEvidence;
+    this.scheduleEvidence = options.scheduleEvidence ?? ((task) => {
+      setTimeout(task, 0);
+    });
+  }
 
   get connectedUrls(): string[] {
     return [...this.relays.keys()];
@@ -21,6 +53,13 @@ export class RelayPool {
 
   get isConnected(): boolean {
     return this.defaultRelayUrls.size > 0;
+  }
+
+  get workflowEvidenceStatus(): { pending: number; dropped: number } {
+    return {
+      pending: this.evidenceTasks.length,
+      dropped: this.droppedEvidenceTasks,
+    };
   }
 
   async connect(urls: readonly string[]): Promise<void> {
@@ -120,33 +159,188 @@ export class RelayPool {
 
   publish(event: Event): Promise<Set<string>> {
     const existing = this.inFlightPublishes.get(event.id);
-    if (existing) return existing;
+    if (existing) {
+      existing.coalescedOperations += 1;
+      return existing.promise;
+    }
 
-    const publish = this.publishToRelays(event).finally(() => {
-      if (this.inFlightPublishes.get(event.id) === publish) {
+    const operation: InFlightPublish = {
+      promise: Promise.resolve(new Set()),
+      coalescedOperations: 0,
+    };
+    const publish = this.publishToRelays(event, operation).finally(() => {
+      if (this.inFlightPublishes.get(event.id) === operation) {
         this.inFlightPublishes.delete(event.id);
       }
     });
-    this.inFlightPublishes.set(event.id, publish);
+    operation.promise = publish;
+    this.inFlightPublishes.set(event.id, operation);
     return publish;
   }
 
-  private async publishToRelays(event: Event): Promise<Set<string>> {
+  private async publishToRelays(
+    event: Event,
+    operation: InFlightPublish,
+  ): Promise<Set<string>> {
+    const startedAt = this.workflowEvidence ? performance.now() : 0;
     const accepted = new Set<string>();
+    const targetUrls = [...this.defaultRelayUrls];
+    const connectedTargets = targetUrls.flatMap((url) => {
+      const relay = this.relays.get(url);
+      return relay ? [{ url, relay }] : [];
+    });
 
-    await Promise.allSettled(
-      [...this.defaultRelayUrls].map(async (url) => {
-        const relay = this.relays.get(url);
-        if (!relay) return;
+    const settlements: PublishSettlement[] = await Promise.all(
+      connectedTargets.map(async ({ url, relay }) => {
         try {
           await relay.publish(event);
           accepted.add(url);
+          return "accepted" as const;
         } catch {
-          // Relay rejected or failed the publish.
+          return relay.connected ? "rejected" as const : "closed" as const;
         }
       }),
     );
 
+    if (!this.workflowEvidence) return accepted;
+
+    const completion = performance.now();
+    const terminalClosed = settlements.filter((result) => result === "closed").length;
+    const explicitRejections = settlements.filter((result) =>
+      result === "rejected"
+    ).length;
+    let eventFrameBytes = 0;
+    try {
+      eventFrameBytes = new TextEncoder().encode(
+        JSON.stringify(["EVENT", event]),
+      ).byteLength;
+    } catch {
+      // Byte evidence is optional and cannot affect publication completion.
+    }
+    const primitives = {
+      acceptedCount: accepted.size,
+      coalescedOperations: operation.coalescedOperations,
+      completionMs: completion - startedAt,
+      connectedTargetCount: connectedTargets.length,
+      eventFrameBytes,
+      explicitRejections,
+      terminalClosed,
+      targetCount: targetUrls.length,
+    };
+    this.deferEvidence(() => this.recordPublishEvidence(primitives));
+
     return accepted;
+  }
+
+  private recordPublishEvidence(
+    primitives: {
+      acceptedCount: number;
+      coalescedOperations: number;
+      completionMs: number;
+      connectedTargetCount: number;
+      eventFrameBytes: number;
+      explicitRejections: number;
+      terminalClosed: number;
+      targetCount: number;
+    },
+  ): void {
+    // Only ACKed or explicitly rejected publishes confirm that the relay parsed
+    // the EVENT. A terminal close is retained separately and never treated as
+    // evidence of relay traffic.
+    const confirmedEventFrames =
+      primitives.acceptedCount + primitives.explicitRejections;
+    const evidence: RelayWorkflowEvidence = {
+      schemaVersion: 1,
+      workflowOwner: "wired.browser.publish",
+      operation: "publish",
+      outcome: relayWorkflowOutcome({
+        targets: primitives.targetCount,
+        successfulTargets: primitives.acceptedCount,
+        timedOut: 0,
+        cancelled: 0,
+      }),
+      work: { attempts: 1, targets: primitives.targetCount },
+      connections: {
+        opened: 0,
+        closed: primitives.terminalClosed,
+        reused: primitives.connectedTargetCount,
+        lateClosed: 0,
+      },
+      relay: {
+        requestsSent: 0,
+        eventsPublished: confirmedEventFrames,
+        eventsReceived: 0,
+        requestBytes: 0,
+        eventBytesSent: Math.min(
+          RELAY_EVIDENCE_LIMITS.bytes,
+          primitives.eventFrameBytes * confirmedEventFrames,
+        ),
+        eventBytesReceived: 0,
+      },
+      results: {
+        unique: 0,
+        duplicates: 0,
+        coalescedOperations: primitives.coalescedOperations,
+      },
+      terminal: {
+        eose: 0,
+        closed: primitives.terminalClosed,
+        connectFailed: primitives.targetCount - primitives.connectedTargetCount,
+        timedOut: 0,
+        cancelled: 0,
+      },
+      publishing: {
+        acceptedCountBucket: relayAcceptedCountBucket(
+          primitives.acceptedCount,
+          primitives.targetCount,
+        ),
+        rejected: primitives.explicitRejections,
+        ownerRetries: 0,
+      },
+      timingMs: {
+        firstResult: null,
+        completion: Math.min(
+          RELAY_EVIDENCE_LIMITS.durationMs,
+          Math.max(0, Math.round(primitives.completionMs)),
+        ),
+      },
+    };
+    this.workflowEvidence?.record(evidence);
+  }
+
+  private deferEvidence(task: () => void): void {
+    if (this.evidenceTasks.length >= MAX_PENDING_EVIDENCE_TASKS) {
+      this.evidenceTasks.shift();
+      this.incrementDroppedEvidence();
+    }
+    this.evidenceTasks.push(task);
+    if (this.evidenceFlushScheduled) return;
+
+    this.evidenceFlushScheduled = true;
+    try {
+      this.scheduleEvidence(() => {
+        this.evidenceFlushScheduled = false;
+        const pending = this.evidenceTasks.splice(0);
+        pending.forEach((pendingTask) => {
+          try {
+            pendingTask();
+          } catch {
+            // Evidence collection cannot affect publication completion.
+            this.incrementDroppedEvidence();
+          }
+        });
+      });
+    } catch {
+      this.evidenceFlushScheduled = false;
+      const dropped = this.evidenceTasks.splice(0).length;
+      this.incrementDroppedEvidence(dropped);
+    }
+  }
+
+  private incrementDroppedEvidence(count = 1): void {
+    this.droppedEvidenceTasks = Math.min(
+      RELAY_EVIDENCE_LIMITS.count,
+      this.droppedEvidenceTasks + count,
+    );
   }
 }

--- a/src/nostr/testing/publish-transcript.test.ts
+++ b/src/nostr/testing/publish-transcript.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   finalizeEvent,
   useWebSocketImplementation as configureWebSocketImplementation,
 } from "nostr-tools";
 import { WebSocket } from "ws";
 import { RelayPool } from "../relay-pool";
+import { RelayWorkflowCollector } from "../evidence/relay-workflow-collector";
 import {
   auditSampleCount,
   emitAuditMeasurement,
@@ -106,7 +107,8 @@ describe("browser publish relay transcript", () => {
       },
     });
     harnesses.push(rejectedRelay, disconnectedRelay);
-    const pool = new RelayPool();
+    const recorder = { record: vi.fn() };
+    const pool = new RelayPool({ workflowEvidence: recorder });
     await pool.connect([rejectedRelay.url, disconnectedRelay.url]);
     const workflow = session.beginWorkflow("browser-publish-reject-disconnect");
     expect(await pool.publish(event)).toEqual(new Set());
@@ -118,6 +120,13 @@ describe("browser publish relay transcript", () => {
       rejections: 1,
       relayFanout: 2,
     });
+    await vi.waitFor(() => expect(recorder.record).toHaveBeenCalledOnce());
+    expect(recorder.record).toHaveBeenCalledWith(expect.objectContaining({
+      connections: expect.objectContaining({ closed: 1 }),
+      terminal: expect.objectContaining({ closed: 1 }),
+      publishing: expect.objectContaining({ rejected: 1 }),
+      relay: expect.objectContaining({ eventsPublished: 1 }),
+    }));
   });
 
   it("does not complete an unacknowledged publish until the relay disconnects", async () => {
@@ -204,5 +213,57 @@ describe("browser publish relay transcript", () => {
       repeatedOperations: 1,
       relayFanout: 2,
     });
+  });
+
+  it("keeps disabled, enabled, full, and failing collection timing-equivalent", async () => {
+    const session = new RelayTranscriptSession();
+    const runHarnesses = [
+      await RelayTranscriptHarness.listen({
+        session,
+        onPublish(publish) { publish.acknowledge(true, "", 5); },
+      }),
+      await RelayTranscriptHarness.listen({
+        session,
+        onPublish(publish) { publish.acknowledge(false, "blocked", 5); },
+      }),
+    ];
+    harnesses.push(...runHarnesses);
+    const variants = [
+      { name: "disabled", recorder: undefined },
+      { name: "enabled", recorder: new RelayWorkflowCollector() },
+      { name: "full", recorder: new RelayWorkflowCollector({ counterLimit: 1 }) },
+      {
+        name: "failing",
+        recorder: { record() { throw new Error("unavailable"); } },
+      },
+    ];
+    const p95ByVariant = new Map<string, number>();
+
+    for (const variant of variants) {
+      const pool = new RelayPool({ workflowEvidence: variant.recorder });
+      await pool.connect(runHarnesses.map((harness) => harness.url));
+      const latencies: number[] = [];
+      for (let run = 0; run < 20; run += 1) {
+        const workflow = session.beginWorkflow(`${variant.name}-${run}`);
+        expect(await pool.publish(event)).toEqual(new Set([runHarnesses[0].url]));
+        workflow.complete();
+        latencies.push(session.summary(workflow).completionLatencyMs);
+      }
+      p95ByVariant.set(
+        variant.name,
+        summarizeSamples(latencies).p95,
+      );
+    }
+
+    const disabledP95 = p95ByVariant.get("disabled")!;
+    expect([...p95ByVariant.values()].every((p95) => p95 <= disabledP95 + 3))
+      .toBe(true);
+    if (process.env.RELAY_AUDIT_OUTPUT === "1") {
+      console.info(JSON.stringify({
+        scenario: "wired-browser-publish-instrumentation-local-fixture",
+        samplesPerVariant: 20,
+        completionP95Ms: Object.fromEntries(p95ByVariant),
+      }));
+    }
   });
 });


### PR DESCRIPTION
Adds a fixed-cardinality, bounded Wired collector and a deferred browser-publication adapter. Collection is content-free, never awaited, bounded to 100 pending numeric tasks, exposes dropped status, separates explicit rejection from terminal close, and preserves exact accepted relays. Controlled loopback p95: disabled 9 ms, enabled 9 ms, full 9 ms, failing 9 ms. Validation: 70 files / 356 tests, typecheck, lint 0 errors. Tracks smolgrrr/wired-admin#83.