### PR TITLE
Migrate notification queries to finite ownership

### DIFF
--- a/src/nostr/subscriptions/notification-finite-query.test.ts
+++ b/src/nostr/subscriptions/notification-finite-query.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POW_RELAYS } from "../../config";
+
+const mocks = vi.hoisted(() => ({
+  registrySubscribe: vi.fn(),
+  startFiniteQuery: vi.fn(),
+}));
+
+vi.mock("../client", () => ({
+  getRegistry: () => ({ subscribe: mocks.registrySubscribe }),
+  startFiniteQuery: mocks.startFiniteQuery,
+}));
+
+import type { FiniteQuery, QueryCompletion } from "../browser-relay-access";
+import { subNotifications } from "./notifications";
+
+function settled(query: FiniteQuery): QueryCompletion {
+  return {
+    reason: "settled",
+    targets: query.coverage.configuredRelayUrls.map((relayUrl) => ({
+      relayUrl,
+      state: "eose",
+    })),
+    receivedEvents: 0,
+  };
+}
+
+describe("notification finite queries", () => {
+  beforeEach(() => {
+    mocks.registrySubscribe.mockReset();
+    mocks.registrySubscribe.mockReturnValue({ id: "legacy", close: vi.fn() });
+    mocks.startFiniteQuery.mockReset();
+    mocks.startFiniteQuery.mockImplementation(() => ({
+      done: new Promise(() => {}),
+      close: vi.fn(),
+    }));
+  });
+
+  it("owns authored and mentioned filters separately and syncs after both complete", () => {
+    const pubkeys = ["a".repeat(64)];
+    const onEose = vi.fn();
+
+    const handle = subNotifications(pubkeys, vi.fn(), onEose);
+
+    expect(mocks.startFiniteQuery).toHaveBeenCalledTimes(2);
+    const authored = mocks.startFiniteQuery.mock.calls[0]?.[0] as FiniteQuery;
+    const mentioned = mocks.startFiniteQuery.mock.calls[1]?.[0] as FiniteQuery;
+    expect(authored).toMatchObject({
+      workflowOwner: "wired.browser.notifications",
+      filters: [{ authors: pubkeys, kinds: [1], limit: 25 }],
+      coverage: { configuredRelayUrls: POW_RELAYS, hintedRelayUrls: [] },
+    });
+    expect(mentioned).toMatchObject({
+      workflowOwner: "wired.browser.notifications",
+      filters: [{ "#p": pubkeys, kinds: [1], limit: 50 }],
+      coverage: { configuredRelayUrls: POW_RELAYS, hintedRelayUrls: [] },
+    });
+
+    authored.onComplete?.(settled(authored));
+    expect(onEose).not.toHaveBeenCalled();
+    mentioned.onComplete?.(settled(mentioned));
+    expect(onEose).toHaveBeenCalledOnce();
+
+    handle.close();
+    expect(mocks.startFiniteQuery.mock.results[0]?.value.close).toHaveBeenCalledOnce();
+    expect(mocks.startFiniteQuery.mock.results[1]?.value.close).toHaveBeenCalledOnce();
+    expect(mocks.registrySubscribe).not.toHaveBeenCalled();
+  });
+
+  it("closes both owned queries without reporting sync when the owner cancels", () => {
+    mocks.startFiniteQuery.mockImplementation((query: FiniteQuery) => ({
+      done: new Promise(() => {}),
+      close: vi.fn(() => query.onComplete?.({
+        reason: "cancelled",
+        targets: query.coverage.configuredRelayUrls.map((relayUrl) => ({
+          relayUrl,
+          state: "cancelled",
+        })),
+        receivedEvents: 0,
+      })),
+    }));
+    const onEose = vi.fn();
+    const handle = subNotifications(["a".repeat(64)], vi.fn(), onEose);
+
+    handle.close();
+
+    expect(onEose).not.toHaveBeenCalled();
+    expect(mocks.startFiniteQuery.mock.results[0]?.value.close).toHaveBeenCalledOnce();
+    expect(mocks.startFiniteQuery.mock.results[1]?.value.close).toHaveBeenCalledOnce();
+  });
+});

