### PR TITLE
Add browser finite-query lifecycle seam

### DIFF
--- a/src/nostr/browser-finite-query.ts
+++ b/src/nostr/browser-finite-query.ts
@@ -1,0 +1,224 @@
+import type { Relay, Subscription } from "nostr-tools";
+import type {
+  FiniteQuery,
+  QueryCompletion,
+  QueryHandle,
+  RelayCompletionState,
+} from "./browser-relay-access";
+
+export type RelayLocation = { mapKey: string; relay: Relay };
+
+export type FiniteConnectionLease = {
+  promise: Promise<RelayLocation | undefined>;
+  release(state?: RelayCompletionState): void;
+};
+
+export type BrowserQueryEvidencePrimitives = {
+  completion: QueryCompletion;
+  completionMs: number;
+  duplicates: number;
+  firstResultMs: number | null;
+  requestBytes: number;
+  requestsSent: number;
+  uniqueResults: number;
+};
+
+export type BrowserFiniteQueryTransport = {
+  normalizeCoverage(urls: readonly string[]): string[];
+  findRelay(relayUrl: string): RelayLocation | undefined;
+  acquireConnection(
+    relayUrl: string,
+    workflowOwner: FiniteQuery["workflowOwner"],
+  ): FiniteConnectionLease;
+  addCloseListener(relayUrl: string, listener: () => void): () => void;
+  trackSubscription(mapKey: string, subscription: Subscription): void;
+  untrackSubscription(mapKey: string | undefined, subscription: Subscription): void;
+  recordCompletion?(primitives: BrowserQueryEvidencePrimitives): void;
+};
+
+type QueryTarget = {
+  relayUrl: string;
+  state?: RelayCompletionState;
+  subscription?: Subscription;
+  relayMapKey?: string;
+  removeCloseListener?: () => void;
+  releaseConnection?: FiniteConnectionLease["release"];
+};
+
+export function startBrowserFiniteQuery(
+  query: FiniteQuery,
+  transport: BrowserFiniteQueryTransport,
+): QueryHandle {
+  const relayUrls = transport.normalizeCoverage([
+    ...query.coverage.configuredRelayUrls,
+    ...(query.coverage.hintedRelayUrls ?? []),
+  ]);
+  const targets: QueryTarget[] = relayUrls.map((relayUrl) => ({ relayUrl }));
+  const startedAt = performance.now();
+  const uniqueEventIds = new Set<string>();
+  let receivedEvents = 0;
+  let duplicates = 0;
+  let firstResultMs: number | null = null;
+  let requestBytes = 0;
+  let requestsSent = 0;
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  let finished = false;
+  let resolveDone!: (completion: QueryCompletion) => void;
+  const done = new Promise<QueryCompletion>((resolve) => {
+    resolveDone = resolve;
+  });
+
+  const cleanupTarget = (target: QueryTarget) => {
+    target.releaseConnection?.(target.state);
+    target.releaseConnection = undefined;
+    target.removeCloseListener?.();
+    target.removeCloseListener = undefined;
+    const subscription = target.subscription;
+    target.subscription = undefined;
+    if (!subscription) return;
+    transport.untrackSubscription(target.relayMapKey, subscription);
+    subscription.close();
+  };
+
+  const finish = (reason: QueryCompletion["reason"]) => {
+    if (finished) return;
+    finished = true;
+    if (deadline) {
+      clearTimeout(deadline);
+      deadline = undefined;
+    }
+    query.signal?.removeEventListener("abort", cancel);
+    const unfinishedState: RelayCompletionState = reason === "cancelled"
+      ? "cancelled"
+      : "timed-out";
+    for (const target of targets) {
+      target.state ??= unfinishedState;
+      cleanupTarget(target);
+    }
+    const completion: QueryCompletion = {
+      reason,
+      targets: targets.map(({ relayUrl, state }) => ({
+        relayUrl,
+        state: state as RelayCompletionState,
+      })),
+      receivedEvents,
+    };
+    try {
+      transport.recordCompletion?.({
+        completion,
+        completionMs: performance.now() - startedAt,
+        duplicates,
+        firstResultMs,
+        requestBytes,
+        requestsSent,
+        uniqueResults: uniqueEventIds.size,
+      });
+    } catch {
+      // Status evidence cannot affect query completion.
+    }
+    resolveDone(completion);
+  };
+
+  const maybeFinish = () => {
+    if (!finished && targets.every((target) => target.state !== undefined)) {
+      finish("settled");
+    }
+  };
+
+  const settleTarget = (target: QueryTarget, state: RelayCompletionState) => {
+    if (finished || target.state) return;
+    target.state = state;
+    cleanupTarget(target);
+    maybeFinish();
+  };
+
+  const subscribeTarget = (
+    target: QueryTarget,
+    relayMapKey: string,
+    relay: Relay,
+  ) => {
+    if (finished || target.state) return;
+    if (!relay.connected) {
+      settleTarget(target, "closed");
+      return;
+    }
+    target.relayMapKey = relayMapKey;
+    target.removeCloseListener = transport.addCloseListener(
+      target.relayUrl,
+      () => settleTarget(target, "closed"),
+    );
+    try {
+      const subscription = relay.subscribe(query.filters, {
+        onevent: (event) => {
+          if (finished || target.state) return;
+          receivedEvents += 1;
+          if (firstResultMs === null) firstResultMs = performance.now() - startedAt;
+          if (uniqueEventIds.has(event.id)) duplicates += 1;
+          else uniqueEventIds.add(event.id);
+          query.onEvent(event, target.relayUrl);
+        },
+        oneose: () => settleTarget(target, "eose"),
+        onclose: () => settleTarget(target, "closed"),
+      });
+      if (finished || target.state) {
+        subscription.close();
+        return;
+      }
+      target.subscription = subscription;
+      transport.trackSubscription(relayMapKey, subscription);
+      requestsSent += 1;
+      if (typeof subscription.id === "string") {
+        try {
+          requestBytes += new TextEncoder().encode(
+            JSON.stringify(["REQ", subscription.id, ...query.filters]),
+          ).byteLength;
+        } catch {
+          // Optional byte evidence cannot affect relay work.
+        }
+      }
+    } catch {
+      settleTarget(target, "closed");
+    }
+  };
+
+  const startTarget = (target: QueryTarget) => {
+    const existing = transport.findRelay(target.relayUrl);
+    if (existing?.relay.connected) {
+      subscribeTarget(target, existing.mapKey, existing.relay);
+      return;
+    }
+
+    const connection = transport.acquireConnection(
+      target.relayUrl,
+      query.workflowOwner,
+    );
+    target.releaseConnection = connection.release;
+    void connection.promise.then((registered) => {
+      target.releaseConnection?.();
+      target.releaseConnection = undefined;
+      if (finished || target.state || !registered) return;
+      subscribeTarget(target, registered.mapKey, registered.relay);
+    }).catch(() => {
+      settleTarget(target, "connect-failed");
+    });
+  };
+
+  function cancel() {
+    finish("cancelled");
+  }
+
+  if (targets.length === 0) {
+    finish("settled");
+  } else if (query.signal?.aborted) {
+    finish("cancelled");
+  } else {
+    query.signal?.addEventListener("abort", cancel, { once: true });
+    deadline = setTimeout(
+      () => finish("deadline"),
+      Math.max(0, query.completionDeadlineMs),
+    );
+    targets.forEach(startTarget);
+  }
+
+  return { done, close: cancel };
+}

