### PR TITLE
Migrate browser context queries to finite ownership

### DIFF
--- a/src/nostr/subscriptions/context-finite-query.test.ts
+++ b/src/nostr/subscriptions/context-finite-query.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Event } from "nostr-tools";
+import { THREAD_RELAYS } from "../../config";
+
+const mocks = vi.hoisted(() => ({
+  registrySubscribe: vi.fn(),
+  startFiniteQuery: vi.fn(),
+}));
+
+vi.mock("../client", () => ({
+  getRegistry: () => ({ subscribe: mocks.registrySubscribe }),
+  startFiniteQuery: mocks.startFiniteQuery,
+  THREAD_RELAYS,
+}));
+
+import {
+  DEFAULT_BROWSER_QUERY_DEADLINE_MS,
+  type FiniteQuery,
+} from "../browser-relay-access";
+import { subNotesOnce } from ".";
+
+describe("referenced-context finite query", () => {
+  beforeEach(() => {
+    mocks.registrySubscribe.mockReset();
+    mocks.registrySubscribe.mockReturnValue({ id: "legacy", close: vi.fn() });
+    mocks.startFiniteQuery.mockReset();
+    mocks.startFiniteQuery.mockReturnValue({
+      done: new Promise(() => {}),
+      close: vi.fn(),
+    });
+  });
+
+  it("owns the exact batched context filter across the selected coverage", () => {
+    const eventIds = ["1".repeat(64), "2".repeat(64)];
+    const relayUrls = ["wss://context-one.example", "wss://context-two.example"];
+    const onEvent = vi.fn();
+
+    const handle = subNotesOnce(eventIds, onEvent, relayUrls);
+
+    expect(mocks.startFiniteQuery).toHaveBeenCalledOnce();
+    const query = mocks.startFiniteQuery.mock.calls[0]?.[0] as FiniteQuery;
+    expect(query).toMatchObject({
+      workflowOwner: "wired.browser.thread",
+      filters: [{ ids: eventIds, kinds: [1], limit: 2 }],
+      coverage: {
+        configuredRelayUrls: relayUrls,
+        hintedRelayUrls: [],
+      },
+      completionDeadlineMs: DEFAULT_BROWSER_QUERY_DEADLINE_MS,
+    });
+    const event: Event = {
+      id: eventIds[0],
+      pubkey: "a".repeat(64),
+      created_at: 1,
+      kind: 1,
+      tags: [],
+      content: "context",
+      sig: "b".repeat(128),
+    };
+    query.onEvent(event, relayUrls[0]);
+    expect(onEvent).toHaveBeenCalledWith(event, relayUrls[0]);
+
+    handle.close();
+    expect(mocks.startFiniteQuery.mock.results[0]?.value.close).toHaveBeenCalledOnce();
+    expect(mocks.registrySubscribe).not.toHaveBeenCalled();
+  });
+});

--- a/src/nostr/subscriptions/index.ts
+++ b/src/nostr/subscriptions/index.ts
@@ -5,10 +5,16 @@ import {
   PROFILE_RELAYS,
   THREAD_RELAYS,
   getRegistry,
+  startFiniteQuery,
 } from "../client";
+import { DEFAULT_BROWSER_QUERY_DEADLINE_MS } from "../browser-relay-access";
 import type { SubCallback, SubHandle } from "../types";
 import type { QuotedRef } from "@lib/quotedEvents";
-import { createSubHandleOwner, emptySubHandle } from "./utils";
+import {
+  createSubHandleOwner,
+  emptySubHandle,
+  finiteQuerySubHandle,
+} from "./utils";
 import { profileQueryLimit } from "./query-limits";
 
 export type { SubCallback, SubHandle };
@@ -26,18 +32,23 @@ export const subNotesOnce = (
     return emptySubHandle("notes-once:empty");
   }
 
-  return getRegistry().subscribe([
-    {
-      filter: {
+  return finiteQuerySubHandle(
+    "notes-once",
+    startFiniteQuery({
+      workflowOwner: "wired.browser.thread",
+      filters: [{
         ids: eventIds,
         kinds: [1],
         limit: eventIds.length,
+      }],
+      coverage: {
+        configuredRelayUrls: relayUrls,
+        hintedRelayUrls: [],
       },
-      relayUrls,
-      cb: onEvent,
-      closeOnEose: true,
-    },
-  ]);
+      completionDeadlineMs: DEFAULT_BROWSER_QUERY_DEADLINE_MS,
+      onEvent,
+    }),
+  );
 };
 
 export async function subProfilesOnce(


### PR DESCRIPTION
Closes smolgrrr/wired-admin#89

## Outcome

Routes `subNotesOnce` referenced-context retrieval through the owned browser finite-query seam. The caller-facing function, batched exact-ID filter, relay coverage, event delivery, and missing-result deadline semantics remain unchanged.

## Preserved behavior

- One exact batched filter: `ids`, `kinds: [1]`, `limit: ids.length`
- Supplied relay URLs remain the full configured coverage; the default remains `THREAD_RELAYS`
- Reachable context events and relay provenance are forwarded unchanged
- Missing IDs settle only after all covered targets are terminal or the unchanged 4,400 ms deadline
- Closing the existing `SubHandle` cancels and cleans up owned finite work
- Context-hint discovery is deliberately unchanged and remains scoped to ticket #105

## Controlled evidence

Loopback transcript evidence only; this is not an estimate of real relay traffic, load, latency, or capacity.

A 100-sample run produced:

| Variant | Completion p50 | Completion p95 |
|---|---:|---:|
| Fixed point `8836d0e` | 18 ms | 20 ms |
| Candidate | 17 ms | 19 ms |

The candidate meets the ticket's 19 ms completion guardrail. Both variants retained:

- exact filter: reachable ID plus missing ID, `kinds: [1]`, `limit: 2`
- 2 relay requests, 2 EOSE/CLOSE completions, 1 reachable returned event
- request bytes `[183,183]`
- returned-event bytes `[366]`

## Verification

- TDD adapter contract: red on the registry path, green on finite ownership
- Focused adapter + context transcript: 3/3
- Full suite: 79 files / 416 tests
- Typecheck: passed
- Lint: 0 errors; 4 pre-existing Fast Refresh warnings
- Standards review: clean
- Spec review: clean

## Rollout / rollback

Roll out only the `subNotesOnce` context adapter and monitor the existing content-free `wired.browser.thread` terminal/completion evidence. Roll back this adapter to the registry-owned implementation if exact context IDs, selected relay coverage, missing-ID completion, navigation cleanup, or the 19 ms controlled guardrail regresses. The browser finite-query seam and thread/feed root adapters remain independently deployable.
