### PR TITLE
Restore Vercel thread runtime

### DIFF
--- a/src/contracts/relay-workflow-status.test.ts
+++ b/src/contracts/relay-workflow-status.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { RelayWorkflowCollector } from "../nostr/evidence/relay-workflow-collector";
 import { validRelayWorkflowEvidence } from "./relay-workflow-evidence.test-fixtures";
@@ -19,6 +20,14 @@ function browserEnvelope(): RelayWorkflowStatusEnvelope {
 }
 
 describe("relay workflow status envelope", () => {
+  it("keeps its server-runtime imports resolvable by Node ESM", async () => {
+    const source = await readFile(
+      new URL("./relay-workflow-status.ts", import.meta.url),
+      "utf8",
+    );
+    expect(source).toContain('from "./relay-workflow-evidence.js"');
+  });
+
   it("accepts fixed, content-free aggregate envelopes", () => {
     expect(isRelayWorkflowStatusEnvelope(browserEnvelope())).toBe(true);
   });

--- a/src/contracts/relay-workflow-status.ts
+++ b/src/contracts/relay-workflow-status.ts
@@ -5,7 +5,7 @@ import {
   RELAY_WORKFLOW_OUTCOMES,
   RELAY_WORKFLOW_OWNERS,
   type RelayWorkflowEvidence,
-} from "./relay-workflow-evidence";
+} from "./relay-workflow-evidence.js";
 
 export const RELAY_WORKFLOW_STATUS_SCHEMA_VERSION = 1 as const;
 export const RELAY_WORKFLOW_STATUS_SOURCES = [


### PR DESCRIPTION
## What changed
- make the relay workflow contract import Node ESM-resolvable in Vercel server functions
- add a regression that pins the runtime import form

## Why
The operational-ingest merge introduced an extensionless relative import. Vercel deployed the client successfully, but every `/thread/*` server function crashed with `ERR_MODULE_NOT_FOUND`.

## Impact
Thread URLs render their HTML shell and metadata again. The media-review fix from #129 remains included.

## Validation
- reproduced with NodeNext type checking before the fix
- NodeNext runtime import check passes
- `npm test` — 392 tests passed
- `npm run build` — passed