--- a/src/nostr/browser-relay-access.test.ts
+++ b/src/nostr/browser-relay-access.test.ts
@@ -1,0 +1,506 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Event, Filter } from "nostr-tools";
+import { RelayPool } from "./relay-pool";
+import { RelayWorkflowCollector } from "./evidence/relay-workflow-collector";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+}));
+
+vi.mock("nostr-tools", () => ({
+  Relay: {
+    connect: mocks.connect,
+  },
+}));
+
+type SubscriptionCallbacks = {
+  onevent?: (event: Event) => void;
+  oneose?: () => void;
+  onclose?: (reason: string) => void;
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function controlledRelay(url: string) {
+  const callbacks: SubscriptionCallbacks[] = [];
+  const subscriptions: Array<{
+    close: ReturnType<typeof vi.fn>;
+    id: string;
+    receivedEose: ReturnType<typeof vi.fn>;
+  }> = [];
+  const relay = {
+    url,
+    connected: true,
+    onclose: null as (() => void) | null,
+    close: vi.fn(),
+    publish: vi.fn(),
+    subscribe: vi.fn((_filters: Filter[], params: SubscriptionCallbacks) => {
+      callbacks.push(params);
+      const subscription = {
+        close: vi.fn(),
+        id: `sub-${subscriptions.length + 1}`,
+        receivedEose: vi.fn(() => params.oneose?.()),
+      };
+      subscriptions.push(subscription);
+      return subscription;
+    }),
+  };
+  return { callbacks, relay, subscriptions };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("RelayPool browser finite queries", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    mocks.connect.mockReset();
+  });
+
+  it("settles an empty target set without opening a connection or timer", async () => {
+    vi.useFakeTimers();
+    const pool = new RelayPool();
+
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: [] },
+      completionDeadlineMs: 1_000,
+      onEvent: vi.fn(),
+    });
+
+    await expect(query.done).resolves.toEqual({
+      reason: "settled",
+      targets: [],
+      receivedEvents: 0,
+    });
+    expect(mocks.connect).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("normalizes and unions configured and hinted coverage without narrowing", async () => {
+    const first = controlledRelay("wss://one.example/");
+    const hinted = controlledRelay("wss://hint.example/");
+    mocks.connect.mockImplementation((url: string) =>
+      Promise.resolve(url === first.relay.url ? first.relay : hinted.relay)
+    );
+    const pool = new RelayPool();
+
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ ids: ["1".repeat(64)] }],
+      coverage: {
+        configuredRelayUrls: ["WSS://ONE.EXAMPLE", "wss://one.example/"],
+        hintedRelayUrls: ["wss://hint.example", "wss://one.example"],
+      },
+      completionDeadlineMs: 1_000,
+      onEvent: vi.fn(),
+    });
+    await flushPromises();
+
+    expect(mocks.connect.mock.calls.map(([url]) => url)).toEqual([
+      "wss://one.example/",
+      "wss://hint.example/",
+    ]);
+    first.callbacks[0]?.oneose?.();
+    hinted.callbacks[0]?.oneose?.();
+
+    await expect(query.done).resolves.toEqual({
+      reason: "settled",
+      targets: [
+        { relayUrl: "wss://one.example/", state: "eose" },
+        { relayUrl: "wss://hint.example/", state: "eose" },
+      ],
+      receivedEvents: 0,
+    });
+  });
+
+  it("reports partial connection outcomes and streams events before EOSE", async () => {
+    const connected = controlledRelay("wss://connected.example/");
+    mocks.connect.mockImplementation((url: string) =>
+      url === connected.relay.url
+        ? Promise.resolve(connected.relay)
+        : Promise.reject(new Error("offline"))
+    );
+    const onEvent = vi.fn();
+    const pool = new RelayPool();
+
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: {
+        configuredRelayUrls: [connected.relay.url, "wss://offline.example"],
+      },
+      completionDeadlineMs: 1_000,
+      onEvent,
+    });
+    await flushPromises();
+
+    const event = { id: "1".repeat(64) } as Event;
+    connected.callbacks[0]?.onevent?.(event);
+    expect(onEvent).toHaveBeenCalledWith(event, connected.relay.url);
+    connected.callbacks[0]?.oneose?.();
+
+    await expect(query.done).resolves.toEqual({
+      reason: "settled",
+      targets: [
+        { relayUrl: connected.relay.url, state: "eose" },
+        { relayUrl: "wss://offline.example/", state: "connect-failed" },
+      ],
+      receivedEvents: 1,
+    });
+  });
+
+  it("reports terminal relay close exactly once before EOSE", async () => {
+    const target = controlledRelay("wss://closed.example/");
+    mocks.connect.mockResolvedValue(target.relay);
+    const pool = new RelayPool();
+
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: [target.relay.url] },
+      completionDeadlineMs: 1_000,
+      onEvent: vi.fn(),
+    });
+    await flushPromises();
+    target.relay.onclose?.();
+    target.callbacks[0]?.oneose?.();
+
+    await expect(query.done).resolves.toEqual({
+      reason: "settled",
+      targets: [{ relayUrl: target.relay.url, state: "closed" }],
+      receivedEvents: 0,
+    });
+  });
+
+  it("cleans a subscription that reaches EOSE synchronously during setup", async () => {
+    const target = controlledRelay("wss://synchronous.example/");
+    target.relay.subscribe.mockImplementation((_filters, params) => {
+      const subscription = {
+        close: vi.fn(),
+        id: "sub-synchronous",
+        receivedEose: vi.fn(),
+      };
+      target.subscriptions.push(subscription);
+      params.oneose?.();
+      return subscription;
+    });
+    mocks.connect.mockResolvedValue(target.relay);
+    const pool = new RelayPool();
+
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: [target.relay.url] },
+      completionDeadlineMs: 1_000,
+      onEvent: vi.fn(),
+    });
+
+    await expect(query.done).resolves.toMatchObject({
+      reason: "settled",
+      targets: [{ relayUrl: target.relay.url, state: "eose" }],
+    });
+    expect(target.subscriptions[0]?.close).toHaveBeenCalledOnce();
+  });
+
+  it("closes a connection that arrives after the query deadline", async () => {
+    vi.useFakeTimers();
+    const late = controlledRelay("wss://late.example/");
+    const connection = deferred<typeof late.relay>();
+    mocks.connect.mockReturnValue(connection.promise);
+    let evidenceTask: (() => void) | undefined;
+    const recorder = new RelayWorkflowCollector();
+    const pool = new RelayPool({
+      workflowEvidence: recorder,
+      scheduleEvidence(task) { evidenceTask = task; },
+    });
+
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: [late.relay.url] },
+      completionDeadlineMs: 25,
+      onEvent: vi.fn(),
+    });
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(query.done).resolves.toEqual({
+      reason: "deadline",
+      targets: [{ relayUrl: late.relay.url, state: "timed-out" }],
+      receivedEvents: 0,
+    });
+    connection.resolve(late.relay);
+    await flushPromises();
+    expect(late.relay.close).toHaveBeenCalledOnce();
+    expect(late.relay.subscribe).not.toHaveBeenCalled();
+    evidenceTask?.();
+    const [aggregate] = recorder.snapshot();
+    expect(aggregate).toMatchObject({
+      samples: 1,
+      totals: expect.objectContaining({
+        attempts: 1,
+        targets: 1,
+        timedOut: 1,
+        connectionsOpened: 1,
+        connectionsClosed: 1,
+        lateConnectionsClosed: 1,
+      }),
+    });
+    expect(Object.values(aggregate?.completionMs ?? {})).toEqual([1]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("times out a connected relay with no EOSE and cleans its subscription", async () => {
+    vi.useFakeTimers();
+    const silent = controlledRelay("wss://silent.example/");
+    mocks.connect.mockResolvedValue(silent.relay);
+    const pool = new RelayPool();
+
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: [silent.relay.url] },
+      completionDeadlineMs: 25,
+      onEvent: vi.fn(),
+    });
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(query.done).resolves.toMatchObject({
+      reason: "deadline",
+      targets: [{ relayUrl: silent.relay.url, state: "timed-out" }],
+    });
+    expect(silent.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cancels before connection and makes close idempotent", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    controller.abort();
+    const pool = new RelayPool();
+
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: ["wss://cancelled.example"] },
+      completionDeadlineMs: 1_000,
+      signal: controller.signal,
+      onEvent: vi.fn(),
+    });
+    query.close();
+    query.close();
+
+    await expect(query.done).resolves.toEqual({
+      reason: "cancelled",
+      targets: [{ relayUrl: "wss://cancelled.example/", state: "cancelled" }],
+      receivedEvents: 0,
+    });
+    expect(mocks.connect).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cancels an active query only after its subscription is cleaned", async () => {
+    vi.useFakeTimers();
+    const active = controlledRelay("wss://active.example/");
+    mocks.connect.mockResolvedValue(active.relay);
+    const pool = new RelayPool();
+    const controller = new AbortController();
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: [active.relay.url] },
+      completionDeadlineMs: 1_000,
+      signal: controller.signal,
+      onEvent: vi.fn(),
+    });
+    await flushPromises();
+
+    controller.abort();
+    query.close();
+    query.close();
+
+    await expect(query.done).resolves.toMatchObject({
+      reason: "cancelled",
+      targets: [{ relayUrl: active.relay.url, state: "cancelled" }],
+    });
+    expect(active.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("shares one in-flight connection across overlapping finite queries", async () => {
+    const target = controlledRelay("wss://shared.example/");
+    const connection = deferred<typeof target.relay>();
+    mocks.connect.mockReturnValue(connection.promise);
+    const pool = new RelayPool();
+    const input = {
+      workflowOwner: "wired.browser.thread" as const,
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: [target.relay.url] },
+      completionDeadlineMs: 1_000,
+      onEvent: vi.fn(),
+    };
+
+    const first = pool.startFiniteQuery(input);
+    const second = pool.startFiniteQuery(input);
+    expect(mocks.connect).toHaveBeenCalledOnce();
+
+    connection.resolve(target.relay);
+    await flushPromises();
+    expect(target.relay.subscribe).toHaveBeenCalledTimes(2);
+    target.callbacks.forEach((callbacks) => callbacks.oneose?.());
+
+    await expect(Promise.all([first.done, second.done])).resolves.toEqual([
+      expect.objectContaining({ reason: "settled" }),
+      expect.objectContaining({ reason: "settled" }),
+    ]);
+  });
+
+  it("shares one normalized connection between finite and configured adapters", async () => {
+    const target = controlledRelay("wss://shared-adapters.example/");
+    const connection = deferred<typeof target.relay>();
+    mocks.connect.mockReturnValue(connection.promise);
+    const pool = new RelayPool();
+    const finite = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: ["WSS://SHARED-ADAPTERS.EXAMPLE"] },
+      completionDeadlineMs: 1_000,
+      onEvent: vi.fn(),
+    });
+    const configured = pool.connectConfigured(["wss://shared-adapters.example"]);
+
+    expect(mocks.connect).toHaveBeenCalledOnce();
+    connection.resolve(target.relay);
+    await configured;
+    await flushPromises();
+    target.callbacks[0]?.oneose?.();
+    await finite.done;
+    pool.subscribe({ kinds: [0] }, vi.fn(), {
+      relayUrls: ["wss://shared-adapters.example"],
+    });
+
+    expect(mocks.connect).toHaveBeenCalledOnce();
+    expect(target.relay.subscribe).toHaveBeenCalledTimes(2);
+    expect(target.relay.close).not.toHaveBeenCalled();
+  });
+
+  it("records bounded query terminal evidence after cleanup without changing results", async () => {
+    const target = controlledRelay("wss://evidence.example/");
+    mocks.connect.mockResolvedValue(target.relay);
+    let evidenceTask: (() => void) | undefined;
+    const recorder = { record: vi.fn() };
+    const pool = new RelayPool({
+      workflowEvidence: recorder,
+      scheduleEvidence(task) { evidenceTask = task; },
+    });
+    const onEvent = vi.fn();
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: [target.relay.url] },
+      completionDeadlineMs: 1_000,
+      onEvent,
+    });
+    await flushPromises();
+    const event = { id: "a".repeat(64) } as Event;
+    target.callbacks[0]?.onevent?.(event);
+    target.callbacks[0]?.onevent?.(event);
+    target.callbacks[0]?.oneose?.();
+
+    await expect(query.done).resolves.toMatchObject({
+      reason: "settled",
+      receivedEvents: 2,
+    });
+    expect(target.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(recorder.record).not.toHaveBeenCalled();
+    evidenceTask?.();
+    expect(recorder.record).toHaveBeenCalledWith(expect.objectContaining({
+      workflowOwner: "wired.browser.thread",
+      operation: "query",
+      outcome: "completed",
+      relay: expect.objectContaining({ requestsSent: 1, eventsReceived: 2 }),
+      results: expect.objectContaining({ unique: 1, duplicates: 1 }),
+      terminal: expect.objectContaining({ eose: 1 }),
+    }));
+  });
+
+  it("drops failing query evidence without affecting completion", async () => {
+    const target = controlledRelay("wss://failing-evidence.example/");
+    mocks.connect.mockResolvedValue(target.relay);
+    let evidenceTask: (() => void) | undefined;
+    const pool = new RelayPool({
+      workflowEvidence: { record() { throw new Error("collector unavailable"); } },
+      scheduleEvidence(task) { evidenceTask = task; },
+    });
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.feed",
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: [target.relay.url] },
+      completionDeadlineMs: 1_000,
+      onEvent: vi.fn(),
+    });
+    await flushPromises();
+    target.callbacks[0]?.oneose?.();
+
+    await expect(query.done).resolves.toMatchObject({ reason: "settled" });
+    expect(() => evidenceTask?.()).not.toThrow();
+    expect(pool.workflowEvidenceStatus.dropped).toBe(1);
+  });
+
+  it("starts configured work immediately while a hinted connection is delayed", async () => {
+    const configured = controlledRelay("wss://configured.example/");
+    const hinted = controlledRelay("wss://hinted.example/");
+    const hintedConnection = deferred<typeof hinted.relay>();
+    mocks.connect.mockImplementation((url: string) =>
+      url === configured.relay.url
+        ? Promise.resolve(configured.relay)
+        : hintedConnection.promise
+    );
+    const pool = new RelayPool();
+
+    const query = pool.startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: {
+        configuredRelayUrls: [configured.relay.url],
+        hintedRelayUrls: [hinted.relay.url],
+      },
+      completionDeadlineMs: 1_000,
+      onEvent: vi.fn(),
+    });
+    await flushPromises();
+
+    expect(configured.relay.subscribe).toHaveBeenCalledOnce();
+    configured.callbacks[0]?.oneose?.();
+    let settled = false;
+    void query.done.then(() => { settled = true; });
+    await flushPromises();
+    expect(settled).toBe(false);
+
+    hintedConnection.resolve(hinted.relay);
+    await flushPromises();
+    expect(hinted.relay.subscribe).toHaveBeenCalledOnce();
+    hinted.callbacks[0]?.oneose?.();
+
+    await expect(query.done).resolves.toEqual({
+      reason: "settled",
+      targets: [
+        { relayUrl: configured.relay.url, state: "eose" },
+        { relayUrl: hinted.relay.url, state: "eose" },
+      ],
+      receivedEvents: 0,
+    });
+  });
+});

