### PR TITLE
Apply media review at the note level

### DIFF
--- a/src/shared/hooks/useMediaModeration.tsx
+++ b/src/shared/hooks/useMediaModeration.tsx
@@ -26,6 +26,10 @@ import type { MediaItem } from "../lib/mediaUtils";
 const MediaModerationContext = createContext<MediaModerationClient | null>(null);
 const COHORT_STORAGE_KEY = "wiredMediaModerationCohort";
 
+function hasContentWarning(event: Event): boolean {
+  return event.tags.some((tag) => tag[0] === "content-warning");
+}
+
 function selectedForMediaModerationCohort(): boolean {
   if (MEDIA_MODERATION_COHORT_PERCENT >= 100) return true;
   if (MEDIA_MODERATION_COHORT_PERCENT <= 0) return false;
@@ -126,5 +130,23 @@ export function useMediaModeration(event: Event, items: MediaItem[]) {
   const blocked = [...verdicts.values()].some(
     (verdict) => verdict.enforced && verdict.status === "blocked",
   );
-  return { blocked, verdicts };
+  const eventRequiresReview = hasContentWarning(event) || [...verdicts.values()].some(
+    (verdict) => verdict.enforced && verdict.status === "review-required",
+  );
+  const presentationVerdicts = useMemo(() => {
+    if (!eventRequiresReview) return verdicts;
+    const reason = hasContentWarning(event)
+      ? "event_content_warning"
+      : "event_attachment_review_required";
+    return new Map(
+      [...verdicts].map(([url, verdict]) => [
+        url,
+        verdict.enforced && verdict.status !== "blocked"
+          ? { ...verdict, status: "review-required" as const, reason }
+          : verdict,
+      ]),
+    );
+  }, [event, eventRequiresReview, verdicts]);
+
+  return { blocked, verdicts: presentationVerdicts };
 }

--- a/src/shared/ui/PostCard.test.tsx
+++ b/src/shared/ui/PostCard.test.tsx
@@ -276,4 +276,98 @@ describe("PostCard thread opening", () => {
     expect(container.querySelector("article")).toBeNull();
     client.close();
   });
+
+  it("covers every attachment when the note declares a content warning", async () => {
+    const warnedEvent = event({
+      tags: [["content-warning", "nsfw"]],
+      content: [
+        "https://example.com/one.jpg",
+        "https://example.com/two.jpg",
+      ].join("\n"),
+    });
+    const client = createMediaModerationClient({
+      baseUrl: "https://admin.example",
+      mode: "enforce",
+      batchDelayMs: 0,
+      fetcher: vi.fn(async (_input, init) => {
+        const request = JSON.parse(String(init?.body)) as {
+          items: Array<{ requestId: string; url: string }>;
+        };
+        return new Response(JSON.stringify({
+          mode: "enforce",
+          policyVersion: "wired-media-v1",
+          verdicts: request.items.map((item) => ({
+            requestId: item.requestId,
+            eventId: warnedEvent.id,
+            url: item.url,
+            mediaType: "image",
+            status: "allowed",
+            reason: "model_allowed",
+            expiresAt: Date.now() + 60_000,
+          })),
+        }), { status: 200 });
+      }),
+    });
+
+    act(() => {
+      root.render(
+        <MediaModerationProvider client={client}>
+          <PostCard event={warnedEvent} replies={[]} totalWork={16} />
+        </MediaModerationProvider>,
+      );
+    });
+
+    expect(container.querySelectorAll("[data-media-cover='true']")).toHaveLength(2);
+    await act(async () => {
+      await client.waitForIdle();
+    });
+    expect(container.querySelectorAll("[data-media-cover='true']")).toHaveLength(2);
+    client.close();
+  });
+
+  it("covers every attachment when one attachment requires review", async () => {
+    const galleryEvent = event({
+      content: [
+        "https://example.com/allowed.jpg",
+        "https://example.com/risky.jpg",
+      ].join("\n"),
+    });
+    const client = createMediaModerationClient({
+      baseUrl: "https://admin.example",
+      mode: "enforce",
+      batchDelayMs: 0,
+      fetcher: vi.fn(async (_input, init) => {
+        const request = JSON.parse(String(init?.body)) as {
+          items: Array<{ requestId: string; url: string }>;
+        };
+        return new Response(JSON.stringify({
+          mode: "enforce",
+          policyVersion: "wired-media-v1",
+          verdicts: request.items.map((item) => ({
+            requestId: item.requestId,
+            eventId: galleryEvent.id,
+            url: item.url,
+            mediaType: "image",
+            status: item.url.endsWith("risky.jpg") ? "review-required" : "allowed",
+            reason: "model_classification",
+            expiresAt: Date.now() + 60_000,
+          })),
+        }), { status: 200 });
+      }),
+    });
+
+    act(() => {
+      root.render(
+        <MediaModerationProvider client={client}>
+          <PostCard event={galleryEvent} replies={[]} totalWork={16} />
+        </MediaModerationProvider>,
+      );
+    });
+
+    await act(async () => {
+      await client.waitForIdle();
+    });
+    expect(container.querySelectorAll("[data-media-cover='true']")).toHaveLength(2);
+    client.close();
+  });
 });


### PR DESCRIPTION
## What changed
- honor NIP-36 `content-warning` at the note level
- cover every media attachment when any attachment requires review
- keep blocked verdicts authoritative so the entire note is removed
- add regression coverage for declared warnings and mixed-risk galleries

## Why
The production post was scanned successfully, but two of four images fell below the per-image model threshold. Applying presentation verdicts independently exposed part of a gallery whose note explicitly declared NSFW content.

## Impact
Risky galleries are now presented consistently. Users can reveal covered media, while blocked notes remain hidden.

## Validation
- `npm test` — 361 tests passed
- `npm run build` — passed