### PR TITLE
Migrate quote queries to finite ownership

### DIFF
--- a/src/nostr/subscriptions/index.ts
+++ b/src/nostr/subscriptions/index.ts
@@ -100,33 +100,6 @@ function extraRelayHintsForQuote(
   return uniqueRelayUrls(ref.relays.filter((relay) => !fallbackRelays.has(relay)));
 }
 
-function hasExtraRelayHints(
-  ref: QuotedRef,
-  fallbackRelayUrls?: readonly string[],
-): boolean {
-  return extraRelayHintsForQuote(ref, fallbackRelayUrls).length > 0;
-}
-
-function quoteRequests(
-  refs: QuotedRef[],
-  onEvent: SubCallback,
-  onEose: ((refId: string) => void) | undefined,
-  relayUrlsForRef: (ref: QuotedRef) => string[],
-  shouldReportEose: (ref: QuotedRef) => boolean = () => true,
-) {
-  return refs.map((ref) => ({
-    filter: {
-      ids: [ref.id],
-      kinds: [1, 1068],
-      limit: 1,
-    },
-    cb: onEvent,
-    closeOnEose: true,
-    onEose: onEose && shouldReportEose(ref) ? () => onEose(ref.id) : undefined,
-    relayUrls: relayUrlsForRef(ref),
-  }));
-}
-
 export async function subQuotedEventsOnce(
   refs: QuotedRef[],
   onEvent: SubCallback,
@@ -148,43 +121,26 @@ export async function subQuotedEventsOnce(
   }
 
   const owner = createSubHandleOwner("quoted-events-once");
-  const refsWithExtraHints = refs.filter((ref) =>
-    hasExtraRelayHints(ref, fallbackRelayUrls)
-  );
-
-  owner.add(
-    getRegistry().subscribe(
-      quoteRequests(
-        refs,
-        onEvent,
-        onEose,
-        () => fallbackRelayUrlsForQuote(fallbackRelayUrls),
-        (ref) => !hasExtraRelayHints(ref, fallbackRelayUrls),
-      ),
-    ),
-  );
-
-  if (refsWithExtraHints.length > 0) {
-    const extraRelayHints = uniqueRelayUrls(
-      refsWithExtraHints.flatMap((ref) =>
-        extraRelayHintsForQuote(ref, fallbackRelayUrls)
-      ),
-    );
-    void ensureRelaysConnected(extraRelayHints)
-      .then(() => {
-        owner.add(
-          getRegistry().subscribe(
-            quoteRequests(
-              refsWithExtraHints,
-              onEvent,
-              onEose,
-              (ref) => extraRelayHintsForQuote(ref, fallbackRelayUrls),
-            ),
-          ),
-        );
-      })
-      .catch(() => {});
-  }
+  refs.forEach((ref) => {
+    const query = startFiniteQuery({
+      workflowOwner: "wired.browser.quotes",
+      filters: [{
+        ids: [ref.id],
+        kinds: [1, 1068],
+        limit: 1,
+      }],
+      coverage: {
+        configuredRelayUrls: fallbackRelayUrlsForQuote(fallbackRelayUrls),
+        hintedRelayUrls: extraRelayHintsForQuote(ref, fallbackRelayUrls),
+      },
+      completionDeadlineMs: DEFAULT_BROWSER_QUERY_DEADLINE_MS,
+      onEvent,
+      onComplete: (completion) => {
+        if (completion.reason !== "cancelled") onEose?.(ref.id);
+      },
+    });
+    owner.add(finiteQuerySubHandle(`quoted-event:${ref.id}`, query));
+  });
 
   return owner.handle();
 }