--- a/src/nostr/browser-relay-access.ts
+++ b/src/nostr/browser-relay-access.ts
@@ -1,0 +1,47 @@
+import type { Event, Filter } from "nostr-tools";
+
+export type RelayCompletionState =
+  | "eose"
+  | "closed"
+  | "connect-failed"
+  | "timed-out"
+  | "cancelled";
+
+export type RelayCompletion = {
+  relayUrl: string;
+  state: RelayCompletionState;
+};
+
+export type QueryCompletion = {
+  reason: "settled" | "deadline" | "cancelled";
+  targets: readonly RelayCompletion[];
+  receivedEvents: number;
+};
+
+export type FiniteQuery = {
+  workflowOwner:
+    | "wired.browser.thread"
+    | "wired.browser.feed"
+    | "wired.browser.notifications"
+    | "wired.browser.quotes"
+    | "wired.browser.profiles";
+  filters: Filter[];
+  coverage: {
+    configuredRelayUrls: readonly string[];
+    hintedRelayUrls?: readonly string[];
+  };
+  completionDeadlineMs: number;
+  signal?: AbortSignal;
+  onEvent(event: Event, relayUrl: string): void;
+};
+
+export type QueryHandle = {
+  done: Promise<QueryCompletion>;
+  close(): void;
+};
+
+export interface BrowserRelayAccess {
+  connectConfigured(urls: readonly string[]): Promise<void>;
+  startFiniteQuery(query: FiniteQuery): QueryHandle;
+  publish(event: Event): Promise<ReadonlySet<string>>;
+}

