### PR TITLE
Cover only risky media

### DIFF
--- a/src/shared/lib/mediaModeration.ts
+++ b/src/shared/lib/mediaModeration.ts
@@ -22,5 +22,5 @@ export const ALLOWED_MEDIA_VERDICT: MediaPresentationVerdict = {
 };
 
 export function isMediaCovered(verdict?: MediaPresentationVerdict): boolean {
-  return Boolean(verdict?.enforced && verdict.status !== "allowed");
+  return Boolean(verdict?.enforced && verdict.status === "review-required");
 }

--- a/src/shared/ui/NoteMedia.test.tsx
+++ b/src/shared/ui/NoteMedia.test.tsx
@@ -352,7 +352,7 @@ describe("NoteMedia video previews", () => {
     expect(container.textContent).toContain("signal lost");
   });
 
-  it("preloads a pending image only behind an opaque moderation cover", () => {
+  it("shows a pending image without a moderation cover", () => {
     const verdict: MediaPresentationVerdict = {
       status: "pending",
       reason: "analysis_queued",
@@ -370,13 +370,10 @@ describe("NoteMedia video previews", () => {
     expect(container.querySelector("img")?.getAttribute("src")).toBe(
       "https://example.com/pending.jpg",
     );
-    const cover = container.querySelector("[data-media-cover='true']");
-    expect(cover).not.toBeNull();
-    expect(cover?.className).toContain("bg-surface");
-    expect(container.textContent).toContain("checking media");
+    expect(container.querySelector("[data-media-cover='true']")).toBeNull();
   });
 
-  it("lets a user reveal an image when the moderation service is unavailable", () => {
+  it("shows an image when the moderation service is unavailable", () => {
     act(() => {
       root.render(
         <MediaAttachment
@@ -390,20 +387,13 @@ describe("NoteMedia video previews", () => {
       );
     });
 
-    const reveal = container.querySelector<HTMLButtonElement>(
-      "[data-media-cover='true']",
-    );
-    expect(reveal).not.toBeNull();
-
-    act(() => reveal?.click());
-
     expect(container.querySelector("[data-media-cover='true']")).toBeNull();
     expect(container.querySelector("img")?.getAttribute("src")).toBe(
       "https://example.com/unavailable.jpg",
     );
   });
 
-  it("loads and reveals a pending video after the user clears its cover", () => {
+  it("loads a pending video without a moderation cover", () => {
     act(() => {
       root.render(
         <MediaAttachment
@@ -413,23 +403,16 @@ describe("NoteMedia video previews", () => {
       );
     });
 
-    const reveal = container.querySelector<HTMLButtonElement>(
-      "[data-media-cover='true']",
-    );
-    expect(container.querySelector("video")).toBeNull();
-
-    act(() => reveal?.click());
-
     expect(container.querySelector("[data-media-cover='true']")).toBeNull();
     expect(container.querySelector("video")?.getAttribute("src")).toBe(
       "https://example.com/pending.mp4",
     );
   });
 
-  it("reveals only the selected image in a moderated image grid", () => {
+  it("reveals only the selected risky image in a moderated image grid", () => {
     const verdict: MediaPresentationVerdict = {
-      status: "pending",
-      reason: "analysis_queued",
+      status: "review-required",
+      reason: "model_review_threshold",
       enforced: true,
     };
     act(() => {
@@ -457,19 +440,31 @@ describe("NoteMedia video previews", () => {
     expect(container.querySelectorAll("[data-media-cover='true']")).toHaveLength(1);
   });
 
-  it("does not assign a video source before an allowed verdict", () => {
+  it("does not assign a risky video source until the cover is cleared", () => {
     act(() => {
       root.render(
         <MediaAttachment
-          item={{ url: "https://example.com/pending.mp4", type: "video" }}
-          verdict={{ status: "pending", reason: "analysis_queued", enforced: true }}
+          item={{ url: "https://example.com/risky.mp4", type: "video" }}
+          verdict={{
+            status: "review-required",
+            reason: "model_review_threshold",
+            enforced: true,
+          }}
         />,
       );
     });
 
     expect(container.querySelector("video")).toBeNull();
-    expect(container.innerHTML).not.toContain("https://example.com/pending.mp4");
-    expect(container.textContent).toContain("checking media");
+    expect(container.innerHTML).not.toContain("https://example.com/risky.mp4");
+    expect(container.textContent).toContain("sensitive media");
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>("[data-media-cover='true']")?.click();
+    });
+
+    expect(container.querySelector("video")?.getAttribute("src")).toBe(
+      "https://example.com/risky.mp4",
+    );
   });
 
   it("reveals media when enforcement is shadow-only", () => {

--- a/src/shared/ui/NoteMedia.tsx
+++ b/src/shared/ui/NoteMedia.tsx
@@ -19,54 +19,24 @@ function MediaFallback() {
   );
 }
 
-function moderationCoverLabel(verdict: MediaPresentationVerdict): string {
-  switch (verdict.status) {
-    case "pending":
-      return "checking media";
-    case "review-required":
-      return "sensitive media";
-    case "unavailable":
-    case "stale":
-      return "media check unavailable";
-    default:
-      return "media unavailable";
-  }
-}
-
 function ModerationCover({
-  verdict,
   onReveal,
 }: {
-  verdict: MediaPresentationVerdict;
-  onReveal?: () => void;
+  onReveal: () => void;
 }) {
-  const label = moderationCoverLabel(verdict);
   const className =
     "absolute inset-0 z-10 flex items-center justify-center rounded border border-ghost bg-surface text-meta text-muted";
 
-  if (onReveal) {
-    return (
-      <button
-        type="button"
-        data-media-cover="true"
-        className={`${className} cursor-pointer`}
-        aria-label={`${label}; click to view`}
-        onClick={onReveal}
-      >
-        {label} · click to view
-      </button>
-    );
-  }
-
   return (
-    <div
+    <button
+      type="button"
       data-media-cover="true"
-      className={className}
-      role="status"
-      aria-label={label}
+      className={`${className} cursor-pointer`}
+      aria-label="sensitive media; click to view"
+      onClick={onReveal}
     >
-      {label}
-    </div>
+      sensitive media · click to view
+    </button>
   );
 }
 
@@ -281,10 +251,7 @@ function GridImage({
       )}
       {isMediaCovered(verdict) && revealedUrl !== item.url && verdict && (
         <ModerationCover
-          verdict={verdict}
-          onReveal={
-            verdict.status === "blocked" ? undefined : () => setRevealedUrl(item.url)
-          }
+          onReveal={() => setRevealedUrl(item.url)}
         />
       )}
     </div>
@@ -435,16 +402,14 @@ export function MediaAttachment({
 }) {
   const [revealedUrl, setRevealedUrl] = useState<string | null>(null);
   const covered = isMediaCovered(verdict) && revealedUrl !== item.url;
-  const onReveal = verdict?.status === "blocked"
-    ? undefined
-    : () => setRevealedUrl(item.url);
+  const onReveal = () => setRevealedUrl(item.url);
   if (covered && item.type === "video" && verdict) {
     return (
       <div
         className={videoWrapperClasses(getOrientation(item.width, item.height), compact)}
         style={{ aspectRatio: aspectRatioFromDimensions(item.width, item.height) }}
       >
-        <ModerationCover verdict={verdict} onReveal={onReveal} />
+        <ModerationCover onReveal={onReveal} />
       </div>
     );
   }
@@ -468,7 +433,7 @@ export function MediaAttachment({
       style={{ aspectRatio: aspectRatioFromDimensions(item.width, item.height) }}
     >
       {media}
-      <ModerationCover verdict={verdict} onReveal={onReveal} />
+      <ModerationCover onReveal={onReveal} />
     </div>
   );
 }

--- a/src/shared/ui/PostCard.test.tsx
+++ b/src/shared/ui/PostCard.test.tsx
@@ -266,7 +266,8 @@ describe("PostCard thread opening", () => {
       );
     });
     expect(container.querySelector("article")).not.toBeNull();
-    expect(container.querySelector("[data-media-cover='true']")).not.toBeNull();
+    expect(container.querySelector("img")).not.toBeNull();
+    expect(container.querySelector("[data-media-cover='true']")).toBeNull();
 
     await act(async () => {
       await client.waitForIdle();


### PR DESCRIPTION
## What changed

- renders pending, allowed, unavailable, and stale media normally
- reserves the opaque click-to-view cover for `review-required` media only
- keeps explicit `blocked` verdicts on the existing whole-note removal path
- updates image, video, grid, and blocked-note regression coverage

## Why

Moderation checks should run asynchronously without hiding ordinary media. A cover is a warning for media the detector actually flags as risky, not a loading or backend-health state.

## Validation

- all 359 client tests pass
- ESLint passes with four existing Fast Refresh warnings
- production build passes