--- a/src/nostr/subscriptions/quote-finite-query.test.ts
+++ b/src/nostr/subscriptions/quote-finite-query.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ensureRelaysConnected: vi.fn(),
+  startFiniteQuery: vi.fn(),
+}));
+
+vi.mock("../client", () => ({
+  ensureRelaysConnected: mocks.ensureRelaysConnected,
+  getRegistry: () => ({ subscribe: vi.fn() }),
+  initNostr: vi.fn(),
+  PROFILE_RELAYS: [],
+  startFiniteQuery: mocks.startFiniteQuery,
+  THREAD_RELAYS: [],
+}));
+
+import type { FiniteQuery } from "../browser-relay-access";
+import { subQuotedEventsOnce } from ".";
+
+describe("quote finite queries", () => {
+  beforeEach(() => {
+    mocks.ensureRelaysConnected.mockReset();
+    mocks.ensureRelaysConnected.mockResolvedValue(undefined);
+    mocks.startFiniteQuery.mockReset();
+    mocks.startFiniteQuery.mockReturnValue({
+      done: new Promise(() => {}),
+      close: vi.fn(),
+    });
+  });
+
+  it("owns fallback plus extra hinted coverage per reference", async () => {
+    const fallbackRelayUrls = ["wss://fallback-one.example", "wss://fallback-two.example"];
+    const hint = "wss://hint.example";
+    const ref = { id: "1".repeat(64), relays: [hint] };
+    const onEose = vi.fn();
+
+    const handle = await subQuotedEventsOnce([ref], vi.fn(), onEose, {
+      fallbackRelayUrls,
+    });
+
+    expect(mocks.startFiniteQuery).toHaveBeenCalledOnce();
+    const query = mocks.startFiniteQuery.mock.calls[0]?.[0] as FiniteQuery;
+    expect(query).toMatchObject({
+      workflowOwner: "wired.browser.quotes",
+      filters: [{ ids: [ref.id], kinds: [1, 1068], limit: 1 }],
+      coverage: {
+        configuredRelayUrls: fallbackRelayUrls,
+        hintedRelayUrls: [hint],
+      },
+    });
+    query.onComplete?.({
+      reason: "settled",
+      targets: [],
+      receivedEvents: 0,
+    });
+    expect(onEose).toHaveBeenCalledWith(ref.id);
+
+    handle.close();
+    expect(mocks.startFiniteQuery.mock.results[0]?.value.close).toHaveBeenCalledOnce();
+  });
+});

--- a/src/nostr/subscriptions/quoted-events.test.ts
+++ b/src/nostr/subscriptions/quoted-events.test.ts
@@ -4,19 +4,19 @@ import { POW_RELAYS, QUOTE_FALLBACK_RELAYS, THREAD_RELAYS } from "../../config";
 const mocks = vi.hoisted(() => ({
   ensureRelaysConnected: vi.fn(),
   initNostr: vi.fn(),
-  subscribe: vi.fn(),
+  startFiniteQuery: vi.fn(),
 }));
 
 vi.mock("../client", () => ({
   ensureRelaysConnected: mocks.ensureRelaysConnected,
-  getRegistry: () => ({
-    subscribe: mocks.subscribe,
-  }),
+  getRegistry: () => ({ subscribe: vi.fn() }),
   initNostr: mocks.initNostr,
   PROFILE_RELAYS: THREAD_RELAYS,
+  startFiniteQuery: mocks.startFiniteQuery,
   THREAD_RELAYS,
 }));
 
+import type { FiniteQuery } from "../browser-relay-access";
 import { subQuotedEventsOnce } from "./index";
 
 const quoteId = "a38fb77ce8783c30bf64063fe78e8060f3b58e41476fb3a5cd94ddfb1b3837d1";