--- a/src/nostr/client.test.ts
+++ b/src/nostr/client.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   connect: vi.fn(),
   ensureConnected: vi.fn(),
+  startFiniteQuery: vi.fn(),
 }));
 
 vi.mock("./relay-pool", () => ({
   RelayPool: vi.fn().mockImplementation(() => ({
     connect: mocks.connect,
     ensureConnected: mocks.ensureConnected,
+    startFiniteQuery: mocks.startFiniteQuery,
   })),
 }));
 
@@ -17,6 +19,7 @@ describe("nostr client", () => {
     vi.resetModules();
     mocks.connect.mockReset();
     mocks.ensureConnected.mockReset();
+    mocks.startFiniteQuery.mockReset();
   });
 
   it("connects requested relays without waiting for global relay init", async () => {
@@ -27,5 +30,31 @@ describe("nostr client", () => {
 
     expect(mocks.connect).not.toHaveBeenCalled();
     expect(mocks.ensureConnected).toHaveBeenCalledWith(relayUrls);
+  });
+
+  it("cancels active finite queries during route subscription cleanup", async () => {
+    const result = { reason: "cancelled" as const, targets: [] as [], receivedEvents: 0 };
+    let resolveDone!: (value: {
+      reason: "cancelled";
+      targets: [];
+      receivedEvents: number;
+    }) => void;
+    const close = vi.fn();
+    const done = new Promise<typeof result>((resolve) => { resolveDone = resolve; });
+    mocks.startFiniteQuery.mockReturnValue({ close, done });
+    const { closeAllSubscriptions, startFiniteQuery } = await import("./client");
+
+    startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ kinds: [1] }],
+      coverage: { configuredRelayUrls: ["wss://relay.example"] },
+      completionDeadlineMs: 1_000,
+      onEvent: vi.fn(),
+    });
+    closeAllSubscriptions();
+
+    expect(close).toHaveBeenCalledOnce();
+    resolveDone(result);
+    await done;
   });
 });

--- a/src/nostr/client.ts
+++ b/src/nostr/client.ts
@@ -5,6 +5,7 @@ import {
   THREAD_RELAYS as CONFIG_THREAD_RELAYS,
 } from "../config";
 import { RelayPool } from "./relay-pool";