--- a/src/nostr/subscriptions/notifications.ts
+++ b/src/nostr/subscriptions/notifications.ts
@@ -1,6 +1,12 @@
-import { getRegistry } from "../client";
+import { POW_RELAYS } from "../../config";
+import { startFiniteQuery } from "../client";
+import { DEFAULT_BROWSER_QUERY_DEADLINE_MS } from "../browser-relay-access";
 import type { SubCallback, SubHandle } from "../types";
-import { emptySubHandle } from "./utils";
+import {
+  createSubHandleOwner,
+  emptySubHandle,
+  finiteQuerySubHandle,
+} from "./utils";
 
 export const subNotifications = (
   pubkeys: string[],
@@ -12,36 +18,45 @@ export const subNotifications = (
     return emptySubHandle("notifications:empty");
   }
 
-  let eoseCount = 0;
-  const handleEose = () => {
-    eoseCount += 1;
-    if (eoseCount >= 2) {
+  const owner = createSubHandleOwner("notifications");
+  const relayUrls = options.relayUrls ?? POW_RELAYS;
+  let completedQueries = 0;
+  const handleCompletion = () => {
+    completedQueries += 1;
+    if (completedQueries >= 2) {
       onEose?.();
     }
   };
 
-  return getRegistry().subscribe([
+  const filters = [
     {
-      filter: {
-        authors: pubkeys,
-        kinds: [1],
-        limit: 25,
-      },
-      cb: onEvent,
-      closeOnEose: true,
-      onEose: handleEose,
-      relayUrls: options.relayUrls,
+      authors: pubkeys,
+      kinds: [1],
+      limit: 25,
     },
     {
-      filter: {
-        "#p": pubkeys,
-        kinds: [1],
-        limit: 50,
-      },
-      cb: onEvent,
-      closeOnEose: true,
-      onEose: handleEose,
-      relayUrls: options.relayUrls,
+      "#p": pubkeys,
+      kinds: [1],
+      limit: 50,
     },
-  ]);
+  ];
+
+  filters.forEach((filter, index) => {
+    const query = startFiniteQuery({
+      workflowOwner: "wired.browser.notifications",
+      filters: [filter],
+      coverage: {
+        configuredRelayUrls: relayUrls,
+        hintedRelayUrls: [],
+      },
+      completionDeadlineMs: DEFAULT_BROWSER_QUERY_DEADLINE_MS,
+      onEvent,
+      onComplete: (completion) => {
+        if (completion.reason !== "cancelled") handleCompletion();
+      },
+    });
+    owner.add(finiteQuerySubHandle(`notifications:${index}`, query));
+  });
+
+  return owner.handle();
 };

--- a/src/nostr/subscriptions/notifications.ts
+++ b/src/nostr/subscriptions/notifications.ts
@@ -20,14 +20,6 @@ export const subNotifications = (
 
   const owner = createSubHandleOwner("notifications");
   const relayUrls = options.relayUrls ?? POW_RELAYS;
-  let completedQueries = 0;
-  const handleCompletion = () => {
-    completedQueries += 1;
-    if (completedQueries >= 2) {
-      onEose?.();
-    }
-  };
-
   const filters = [
     {
       authors: pubkeys,
@@ -40,6 +32,13 @@ export const subNotifications = (
       limit: 50,
     },
   ];
+  let completedQueries = 0;
+  const handleCompletion = () => {
+    completedQueries += 1;
+    if (completedQueries >= filters.length) {
+      onEose?.();
+    }
+  };
 
   filters.forEach((filter, index) => {
     const query = startFiniteQuery({

--- a/src/nostr/testing/notification-enrichment-transcript.test.ts
+++ b/src/nostr/testing/notification-enrichment-transcript.test.ts
@@ -238,6 +238,48 @@ describe("notification and enrichment relay transcripts", () => {
     });
   });
 
+  it("completes an empty notification union across all covered relays", async () => {
+    const session = new RelayTranscriptSession();
+    const relayUrls = await Promise.all([0, 1].map(async () => {
+      const relay = await RelayTranscriptHarness.listen({
+        session,
+        onRequest(request) {
+          request.sendEose(5);
+        },
+      });
+      harnesses.push(relay);
+      return relay.url;
+    }));
+    await ensureRelaysConnected(relayUrls);
+    const workflow = session.beginWorkflow("notifications-empty");
+    const receivedIds = new Set<string>();
+    let completed = false;
+    const handle = subNotifications(
+      [localAuthored.pubkey],
+      (event) => receivedIds.add(event.id),
+      () => { completed = true; },
+      { relayUrls },
+    );
+
+    await session.waitFor(() => completed);
+    await session.waitFor((entries) =>
+      entries.filter((entry) => entry.type === "close").length === 4
+    );
+    handle.close();
+    workflow.complete();
+
+    expect(receivedIds).toEqual(new Set());
+    const entries = workflowEntries(session, workflow);
+    expectExactFiniteCompletion(entries);
+    expect(session.summary(workflow)).toMatchObject({
+      requests: 4,
+      closes: 4,
+      eose: 4,
+      returnedEvents: 0,
+      relayFanout: 2,
+    });
+  });
+
   it("captures batched profiles and deterministic newest metadata inputs", async () => {
     const session = new RelayTranscriptSession();
     const profileKeys = [localPubkeyKey, otherKey];


### PR DESCRIPTION
Closes smolgrrr/wired-admin#90

## Outcome

Moves the authored and mentioned notification queries behind owned finite completion while preserving their separate filters, visible union, relay coverage, and synchronization state.

## Preserved behavior

- Authored filter remains `authors + kinds [1] + limit 25`
- Mentioned filter remains `#p + kinds [1] + limit 50`
- The two filters remain separate finite queries, preserving 4 REQs across the two-relay fixture
- Default coverage remains the configured PoW relay set; explicit test/caller coverage is unchanged
- Synchronization fires only after both non-cancelled query groups complete
- Unmount/key-change cancellation closes both owned queries and cannot report a false `synced` state
- Empty and partial-relay completion preserve the visible union contract

## Controlled evidence

Loopback transcript evidence only; not an estimate of public relay traffic, load, latency, or capacity.

100 samples:

| Variant | Completion p50 | Completion p95 |
|---|---:|---:|
| Fixed point `23eb642` | 28 ms | 30 ms |
| Candidate | 28 ms | 30 ms |

Both are below the 39 ms guardrail. Exact evidence remained identical:

- 4 REQs, 4 EOSE/CLOSE, 6 raw deliveries, 2 visible unique IDs
- request bytes `[119,114,119,114]`
- returned-event bytes `[451,451,439,451,451,439]`

Additional fixtures cover empty union (4 EOSE/CLOSE, zero events), partial relay disconnect with exact IDs, and cancellation of both owned handles without sync.

## Verification

- Focused adapter/transcript: 8/8
- Full suite: 80 files / 419 tests
- Typecheck: passed
- Lint: 0 errors; 4 pre-existing Fast Refresh warnings
- Standards review: clean after deriving completion cardinality from `filters.length`
- Spec review: clean

## Rollout / rollback

Roll out only `subNotifications` and monitor bounded `wired.browser.notifications` completion/cancellation evidence plus the existing UI sync/degraded state. Roll back to registry ownership if exact authored/mentioned IDs, relay coverage, empty/partial completion, unmount cleanup, synchronization state, or the 39 ms controlled guardrail regresses. Notification history/cursor behavior remains unchanged for #112/#113.