@@ -29,20 +29,16 @@ describe("subQuotedEventsOnce", () => {
   beforeEach(() => {
     mocks.ensureRelaysConnected.mockReset();
     mocks.initNostr.mockReset();
-    mocks.subscribe.mockReset();
+    mocks.startFiniteQuery.mockReset();
     mocks.initNostr.mockResolvedValue(undefined);
     mocks.ensureRelaysConnected.mockResolvedValue(undefined);
-    mocks.subscribe.mockReturnValue({ id: "sub", close: vi.fn() });
+    mocks.startFiniteQuery.mockReturnValue({
+      done: new Promise(() => {}),
+      close: vi.fn(),
+    });
   });
 
-  it("subscribes to fallback quote relays before waiting for stale relay hints", async () => {
-    let resolveHintRelays: () => void = () => {};
-    mocks.ensureRelaysConnected.mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolveHintRelays = resolve;
-      }),
-    );
-
+  it("starts configured fallback coverage with a stale relay hint", async () => {
     await subQuotedEventsOnce(
       [{ id: quoteId, relays: ["wss://nostr.land"] }],
       vi.fn(),
@@ -50,27 +46,16 @@ describe("subQuotedEventsOnce", () => {
     );
 
     expect(mocks.initNostr).toHaveBeenCalledTimes(1);
-    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
-    expect(mocks.ensureRelaysConnected).toHaveBeenCalledWith(["wss://nostr.land"]);
-
-    const fallbackRequest = mocks.subscribe.mock.calls[0][0][0];
-    expect(fallbackRequest.filter).toEqual({
-      ids: [quoteId],
-      kinds: [1, 1068],
-      limit: 1,
+    expect(mocks.startFiniteQuery).toHaveBeenCalledOnce();
+    expect(mocks.ensureRelaysConnected).not.toHaveBeenCalled();
+    const query = mocks.startFiniteQuery.mock.calls[0][0] as FiniteQuery;
+    expect(query.filters).toEqual([{
+      ids: [quoteId], kinds: [1, 1068], limit: 1,
+    }]);
+    expect(query.coverage).toEqual({
+      configuredRelayUrls: [...new Set([...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS])],
+      hintedRelayUrls: ["wss://nostr.land"],
     });
-    expect(fallbackRequest.relayUrls).toEqual([
-      ...new Set([...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS]),
-    ]);
-    expect(fallbackRequest.onEose).toBeUndefined();
-
-    resolveHintRelays();
-    await Promise.resolve();
-
-    expect(mocks.subscribe).toHaveBeenCalledTimes(2);
-    const hintedRequest = mocks.subscribe.mock.calls[1][0][0];
-    expect(hintedRequest.relayUrls).toEqual(["wss://nostr.land"]);
-    expect(hintedRequest.onEose).toEqual(expect.any(Function));
   });
 
   it("reports EOSE from the fallback subscription when no extra relay hints exist", async () => {
@@ -83,14 +68,13 @@ describe("subQuotedEventsOnce", () => {
     );
 
     expect(mocks.ensureRelaysConnected).not.toHaveBeenCalled();
-    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
-
-    const fallbackRequest = mocks.subscribe.mock.calls[0][0][0];
-    expect(fallbackRequest.relayUrls).toEqual([
+    expect(mocks.startFiniteQuery).toHaveBeenCalledOnce();
+    const query = mocks.startFiniteQuery.mock.calls[0][0] as FiniteQuery;
+    expect(query.coverage.configuredRelayUrls).toEqual([
       ...new Set([...POW_RELAYS, ...QUOTE_FALLBACK_RELAYS, "wss://nos.lol"]),
     ]);
-
-    fallbackRequest.onEose();
+    expect(query.coverage.hintedRelayUrls).toEqual([]);
+    query.onComplete?.({ reason: "settled", targets: [], receivedEvents: 0 });
     expect(onEose).toHaveBeenCalledWith(quoteId);
   });
 
@@ -116,12 +100,12 @@ describe("subQuotedEventsOnce", () => {
       vi.fn(),
     );
 
-    const fallbackRequest = mocks.subscribe.mock.calls[0][0][0];
-    expect(fallbackRequest.relayUrls).toEqual([
+    const query = mocks.startFiniteQuery.mock.calls[0][0] as FiniteQuery;
+    expect(query.coverage.configuredRelayUrls).toEqual([
       ...powRelays,
       ...defaultQuoteRelays,
       ...configuredQuoteRelays,
     ]);
-    expect(mocks.ensureRelaysConnected).toHaveBeenCalledWith(["wss://nostr.land"]);
+    expect(query.coverage.hintedRelayUrls).toEqual(["wss://nostr.land"]);
   });
 });


### PR DESCRIPTION
Closes smolgrrr/wired-admin#91

## Outcome
Moves each quote reference behind one owned finite query. Configured fallback coverage starts first; only extra relays are hinted coverage. Exact kind 1/1068 filters and per-reference missing completion remain unchanged.

## Controlled evidence
Loopback evidence only—not real relay-load evidence.

- 20-run baseline p50/p95: `22/22 ms`
- Candidate: `22/23 ms`, meeting the `<=23 ms` guardrail
- Normal fixture unchanged: 5 REQs, 5 EOSE/CLOSE, 3 deliveries, exact IDs
- Stale/missing fixture unchanged: 7 REQs; invalid hint sends no REQ; exact fallback/hinted/missing completion
- Request bytes `[120,120,120,120,120]`, returned bytes `[382,382,386]`, unchanged

Late hint connections and cancellation are owned by the finite seam; cancellation does not report a missing state.

## Verification
- Focused quote/unit/transcript: 10/10
- Full suite: 81 files / 420 tests
- Typecheck passed; lint 0 errors (4 pre-existing warnings)
- Standards review clean; Spec review clean

## Rollout / rollback
Roll out only `subQuotedEventsOnce` and monitor `wired.browser.quotes` completion/cancellation/late-cleanup evidence. Roll back to the split registry fallback/hint implementation if exact IDs, configured/hinted coverage, stale/missing completion, cleanup, duplicate REQs, or the 23 ms guardrail regresses. Quote batching remains out of scope for #118.