+import type { FiniteQuery, QueryHandle } from "./browser-relay-access";
 import { SubscriptionRegistry } from "./subscription-registry";
 import {
   RelayWorkflowCollector,
@@ -19,10 +20,18 @@ import {
 } from "./evidence/relay-workflow-exporter";
 
 export { THREAD_RELAYS } from "../config";
+export type {
+  FiniteQuery,
+  QueryCompletion,
+  QueryHandle,
+  RelayCompletion,
+  RelayCompletionState,
+} from "./browser-relay-access";
 
 let pool: RelayPool | null = null;
 let registry: SubscriptionRegistry | null = null;
 let connectPromise: Promise<void> | null = null;
+const activeFiniteQueries = new Set<QueryHandle>();
 let scheduleWorkflowEvidenceExport = () => {};
 const workflowEvidence = new RelayWorkflowCollector({
   onChange: () => { scheduleWorkflowEvidenceExport(); },
@@ -111,6 +120,17 @@ export async function ensureRelaysConnected(urls: readonly string[]): Promise<vo
   await pool.ensureConnected(urls);
 }
 
+export function startFiniteQuery(query: FiniteQuery): QueryHandle {
+  ensureNostrClient();
+  if (!pool) {
+    throw new Error("Nostr client is not initialized.");
+  }
+  const handle = pool.startFiniteQuery(query);
+  activeFiniteQueries.add(handle);
+  void handle.done.finally(() => activeFiniteQueries.delete(handle));
+  return handle;
+}
+
 export async function publish(event: Event): Promise<Set<string>> {
   await initNostr();
   if (!pool) {
@@ -125,4 +145,5 @@ export function isNostrReady(): boolean {
 
 export function closeAllSubscriptions(): void {
   registry?.closeAll();
+  [...activeFiniteQueries].forEach((query) => query.close());
 }

--- a/src/nostr/evidence/relay-workflow-collector.test.ts
+++ b/src/nostr/evidence/relay-workflow-collector.test.ts
@@ -55,6 +55,43 @@ describe("RelayWorkflowCollector", () => {
     expect(collector.snapshot()).toEqual([]);
   });
 
+  it("adds late cleanup without creating another operation sample", () => {
+    const collector = new RelayWorkflowCollector();
+    const timedOut = {
+      ...validRelayWorkflowEvidence.query,
+      outcome: "timed-out" as const,
+      work: { attempts: 1, targets: 1 },
+      terminal: {
+        eose: 0,
+        closed: 0,
+        connectFailed: 0,
+        timedOut: 1,
+        cancelled: 0,
+      },
+      timingMs: { firstResult: null, completion: 25 },
+    };
+    collector.record(timedOut);
+    collector.recordLateConnectionClosed({
+      workflowOwner: timedOut.workflowOwner,
+      operation: "query",
+      outcome: "timed-out",
+    });
+
+    const [aggregate] = collector.snapshot();
+    expect(aggregate).toMatchObject({
+      samples: 1,
+      totals: expect.objectContaining({
+        attempts: 1,
+        targets: 1,
+        timedOut: 1,
+        connectionsOpened: 3,
+        connectionsClosed: 3,
+        lateConnectionsClosed: 1,
+      }),
+      completionMs: { "25": 1 },
+    });
+  });
+
   it("isolates change callback failures", () => {
     const collector = new RelayWorkflowCollector({
       onChange() { throw new Error("scheduler unavailable"); },

--- a/src/nostr/evidence/relay-workflow-collector.ts
+++ b/src/nostr/evidence/relay-workflow-collector.ts
@@ -5,6 +5,7 @@ import {
   type RelayWorkflowEvidence,
 } from "../../contracts/relay-workflow-evidence";
 import type { RelayWorkflowAggregate } from "../../contracts/relay-workflow-status";
+import { RELAY_WORKFLOW_TOTAL_KEYS } from "../../contracts/relay-workflow-status";
 
 export type { RelayWorkflowAggregate } from "../../contracts/relay-workflow-status";
 
@@ -18,6 +19,11 @@ type MutableAggregate = RelayWorkflowAggregate;
 
 export type RelayWorkflowEvidenceRecorder = {
   record(evidence: unknown): void;
+  recordLateConnectionClosed?(delta: {
+    workflowOwner: RelayWorkflowEvidence["workflowOwner"];
+    operation: RelayWorkflowEvidence["operation"];
+    outcome: RelayWorkflowEvidence["outcome"];
+  }): void;
 };
 
 export class RelayWorkflowCollector implements RelayWorkflowEvidenceRecorder {
@@ -102,6 +108,29 @@ export class RelayWorkflowCollector implements RelayWorkflowEvidenceRecorder {
     this.notifyChange();
   }
 
+  recordLateConnectionClosed(delta: {
+    workflowOwner: RelayWorkflowEvidence["workflowOwner"];
+    operation: RelayWorkflowEvidence["operation"];
+    outcome: RelayWorkflowEvidence["outcome"];
+  }): void {
+    const key = [delta.workflowOwner, delta.operation, delta.outcome].join("|");
+    const aggregate = this.aggregates.get(key) ?? this.createAggregate(delta);
+    aggregate.totals.connectionsOpened = this.add(
+      aggregate.totals.connectionsOpened ?? 0,
+      1,
+    );
+    aggregate.totals.connectionsClosed = this.add(
+      aggregate.totals.connectionsClosed ?? 0,
+      1,
+    );
+    aggregate.totals.lateConnectionsClosed = this.add(
+      aggregate.totals.lateConnectionsClosed ?? 0,
+      1,
+    );
+    this.aggregates.set(key, aggregate);
+    this.notifyChange();
+  }
+
   snapshot(): RelayWorkflowAggregate[] {
     return [...this.aggregates.values()]
       .sort((left, right) =>
@@ -117,9 +146,10 @@ export class RelayWorkflowCollector implements RelayWorkflowEvidenceRecorder {
     return aggregates;
   }
 
-  private createAggregate(
-    evidence: RelayWorkflowEvidence,
-  ): MutableAggregate {
+  private createAggregate(evidence: Pick<
+    RelayWorkflowEvidence,
+    "workflowOwner" | "operation" | "outcome"
+  >): MutableAggregate {
     return {
       schemaVersion: 1,
       workflowOwner: evidence.workflowOwner,
@@ -127,7 +157,7 @@ export class RelayWorkflowCollector implements RelayWorkflowEvidenceRecorder {
       outcome: evidence.outcome,
       samples: 0,
       overflowed: 0,
-      totals: {},
+      totals: Object.fromEntries(RELAY_WORKFLOW_TOTAL_KEYS.map((key) => [key, 0])),
       acceptedCountBuckets: Object.fromEntries(
         RELAY_ACCEPTED_COUNT_BUCKETS.map((bucket) => [bucket, 0]),
       ),

--- a/src/nostr/relay-pool.test.ts
+++ b/src/nostr/relay-pool.test.ts
@@ -16,6 +16,7 @@ function relay(url: string) {
     url,
     connected: true,
     onclose: null as (() => void) | null,
+    close: vi.fn(),
     subscribe: vi.fn(),
     publish: vi.fn(),
   };
@@ -47,6 +48,25 @@ describe("RelayPool", () => {
     await connected;
 
     expect(pool.connectedUrls).toEqual(["wss://fast.example"]);
+  });
+
+  it("closes a legacy connection that arrives after its connect timeout", async () => {
+    vi.useFakeTimers();
+    const pool = new RelayPool();
+    const lateRelay = relay("wss://late.example");
+    let resolveConnection: ((value: typeof lateRelay) => void) | undefined;
+    mocks.connect.mockReturnValue(new Promise((resolve) => {
+      resolveConnection = resolve;
+    }));
+
+    const connecting = pool.ensureConnected([lateRelay.url]);
+    await vi.advanceTimersByTimeAsync(4_000);
+    await connecting;
+    resolveConnection?.(lateRelay);
+    await Promise.resolve();
+
+    expect(lateRelay.close).toHaveBeenCalledOnce();
+    expect(pool.connectedUrls).toEqual([]);
   });
 
   it("settles open subscriptions and removes a terminal relay", async () => {

--- a/src/nostr/relay-pool.ts
+++ b/src/nostr/relay-pool.ts
@@ -1,5 +1,16 @@
 import { Event, Filter, Relay, Subscription } from "nostr-tools";
+import { normalizeURL } from "nostr-tools/utils";
 import type { SubCallback } from "./types";
+import type {
+  BrowserRelayAccess,
+  FiniteQuery,
+  QueryHandle,
+} from "./browser-relay-access";
+import {
+  startBrowserFiniteQuery,
+  type BrowserQueryEvidencePrimitives,
+  type RelayLocation,
+} from "./browser-finite-query";
 import {
   RELAY_EVIDENCE_LIMITS,
   relayAcceptedCountBucket,
@@ -29,9 +40,23 @@ type InFlightPublish = {
 
 type PublishSettlement = "accepted" | "rejected" | "closed";
 
-export class RelayPool {
+type InFlightConnection = {
+  mapKey: string;
+  normalizedUrl: string;
+  promise: Promise<RelayLocation | undefined>;
+  waiters: Set<symbol>;
+  lateEvidence?: {
+    owner: NonNullable<FiniteQuery["workflowOwner"]>;
+    state: "timed-out" | "cancelled";
+  };
+};
+
+export class RelayPool implements BrowserRelayAccess {
   private readonly relays = new Map<string, Relay>();
+  private readonly relaysByNormalizedUrl = new Map<string, RelayLocation>();
   private readonly subscriptionsByRelay = new Map<string, Set<Subscription>>();
+  private readonly closeListenersByRelay = new Map<string, Set<() => void>>();
+  private readonly inFlightConnections = new Map<string, InFlightConnection>();
   private defaultRelayUrls = new Set<string>();
   private readonly inFlightPublishes = new Map<string, InFlightPublish>();
   private readonly workflowEvidence?: RelayWorkflowEvidenceRecorder;
@@ -67,6 +92,10 @@ export class RelayPool {
     await this.ensureConnected(urls);
   }
 
+  async connectConfigured(urls: readonly string[]): Promise<void> {
+    await this.connect(urls);
+  }
+
   async ensureConnected(urls: readonly string[]): Promise<void> {
     const toConnect = urls.filter((url) => !this.relays.has(url));
     await Promise.allSettled(toConnect.map((url) => this.connectRelay(url)));
@@ -74,42 +103,208 @@ export class RelayPool {
 
   private async connectRelay(url: string): Promise<void> {
     let timeout: ReturnType<typeof setTimeout> | undefined;
+    let timedOut = false;
+    const connection = this.acquireConnection(url);
 
     try {
-      const relay = await Promise.race([
-        Relay.connect(url),
+      await Promise.race([
+        connection.promise,
         new Promise<never>((_, reject) => {
           timeout = setTimeout(
-            () => reject(new Error("Relay connection timed out")),
+            () => {
+              timedOut = true;
+              reject(new Error("Relay connection timed out"));
+            },
             RELAY_CONNECT_TIMEOUT_MS,
           );
         }),
       ]);
-      this.relays.set(url, relay);
-      relay.onclose = () => {
-        if (this.relays.get(url) !== relay) return;
-        this.relays.delete(url);
-        // A terminal relay cannot deliver more events. Count its open subscriptions
-        // as EOSE so aggregate traversals can continue immediately and their
-        // library EOSE timers are cleared.
-        const subscriptions = this.subscriptionsByRelay.get(url) ?? [];
-        this.subscriptionsByRelay.delete(url);
-        [...subscriptions].forEach((subscription) => {
-          subscription.receivedEose();
-        });
-      };
     } catch {
       // Relay unavailable; other relays may still connect.
     } finally {
+      connection.release(timedOut ? "timed-out" : undefined);
       if (timeout) clearTimeout(timeout);
     }
+  }
+
+  startFiniteQuery(query: FiniteQuery): QueryHandle {
+    return startBrowserFiniteQuery(query, {
+      normalizeCoverage: (urls) => this.normalizeCoverage(urls),
+      findRelay: (relayUrl) => this.findRelay(relayUrl),
+      acquireConnection: (relayUrl, workflowOwner) =>
+        this.acquireConnection(relayUrl, workflowOwner),
+      addCloseListener: (relayUrl, listener) =>
+        this.addRelayCloseListener(relayUrl, listener),
+      trackSubscription: (mapKey, subscription) =>
+        this.trackSubscription(mapKey, subscription),
+      untrackSubscription: (mapKey, subscription) =>
+        this.untrackSubscription(mapKey, subscription),
+      recordCompletion: query.workflowOwner && this.workflowEvidence
+        ? (primitives) => this.deferEvidence(() =>
+          this.recordQueryEvidence(query.workflowOwner!, primitives)
+        )
+        : undefined,
+    });
+  }
+
+  private normalizeCoverage(urls: readonly string[]): string[] {
+    const normalized = new Set<string>();
+    for (const url of urls) {
+      try {
+        normalized.add(normalizeURL(url));
+      } catch {
+        const preserved = url.trim();
+        if (preserved) normalized.add(preserved);
+      }
+    }
+    return [...normalized];
+  }
+
+  private findRelay(relayUrl: string): { mapKey: string; relay: Relay } | undefined {
+    const exact = this.relays.get(relayUrl);
+    if (exact) return { mapKey: relayUrl, relay: exact };
+    const normalizedRelayUrl = this.normalizeCoverage([relayUrl])[0] ?? relayUrl;
+    return this.relaysByNormalizedUrl.get(normalizedRelayUrl);
+  }
+
+  private acquireConnection(
+    relayUrl: string,
+    workflowOwner?: FiniteQuery["workflowOwner"],
+  ): {
+    promise: Promise<RelayLocation | undefined>;
+    release: (state?: "eose" | "closed" | "connect-failed" | "timed-out" | "cancelled") => void;
+  } {
+    const normalizedRelayUrl = this.normalizeCoverage([relayUrl])[0] ?? relayUrl;
+    const connected = this.relaysByNormalizedUrl.get(normalizedRelayUrl);
+    if (connected?.relay.connected) {
+      return { promise: Promise.resolve(connected), release: () => {} };
+    }
+
+    let connection = this.inFlightConnections.get(normalizedRelayUrl);
+    if (!connection) {
+      const waiters = new Set<symbol>();
+      connection = {
+        mapKey: relayUrl,
+        normalizedUrl: normalizedRelayUrl,
+        promise: Promise.resolve(undefined),
+        waiters,
+      };
+      const ownedConnection = connection;
+      connection.promise = Relay.connect(relayUrl).then((relay) => {
+        this.inFlightConnections.delete(normalizedRelayUrl);
+        if (waiters.size === 0) {
+          relay.close();
+          if (ownedConnection.lateEvidence && this.workflowEvidence) {
+            this.deferEvidence(() => this.recordLateConnectionEvidence(
+              ownedConnection.lateEvidence!,
+            ));
+          }
+          return undefined;
+        }
+        return this.registerRelay(
+          ownedConnection.mapKey,
+          ownedConnection.normalizedUrl,
+          relay,
+        );
+      }).catch((error: unknown) => {
+        this.inFlightConnections.delete(normalizedRelayUrl);
+        throw error;
+      });
+      this.inFlightConnections.set(normalizedRelayUrl, connection);
+    }
+
+    const waiter = Symbol(normalizedRelayUrl);
+    connection.waiters.add(waiter);
+    let released = false;
+    return {
+      promise: connection.promise,
+      release: (state) => {
+        if (released) return;
+        released = true;
+        connection.waiters.delete(waiter);
+        if (workflowOwner && (state === "timed-out" || state === "cancelled")) {
+          connection.lateEvidence ??= { owner: workflowOwner, state };
+        }
+      },
+    };
+  }
+
+  private registerRelay(
+    mapKey: string,
+    normalizedUrl: string,
+    relay: Relay,
+  ): RelayLocation {
+    const existing = this.relaysByNormalizedUrl.get(normalizedUrl);
+    if (existing && existing.relay !== relay) {
+      relay.close();
+      return existing;
+    }
+
+    this.relays.set(mapKey, relay);
+    const location = { mapKey, relay };
+    this.relaysByNormalizedUrl.set(normalizedUrl, location);
+    this.installRelayCloseHandler(mapKey, normalizedUrl, relay);
+    return location;
+  }
+
+  private installRelayCloseHandler(
+    mapKey: string,
+    normalizedUrl: string,
+    relay: Relay,
+  ): void {
+    relay.onclose = () => {
+      if (this.relays.get(mapKey) !== relay) return;
+      this.relays.delete(mapKey);
+      if (this.relaysByNormalizedUrl.get(normalizedUrl)?.relay === relay) {
+        this.relaysByNormalizedUrl.delete(normalizedUrl);
+      }
+      const listeners = this.closeListenersByRelay.get(normalizedUrl) ?? [];
+      this.closeListenersByRelay.delete(normalizedUrl);
+      [...listeners].forEach((listener) => listener());
+      // A terminal relay cannot deliver more events. Count legacy open
+      // subscriptions as EOSE so aggregate traversals can continue immediately.
+      const subscriptions = this.subscriptionsByRelay.get(mapKey) ?? [];
+      this.subscriptionsByRelay.delete(mapKey);
+      [...subscriptions].forEach((subscription) => {
+        subscription.receivedEose();
+      });
+    };
+  }
+
+  private addRelayCloseListener(relayUrl: string, listener: () => void): () => void {
+    const listeners = this.closeListenersByRelay.get(relayUrl) ?? new Set<() => void>();
+    listeners.add(listener);
+    this.closeListenersByRelay.set(relayUrl, listeners);
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) this.closeListenersByRelay.delete(relayUrl);
+    };
+  }
+
+  private trackSubscription(mapKey: string, subscription: Subscription): void {
+    const tracked = this.subscriptionsByRelay.get(mapKey) ?? new Set<Subscription>();
+    tracked.add(subscription);
+    this.subscriptionsByRelay.set(mapKey, tracked);
+  }
+
+  private untrackSubscription(mapKey: string | undefined, subscription: Subscription): void {
+    if (!mapKey) return;
+    const tracked = this.subscriptionsByRelay.get(mapKey);
+    tracked?.delete(subscription);
+    if (tracked?.size === 0) this.subscriptionsByRelay.delete(mapKey);
   }
 
   subscribe(filter: Filter, cb: SubCallback, options: SubscribeOptions = {}): Subscription[] {
     const { closeOnEose = false, relayUrls, onEose } = options;
     const targetUrls = relayUrls ?? [...this.defaultRelayUrls];
     const subscriptions: Subscription[] = [];
-    const connectedUrls = targetUrls.filter((url) => this.relays.get(url)?.connected);
+    let connectedUrls = targetUrls.filter((url) => this.relays.get(url)?.connected);
+    if (connectedUrls.length !== targetUrls.length) {
+      connectedUrls = [...new Set(targetUrls.flatMap((url) => {
+        const connected = this.findRelay(url);
+        return connected?.relay.connected ? [connected.mapKey] : [];
+      }))];
+    }
     let eoseCount = 0;
 
     const handleEose = (sub: Subscription) => {
@@ -178,6 +373,85 @@ export class RelayPool {
     return publish;
   }
 
+  private recordQueryEvidence(
+    workflowOwner: NonNullable<FiniteQuery["workflowOwner"]>,
+    primitives: BrowserQueryEvidencePrimitives,
+  ): void {
+    const terminal = {
+      eose: 0,
+      closed: 0,
+      connectFailed: 0,
+      timedOut: 0,
+      cancelled: 0,
+    };
+    primitives.completion.targets.forEach(({ state }) => {
+      if (state === "eose") terminal.eose += 1;
+      else if (state === "closed") terminal.closed += 1;
+      else if (state === "connect-failed") terminal.connectFailed += 1;
+      else if (state === "timed-out") terminal.timedOut += 1;
+      else terminal.cancelled += 1;
+    });
+    const targetCount = primitives.completion.targets.length;
+    const evidence: RelayWorkflowEvidence = {
+      schemaVersion: 1,
+      workflowOwner,
+      operation: "query",
+      outcome: relayWorkflowOutcome({
+        targets: targetCount,
+        successfulTargets: terminal.eose,
+        timedOut: terminal.timedOut,
+        cancelled: terminal.cancelled,
+      }),
+      work: { attempts: 1, targets: targetCount },
+      connections: { opened: 0, closed: terminal.closed, reused: 0, lateClosed: 0 },
+      relay: {
+        requestsSent: Math.min(RELAY_EVIDENCE_LIMITS.count, primitives.requestsSent),
+        eventsPublished: 0,
+        eventsReceived: Math.min(
+          RELAY_EVIDENCE_LIMITS.count,
+          primitives.completion.receivedEvents,
+        ),
+        requestBytes: Math.min(RELAY_EVIDENCE_LIMITS.bytes, primitives.requestBytes),
+        eventBytesSent: 0,
+        eventBytesReceived: 0,
+      },
+      results: {
+        unique: Math.min(RELAY_EVIDENCE_LIMITS.count, primitives.uniqueResults),
+        duplicates: Math.min(RELAY_EVIDENCE_LIMITS.count, primitives.duplicates),
+        coalescedOperations: 0,
+      },
+      terminal,
+      publishing: { acceptedCountBucket: "none", rejected: 0, ownerRetries: 0 },
+      timingMs: {
+        firstResult: primitives.firstResultMs === null
+          ? null
+          : this.boundedDuration(primitives.firstResultMs),
+        completion: this.boundedDuration(primitives.completionMs),
+      },
+    };
+    this.workflowEvidence?.record(evidence);
+  }
+
+  private recordLateConnectionEvidence(
+    late: {
+      owner: NonNullable<FiniteQuery["workflowOwner"]>;
+      state: "timed-out" | "cancelled";
+    },
+  ): void {
+    this.workflowEvidence?.recordLateConnectionClosed?.({
+      workflowOwner: late.owner,
+      operation: "query",
+      outcome: late.state === "cancelled" ? "cancelled" : "timed-out",
+    });
+  }
+
+  private boundedDuration(durationMs: number): number {
+    return Math.min(
+      RELAY_EVIDENCE_LIMITS.durationMs,
+      Math.max(0, Math.round(durationMs)),
+    );
+  }
+
   private async publishToRelays(
     event: Event,
     operation: InFlightPublish,
@@ -186,7 +460,7 @@ export class RelayPool {
     const accepted = new Set<string>();
     const targetUrls = [...this.defaultRelayUrls];
     const connectedTargets = targetUrls.flatMap((url) => {
-      const relay = this.relays.get(url);
+      const relay = this.relays.get(url) ?? this.findRelay(url)?.relay;
       return relay ? [{ url, relay }] : [];
     });
 

--- a/src/shared/hooks/useFiniteQueryScope.test.tsx
+++ b/src/shared/hooks/useFiniteQueryScope.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { act, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { Link, MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useFiniteQueryScope } from "./useFiniteQueryScope";
+
+const mocks = vi.hoisted(() => ({
+  startFiniteQuery: vi.fn(),
+}));
+
+vi.mock("../../nostr/client", () => ({
+  startFiniteQuery: mocks.startFiniteQuery,
+}));
+
+describe("useFiniteQueryScope", () => {
+  afterEach(() => {
+    mocks.startFiniteQuery.mockReset();
+    document.body.innerHTML = "";
+  });
+
+  it("closes route-owned finite work on an actual navigation", async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+      .IS_REACT_ACT_ENVIRONMENT = true;
+    const close = vi.fn();
+    mocks.startFiniteQuery.mockReturnValue({
+      close,
+      done: new Promise(() => {}),
+    });
+
+    function ThreadRoute() {
+      const startQuery = useFiniteQueryScope();
+      useEffect(() => {
+        startQuery({
+          workflowOwner: "wired.browser.thread",
+          filters: [{ kinds: [1] }],
+          coverage: { configuredRelayUrls: ["wss://relay.example"] },
+          completionDeadlineMs: 1_000,
+          onEvent: vi.fn(),
+        });
+      }, [startQuery]);
+      return <Link to="/feed">Feed</Link>;
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/thread/1"]}>
+          <Routes>
+            <Route path="/thread/:id" element={<ThreadRoute />} />
+            <Route path="/feed" element={<div>Feed route</div>} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+    expect(mocks.startFiniteQuery).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      container.querySelector("a")?.dispatchEvent(new MouseEvent("click", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+      }));
+    });
+
+    expect(container.textContent).toBe("Feed route");
+    expect(close).toHaveBeenCalledOnce();
+    await act(async () => root.unmount());
+  });
+});

--- a/src/shared/hooks/useFiniteQueryScope.ts
+++ b/src/shared/hooks/useFiniteQueryScope.ts
@@ -1,0 +1,20 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { FiniteQuery, QueryHandle } from "../../nostr/browser-relay-access";
+import { startFiniteQuery } from "../../nostr/client";
+
+export function useFiniteQueryScope(): (query: FiniteQuery) => QueryHandle {
+  const active = useRef(new Set<QueryHandle>());
+
+  useEffect(() => () => {
+    const handles = active.current;
+    handles.forEach((handle) => handle.close());
+    handles.clear();
+  }, []);
+
+  return useCallback((query: FiniteQuery) => {
+    const handle = startFiniteQuery(query);
+    active.current.add(handle);
+    void handle.done.finally(() => active.current.delete(handle));
+    return handle;
+  }, []);
+}


### PR DESCRIPTION
## Summary

- add the typed browser finite-query seam at the existing RelayPool/client boundary
- normalize and union configured plus hinted coverage, with one shared configured/finite connection attempt per normalized target
- own EOSE/close/connect-failure/deadline/cancellation settlement, late arrival cleanup, idempotent close, and route-scoped cleanup
- emit bounded, failure-isolated terminal evidence; late cleanup is a counter-only delta so one query remains one operation sample
- keep every existing workflow function as a compatibility adapter; this ticket does not migrate or narrow filters/results

Closes smolgrrr/wired-admin#87

## Verification

- focused lifecycle/collector/navigation matrix: 31/31
- full repository suite: 77 files, 410 tests
- TypeScript: clean
- ESLint: 0 errors (4 pre-existing Fast Refresh warnings)
- standards review: clean
- spec review: clean

Controlled transcripts retained exact event IDs, filters, target fan-out, REQ counts, returned-event counts, and CLOSE/EOSE cleanup. Representative paired 20-run local measurements (candidate vs fixed-point baseline):

- thread initial p50/p95: 8/26 ms vs 7/25 ms; complete: 29/52 ms vs 27/51 ms
- context complete: 18/21 ms vs 17/20 ms
- feed initial: 6/25 ms vs 6/24 ms; complete p50: 27 ms vs 25 ms
- notifications p50/p95: 27/31 ms vs 28/33 ms
- profiles: 33/38 ms vs 33/36 ms
- quotes: 22/23 ms vs 21/22 ms

The 20-run feed completion p95 varied between 45 and 54 ms across repeated candidate batches because one local harness iteration was an outlier; stable p50 differed by 2 ms and protocol/output identity stayed exact. These are client-observed controlled-fixture measurements, not estimates of real relay load.

## Rollout / rollback

This PR lands an inert seam: no production workflow switches to it here. Roll out separately through #88-#92, one existing function at a time, requiring exact targets/filters/results and the workflow p95 stop gate before retaining each adapter. Configured work must start without waiting for hinted connections.

If any adapter changes identity, availability, initial-result timing, completion timing, socket/timer cleanup, or status isolation, revert that adapter to the existing function without removing this seam or its failing fixture. The required workflow owner keeps status evidence attributable; an unavailable collector only drops evidence and never changes relay work.