### PR TITLE
Migrate profile queries to finite ownership

### DIFF
--- a/src/nostr/subscriptions/index.ts
+++ b/src/nostr/subscriptions/index.ts
@@ -4,7 +4,6 @@ import {
   initNostr,
   PROFILE_RELAYS,
   THREAD_RELAYS,
-  getRegistry,
   startFiniteQuery,
 } from "../client";
 import { DEFAULT_BROWSER_QUERY_DEADLINE_MS } from "../browser-relay-access";
@@ -61,25 +60,26 @@ export async function subProfilesOnce(
     return emptySubHandle("profiles-once:empty");
   }
 
-  if (options.relayUrls) {
-    await ensureRelaysConnected(options.relayUrls);
-  } else {
-    await initNostr();
-  }
-
-  return getRegistry().subscribe([
-    {
-      filter: {
+  return finiteQuerySubHandle(
+    "profiles-once",
+    startFiniteQuery({
+      workflowOwner: "wired.browser.profiles",
+      filters: [{
         authors: pubkeys,
         kinds: [0],
         limit: profileQueryLimit(pubkeys.length),
+      }],
+      coverage: {
+        configuredRelayUrls: options.relayUrls ?? PROFILE_RELAYS,
+        hintedRelayUrls: [],
       },
-      cb: onEvent,
-      closeOnEose: true,
-      onEose,
-      relayUrls: options.relayUrls ?? PROFILE_RELAYS,
-    },
-  ]);
+      completionDeadlineMs: DEFAULT_BROWSER_QUERY_DEADLINE_MS,
+      onEvent,
+      onComplete: (completion) => {
+        if (completion.reason !== "cancelled") onEose?.();
+      },
+    }),
+  );
 }
 
 function uniqueRelayUrls(relays: readonly string[]): string[] {

--- a/src/nostr/subscriptions/profile-finite-query.test.ts
+++ b/src/nostr/subscriptions/profile-finite-query.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ensureRelaysConnected: vi.fn(),
+  startFiniteQuery: vi.fn(),
+}));
+
+vi.mock("../client", () => ({
+  ensureRelaysConnected: mocks.ensureRelaysConnected,
+  getRegistry: () => ({ subscribe: vi.fn() }),
+  initNostr: vi.fn(),
+  PROFILE_RELAYS: ["wss://profiles.example"],
+  startFiniteQuery: mocks.startFiniteQuery,
+  THREAD_RELAYS: [],
+}));
+
+import type { FiniteQuery } from "../browser-relay-access";
+import { subProfilesOnce } from ".";
+
+describe("profile finite query", () => {
+  beforeEach(() => {
+    mocks.ensureRelaysConnected.mockReset();
+    mocks.ensureRelaysConnected.mockResolvedValue(undefined);
+    mocks.startFiniteQuery.mockReset();
+    mocks.startFiniteQuery.mockReturnValue({
+      done: new Promise(() => {}),
+      close: vi.fn(),
+    });
+  });
+
+  it("owns the exact batched metadata filter across all configured relays", async () => {
+    const pubkeys = ["a".repeat(64), "b".repeat(64)];
+    const relayUrls = ["wss://profile-one.example", "wss://profile-two.example"];
+    const onEose = vi.fn();
+    const handle = await subProfilesOnce(pubkeys, vi.fn(), onEose, { relayUrls });
+
+    expect(mocks.startFiniteQuery).toHaveBeenCalledOnce();
+    const query = mocks.startFiniteQuery.mock.calls[0]?.[0] as FiniteQuery;
+    expect(query).toMatchObject({
+      workflowOwner: "wired.browser.profiles",
+      filters: [{ authors: pubkeys, kinds: [0], limit: 2 }],
+      coverage: { configuredRelayUrls: relayUrls, hintedRelayUrls: [] },
+    });
+    query.onComplete?.({ reason: "settled", targets: [], receivedEvents: 0 });
+    expect(onEose).toHaveBeenCalledOnce();
+
+    handle.close();
+    expect(mocks.startFiniteQuery.mock.results[0]?.value.close).toHaveBeenCalledOnce();
+  });
+});

--- a/src/shared/hooks/useProfiles.test.tsx
+++ b/src/shared/hooks/useProfiles.test.tsx
@@ -126,4 +126,39 @@ describe("useProfiles batching", () => {
 
     await act(async () => root.unmount());
   });
+
+  it("allows a later consumer to retry after a completed profile miss", async () => {
+    mocks.subProfilesOnce.mockResolvedValue({ id: "profiles", close: vi.fn() });
+    const pubkey = "c".repeat(64);
+    const firstContainer = document.createElement("div");
+    document.body.append(firstContainer);
+    containers.push(firstContainer);
+    const firstRoot = createRoot(firstContainer);
+
+    await act(async () => {
+      firstRoot.render(<Probe pubkey={pubkey} />);
+      await Promise.resolve();
+    });
+    expect(mocks.subProfilesOnce).toHaveBeenCalledTimes(1);
+    const onEose = mocks.subProfilesOnce.mock.calls[0]?.[2] as
+      | (() => void)
+      | undefined;
+    await act(async () => {
+      onEose?.();
+      firstRoot.unmount();
+    });
+
+    const laterContainer = document.createElement("div");
+    document.body.append(laterContainer);
+    containers.push(laterContainer);
+    const laterRoot = createRoot(laterContainer);
+    await act(async () => {
+      laterRoot.render(<Probe pubkey={pubkey} />);
+      await Promise.resolve();
+    });
+
+    expect(mocks.subProfilesOnce).toHaveBeenCalledTimes(2);
+    expect(mocks.subProfilesOnce.mock.calls[1]?.[0]).toEqual([pubkey]);
+    await act(async () => laterRoot.unmount());
+  });
 });


### PR DESCRIPTION
Closes smolgrrr/wired-admin#92

## Outcome
Moves batched profile enrichment behind the owned finite-query seam. Exact kind-0 filters, all configured profile relays, newest-created_at selection, positive caching, and retry-after-miss behavior remain unchanged.

## Controlled evidence
Loopback evidence only—not real relay-load evidence.

- 200-sample fixed point p95: `36 ms`
- Candidate after removing redundant legacy preconnection: `35 ms`
- Original ticket comparator: `34 ms`
- The candidate improves the fixed point but misses the absolute comparator by 1 ms. The user explicitly approved this exception after reviewing those values.
- Exact 2 REQs, 4 metadata events, filters, request bytes `[187,187]`, returned bytes `[384,384,384,384]`, and newest selection remain unchanged.

Missing profiles are not negatively cached; a later consumer retry is explicitly tested. Partial/cancel/deadline lifecycle remains owned by the tested finite seam.

## Verification
- Focused adapter/hook/transcript green
- Full suite: 82 files / 422 tests
- Typecheck passed; lint 0 errors (4 pre-existing warnings)
- Standards review clean; Spec review clean with approved timing exception recorded

## Rollout / rollback
Roll out only `subProfilesOnce`. Monitor bounded `wired.browser.profiles` terminal/completion evidence and visible metadata selection. Roll back to registry ownership if relay coverage, newest selection, positive cache, retry-after-miss, cleanup, or timing regresses from the measured fixed point. In-flight joining and >250 chunking remain scoped to #111/#114.
