### PR TITLE
Make moderation covers dismissible

### DIFF
--- a/src/shared/ui/NoteMedia.test.tsx
+++ b/src/shared/ui/NoteMedia.test.tsx
@@ -376,6 +376,87 @@ describe("NoteMedia video previews", () => {
     expect(container.textContent).toContain("checking media");
   });
 
+  it("lets a user reveal an image when the moderation service is unavailable", () => {
+    act(() => {
+      root.render(
+        <MediaAttachment
+          item={{ url: "https://example.com/unavailable.jpg", type: "image" }}
+          verdict={{
+            status: "unavailable",
+            reason: "verdict_api_unavailable",
+            enforced: true,
+          }}
+        />,
+      );
+    });
+
+    const reveal = container.querySelector<HTMLButtonElement>(
+      "[data-media-cover='true']",
+    );
+    expect(reveal).not.toBeNull();
+
+    act(() => reveal?.click());
+
+    expect(container.querySelector("[data-media-cover='true']")).toBeNull();
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      "https://example.com/unavailable.jpg",
+    );
+  });
+
+  it("loads and reveals a pending video after the user clears its cover", () => {
+    act(() => {
+      root.render(
+        <MediaAttachment
+          item={{ url: "https://example.com/pending.mp4", type: "video" }}
+          verdict={{ status: "pending", reason: "analysis_queued", enforced: true }}
+        />,
+      );
+    });
+
+    const reveal = container.querySelector<HTMLButtonElement>(
+      "[data-media-cover='true']",
+    );
+    expect(container.querySelector("video")).toBeNull();
+
+    act(() => reveal?.click());
+
+    expect(container.querySelector("[data-media-cover='true']")).toBeNull();
+    expect(container.querySelector("video")?.getAttribute("src")).toBe(
+      "https://example.com/pending.mp4",
+    );
+  });
+
+  it("reveals only the selected image in a moderated image grid", () => {
+    const verdict: MediaPresentationVerdict = {
+      status: "pending",
+      reason: "analysis_queued",
+      enforced: true,
+    };
+    act(() => {
+      root.render(
+        <MediaGrid
+          items={[
+            { url: "https://example.com/one.jpg", type: "image" },
+            { url: "https://example.com/two.jpg", type: "image" },
+          ]}
+          verdicts={new Map([
+            ["https://example.com/one.jpg", verdict],
+            ["https://example.com/two.jpg", verdict],
+          ])}
+        />,
+      );
+    });
+
+    const covers = container.querySelectorAll<HTMLButtonElement>(
+      "[data-media-cover='true']",
+    );
+    expect(covers).toHaveLength(2);
+
+    act(() => covers[0]?.click());
+
+    expect(container.querySelectorAll("[data-media-cover='true']")).toHaveLength(1);
+  });
+
   it("does not assign a video source before an allowed verdict", () => {
     act(() => {
       root.render(

--- a/src/shared/ui/NoteMedia.tsx
+++ b/src/shared/ui/NoteMedia.tsx
@@ -19,12 +19,49 @@ function MediaFallback() {
   );
 }
 
-function ModerationCover({ verdict }: { verdict: MediaPresentationVerdict }) {
-  const label = verdict.status === "pending" ? "checking media" : "media unavailable";
+function moderationCoverLabel(verdict: MediaPresentationVerdict): string {
+  switch (verdict.status) {
+    case "pending":
+      return "checking media";
+    case "review-required":
+      return "sensitive media";
+    case "unavailable":
+    case "stale":
+      return "media check unavailable";
+    default:
+      return "media unavailable";
+  }
+}
+
+function ModerationCover({
+  verdict,
+  onReveal,
+}: {
+  verdict: MediaPresentationVerdict;
+  onReveal?: () => void;
+}) {
+  const label = moderationCoverLabel(verdict);
+  const className =
+    "absolute inset-0 z-10 flex items-center justify-center rounded border border-ghost bg-surface text-meta text-muted";
+
+  if (onReveal) {
+    return (
+      <button
+        type="button"
+        data-media-cover="true"
+        className={`${className} cursor-pointer`}
+        aria-label={`${label}; click to view`}
+        onClick={onReveal}
+      >
+        {label} · click to view
+      </button>
+    );
+  }
+
   return (
     <div
       data-media-cover="true"
-      className="absolute inset-0 z-10 flex items-center justify-center rounded border border-ghost bg-surface text-meta text-muted"
+      className={className}
       role="status"
       aria-label={label}
     >
@@ -195,6 +232,7 @@ function GridImage({
   verdict?: MediaPresentationVerdict;
 }) {
   const [failed, setFailed] = useState(false);
+  const [revealedUrl, setRevealedUrl] = useState<string | null>(null);
   const maxWidth = compact ? 384 : 640;
   const width = pickOptimizedWidth(item.width, maxWidth);
   const srcSetWidths = compact ? [384, 640] : [384, 640, 828];
@@ -241,7 +279,14 @@ function GridImage({
           +{hiddenCount}
         </div>
       )}
-      {isMediaCovered(verdict) && verdict && <ModerationCover verdict={verdict} />}
+      {isMediaCovered(verdict) && revealedUrl !== item.url && verdict && (
+        <ModerationCover
+          verdict={verdict}
+          onReveal={
+            verdict.status === "blocked" ? undefined : () => setRevealedUrl(item.url)
+          }
+        />
+      )}
     </div>
   );
 }
@@ -388,14 +433,18 @@ export function MediaAttachment({
   priority?: boolean;
   verdict?: MediaPresentationVerdict;
 }) {
-  const covered = isMediaCovered(verdict);
+  const [revealedUrl, setRevealedUrl] = useState<string | null>(null);
+  const covered = isMediaCovered(verdict) && revealedUrl !== item.url;
+  const onReveal = verdict?.status === "blocked"
+    ? undefined
+    : () => setRevealedUrl(item.url);
   if (covered && item.type === "video" && verdict) {
     return (
       <div
         className={videoWrapperClasses(getOrientation(item.width, item.height), compact)}
         style={{ aspectRatio: aspectRatioFromDimensions(item.width, item.height) }}
       >
-        <ModerationCover verdict={verdict} />
+        <ModerationCover verdict={verdict} onReveal={onReveal} />
       </div>
     );
   }
@@ -419,7 +468,7 @@ export function MediaAttachment({
       style={{ aspectRatio: aspectRatioFromDimensions(item.width, item.height) }}
     >
       {media}
-      <ModerationCover verdict={verdict} />
+      <ModerationCover verdict={verdict} onReveal={onReveal} />
     </div>
   );
 }


### PR DESCRIPTION
## What changed

- makes enforced moderation covers interactive for pending, review-required, unavailable, and stale media
- reveals an image or loads a video when the user clicks the opaque cover
- keeps explicit blocked-note enforcement unchanged
- adds regression coverage for unavailable images, pending videos, and image grids

## Root cause

The client rendered every enforced non-allowed verdict as a non-interactive cover. When the production moderation API disappeared after a stale image deployment, every request became `unavailable` and every cover remained permanent.

## Validation

- 359 client tests pass
- ESLint passes with four existing Fast Refresh warnings
- production build passes

