### PR TITLE
Add scoped server finite relay session

### DIFF
--- a/lib/serverRelaySession.test.ts
+++ b/lib/serverRelaySession.test.ts
@@ -1,0 +1,446 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Event, Filter } from "nostr-tools";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  useWebSocketImplementation: vi.fn(),
+}));
+
+vi.mock("nostr-tools", () => ({
+  Relay: { connect: mocks.connect },
+  useWebSocketImplementation: mocks.useWebSocketImplementation,
+}));
+
+import { withFiniteRelaySession } from "./serverRelaySession";
+
+function controlledRelay(url: string) {
+  return {
+    url,
+    connected: true,
+    close: vi.fn(),
+    subscribe: vi.fn(),
+  };
+}
+
+type SubscriptionCallbacks = {
+  onevent?: (event: Event) => void;
+  oneose?: () => void;
+  onclose?: (reason: string) => void;
+};
+
+function controlledQueryRelay(url: string) {
+  const callbacks: SubscriptionCallbacks[] = [];
+  const subscriptions: Array<{ close: ReturnType<typeof vi.fn> }> = [];
+  const relay = controlledRelay(url);
+  relay.subscribe.mockImplementation(
+    (_filters: Filter[], params: SubscriptionCallbacks) => {
+      callbacks.push(params);
+      const subscription = { close: vi.fn() };
+      subscriptions.push(subscription);
+      return subscription;
+    },
+  );
+  return { callbacks, relay, subscriptions };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("Wired server finite relay session", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    mocks.connect.mockReset();
+  });
+
+  it("normalizes initial targets, reports connected reuse, and closes the session", async () => {
+    const relay = controlledRelay("wss://one.example/");
+    mocks.connect.mockResolvedValue(relay);
+
+    const outcomes = await withFiniteRelaySession(
+      {
+        relayUrls: ["WSS://ONE.EXAMPLE", "wss://one.example/"],
+        connectDeadlineMs: 1_000,
+      },
+      (session) => session.ensureRelays(["wss://one.example"], 1_000),
+    );
+
+    expect(mocks.connect).toHaveBeenCalledOnce();
+    expect(outcomes).toEqual([
+      { relayUrl: "wss://one.example/", state: "connected" },
+    ]);
+    expect(relay.close).toHaveBeenCalledOnce();
+  });
+
+  it("reports a connection deadline and closes a relay that arrives late", async () => {
+    vi.useFakeTimers();
+    const relay = controlledRelay("wss://late.example/");
+    const connection = deferred<typeof relay>();
+    mocks.connect.mockReturnValue(connection.promise);
+
+    const operation = withFiniteRelaySession(
+      {
+        relayUrls: [relay.url],
+        connectDeadlineMs: 25,
+      },
+      (session) => session.ensureRelays([relay.url], 25),
+    );
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(operation).resolves.toEqual([
+      { relayUrl: relay.url, state: "timed-out" },
+    ]);
+    connection.resolve(relay);
+    await flushPromises();
+
+    expect(relay.close).toHaveBeenCalledOnce();
+    expect(relay.subscribe).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("reports failed targets without preventing partial-relay success", async () => {
+    const connected = controlledQueryRelay("wss://connected.example/");
+    mocks.connect.mockImplementation((url: string) =>
+      url === connected.relay.url
+        ? Promise.resolve(connected.relay)
+        : Promise.reject(new Error("offline")),
+    );
+
+    const result = await withFiniteRelaySession(
+      {
+        relayUrls: [connected.relay.url, "wss://offline.example"],
+        connectDeadlineMs: 1_000,
+      },
+      async (session) => {
+        const connectionOutcomes = await session.ensureRelays(
+          [connected.relay.url, "wss://offline.example"],
+          1_000,
+        );
+        const query = session.query({
+          filters: [{ kinds: [1] }],
+          deadlineMs: 1_000,
+          onEvent: vi.fn(),
+        });
+        await flushPromises();
+        connected.callbacks[0]?.oneose?.();
+        return { connectionOutcomes, completion: await query };
+      },
+    );
+
+    expect(result.connectionOutcomes).toEqual([
+      { relayUrl: connected.relay.url, state: "connected" },
+      { relayUrl: "wss://offline.example/", state: "connect-failed" },
+    ]);
+    expect(result.completion.targets).toEqual([
+      { relayUrl: connected.relay.url, state: "eose" },
+      { relayUrl: "wss://offline.example/", state: "connect-failed" },
+    ]);
+  });
+
+  it("settles immediately when every relay connection fails", async () => {
+    vi.useFakeTimers();
+    mocks.connect.mockRejectedValue(new Error("offline"));
+
+    const result = await withFiniteRelaySession(
+      {
+        relayUrls: ["wss://one.example", "wss://two.example"],
+        connectDeadlineMs: 1_000,
+      },
+      async (session) => ({
+        connectionOutcomes: await session.ensureRelays(
+          ["wss://one.example", "wss://two.example"],
+          1_000,
+        ),
+        completion: await session.query({
+          filters: [{ kinds: [1] }],
+          deadlineMs: 1_000,
+          onEvent: vi.fn(),
+        }),
+      }),
+    );
+
+    expect(result.connectionOutcomes).toEqual([
+      { relayUrl: "wss://one.example/", state: "connect-failed" },
+      { relayUrl: "wss://two.example/", state: "connect-failed" },
+    ]);
+    expect(result.completion).toEqual({
+      reason: "settled",
+      targets: [
+        { relayUrl: "wss://one.example/", state: "connect-failed" },
+        { relayUrl: "wss://two.example/", state: "connect-failed" },
+      ],
+      receivedEvents: 0,
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("streams finite-query events and settles every target after cleanup", async () => {
+    const first = controlledQueryRelay("wss://one.example/");
+    const second = controlledQueryRelay("wss://two.example/");
+    mocks.connect.mockImplementation((url: string) =>
+      Promise.resolve(url === first.relay.url ? first.relay : second.relay),
+    );
+    const onEvent = vi.fn();
+
+    const completion = await withFiniteRelaySession(
+      {
+        relayUrls: [first.relay.url, second.relay.url],
+        connectDeadlineMs: 1_000,
+      },
+      async (session) => {
+        const query = session.query({
+          filters: [{ kinds: [1] }],
+          deadlineMs: 1_000,
+          onEvent,
+        });
+        await flushPromises();
+        const event = { id: "1".repeat(64) } as Event;
+        first.callbacks[0]?.onevent?.(event);
+        second.callbacks[0]?.onevent?.(event);
+        first.callbacks[0]?.oneose?.();
+        second.callbacks[0]?.oneose?.();
+        return query;
+      },
+    );
+
+    expect(onEvent).toHaveBeenNthCalledWith(1, expect.anything(), first.relay.url);
+    expect(onEvent).toHaveBeenNthCalledWith(2, expect.anything(), second.relay.url);
+    expect(completion).toEqual({
+      reason: "settled",
+      targets: [
+        { relayUrl: first.relay.url, state: "eose" },
+        { relayUrl: second.relay.url, state: "eose" },
+      ],
+      receivedEvents: 2,
+    });
+    expect(first.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(second.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(first.relay.close).toHaveBeenCalledOnce();
+    expect(second.relay.close).toHaveBeenCalledOnce();
+  });
+
+  it("settles a relay close before EOSE without waiting for the deadline", async () => {
+    vi.useFakeTimers();
+    const target = controlledQueryRelay("wss://closed.example/");
+    mocks.connect.mockResolvedValue(target.relay);
+
+    const completion = await withFiniteRelaySession(
+      { relayUrls: [target.relay.url], connectDeadlineMs: 1_000 },
+      async (session) => {
+        const query = session.query({
+          filters: [{ kinds: [1] }],
+          deadlineMs: 1_000,
+          onEvent: vi.fn(),
+        });
+        await flushPromises();
+        target.callbacks[0]?.onclose?.("relay closed");
+        return query;
+      },
+    );
+
+    expect(completion).toEqual({
+      reason: "settled",
+      targets: [{ relayUrl: target.relay.url, state: "closed" }],
+      receivedEvents: 0,
+    });
+    expect(target.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cleans a subscription that reaches EOSE during subscribe setup", async () => {
+    const target = controlledQueryRelay("wss://synchronous.example/");
+    target.relay.subscribe.mockImplementation((_filters, params) => {
+      const subscription = { close: vi.fn() };
+      target.subscriptions.push(subscription);
+      params.oneose?.();
+      return subscription;
+    });
+    mocks.connect.mockResolvedValue(target.relay);
+
+    const completion = await withFiniteRelaySession(
+      { relayUrls: [target.relay.url], connectDeadlineMs: 1_000 },
+      (session) => session.query({
+        filters: [{ kinds: [1] }],
+        deadlineMs: 1_000,
+        onEvent: vi.fn(),
+      }),
+    );
+
+    expect(completion).toMatchObject({
+      reason: "settled",
+      targets: [{ relayUrl: target.relay.url, state: "eose" }],
+    });
+    expect(target.subscriptions[0]?.close).toHaveBeenCalledOnce();
+  });
+
+  it("times out a no-EOSE query only after closing its subscription", async () => {
+    vi.useFakeTimers();
+    const target = controlledQueryRelay("wss://silent.example/");
+    mocks.connect.mockResolvedValue(target.relay);
+
+    const operation = withFiniteRelaySession(
+      { relayUrls: [target.relay.url], connectDeadlineMs: 1_000 },
+      async (session) => {
+        const query = session.query({
+          filters: [{ kinds: [1] }],
+          deadlineMs: 25,
+          onEvent: vi.fn(),
+        });
+        await flushPromises();
+        await vi.advanceTimersByTimeAsync(25);
+        return query;
+      },
+    );
+
+    await expect(operation).resolves.toEqual({
+      reason: "deadline",
+      targets: [{ relayUrl: target.relay.url, state: "timed-out" }],
+      receivedEvents: 0,
+    });
+    expect(target.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cancels an active query after cleanup and ignores later events", async () => {
+    vi.useFakeTimers();
+    const target = controlledQueryRelay("wss://cancelled.example/");
+    mocks.connect.mockResolvedValue(target.relay);
+    const controller = new AbortController();
+    const onEvent = vi.fn();
+
+    const completion = await withFiniteRelaySession(
+      { relayUrls: [target.relay.url], connectDeadlineMs: 1_000 },
+      async (session) => {
+        const query = session.query({
+          filters: [{ kinds: [1] }],
+          deadlineMs: 1_000,
+          signal: controller.signal,
+          onEvent,
+        });
+        await flushPromises();
+        controller.abort();
+        target.callbacks[0]?.onevent?.({ id: "2".repeat(64) } as Event);
+        return query;
+      },
+    );
+
+    expect(completion).toEqual({
+      reason: "cancelled",
+      targets: [{ relayUrl: target.relay.url, state: "cancelled" }],
+      receivedEvents: 0,
+    });
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(target.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("adds dynamic hints and reuses their connections across sequential phases", async () => {
+    const configured = controlledQueryRelay("wss://configured.example/");
+    const hinted = controlledQueryRelay("wss://hinted.example/");
+    mocks.connect.mockImplementation((url: string) =>
+      Promise.resolve(url === configured.relay.url ? configured.relay : hinted.relay),
+    );
+
+    const outcomes = await withFiniteRelaySession(
+      { relayUrls: [configured.relay.url], connectDeadlineMs: 1_000 },
+      async (session) => {
+        const hintOutcomes = await session.ensureRelays(
+          [hinted.relay.url, "WSS://HINTED.EXAMPLE"],
+          1_000,
+        );
+        const firstQuery = session.query({
+          filters: [{ ids: ["1".repeat(64)] }],
+          relayUrls: [configured.relay.url, hinted.relay.url],
+          deadlineMs: 1_000,
+          onEvent: vi.fn(),
+        });
+        await flushPromises();
+        configured.callbacks[0]?.oneose?.();
+        hinted.callbacks[0]?.oneose?.();
+        const firstCompletion = await firstQuery;
+
+        const secondQuery = session.query({
+          filters: [{ ids: ["2".repeat(64)] }],
+          relayUrls: [hinted.relay.url],
+          deadlineMs: 1_000,
+          onEvent: vi.fn(),
+        });
+        await flushPromises();
+        hinted.callbacks[1]?.oneose?.();
+        return { hintOutcomes, firstCompletion, secondCompletion: await secondQuery };
+      },
+    );
+
+    expect(outcomes.hintOutcomes).toEqual([
+      { relayUrl: hinted.relay.url, state: "connected" },
+    ]);
+    expect(outcomes.firstCompletion.reason).toBe("settled");
+    expect(outcomes.secondCompletion).toMatchObject({
+      reason: "settled",
+      targets: [{ relayUrl: hinted.relay.url, state: "eose" }],
+    });
+    expect(mocks.connect).toHaveBeenCalledTimes(2);
+    expect(hinted.relay.subscribe).toHaveBeenCalledTimes(2);
+    expect(configured.relay.close).toHaveBeenCalledOnce();
+    expect(hinted.relay.close).toHaveBeenCalledOnce();
+  });
+
+  it("cancels an unawaited connection when the session callback exits", async () => {
+    vi.useFakeTimers();
+    const late = controlledRelay("wss://cancelled-late.example/");
+    const connection = deferred<typeof late>();
+    mocks.connect.mockReturnValue(connection.promise);
+    let dynamicOutcome: Promise<readonly unknown[]> | undefined;
+
+    await withFiniteRelaySession(
+      { relayUrls: [], connectDeadlineMs: 1_000 },
+      (session) => {
+        dynamicOutcome = session.ensureRelays([late.url], 1_000);
+      },
+    );
+
+    await expect(dynamicOutcome).resolves.toEqual([
+      { relayUrl: late.url, state: "cancelled" },
+    ]);
+    connection.resolve(late);
+    await flushPromises();
+    expect(late.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cleans active query handles before propagating a callback failure", async () => {
+    vi.useFakeTimers();
+    const target = controlledQueryRelay("wss://failed-workflow.example/");
+    mocks.connect.mockResolvedValue(target.relay);
+    let query: Promise<unknown> | undefined;
+
+    await expect(withFiniteRelaySession(
+      { relayUrls: [target.relay.url], connectDeadlineMs: 1_000 },
+      async (session) => {
+        query = session.query({
+          filters: [{ kinds: [1] }],
+          deadlineMs: 1_000,
+          onEvent: vi.fn(),
+        });
+        await flushPromises();
+        throw new Error("snapshot failed");
+      },
+    )).rejects.toThrow("snapshot failed");
+
+    await expect(query).resolves.toMatchObject({ reason: "cancelled" });
+    expect(target.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(target.relay.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/lib/serverRelaySession.ts
+++ b/lib/serverRelaySession.ts
@@ -1,0 +1,327 @@
+import {
+  Relay,
+  type Event,
+  type Filter,
+  type Subscription,
+  useWebSocketImplementation,
+} from "nostr-tools";
+import { normalizeURL } from "nostr-tools/utils";
+import { WebSocket } from "ws";
+
+useWebSocketImplementation(WebSocket);
+
+export type RelayConnectionOutcome = {
+  relayUrl: string;
+  state: "connected" | "connect-failed" | "timed-out" | "cancelled";
+};
+
+export type RelaySessionOptions = {
+  relayUrls: readonly string[];
+  connectDeadlineMs: number;
+};
+
+export type FiniteRelayQuery = {
+  filters: Filter[];
+  relayUrls?: readonly string[];
+  deadlineMs: number;
+  signal?: AbortSignal;
+  onEvent(event: Event, relayUrl: string): void;
+};
+
+export type RelayCompletionState =
+  | "eose"
+  | "closed"
+  | "connect-failed"
+  | "timed-out"
+  | "cancelled";
+
+export type QueryCompletion = {
+  reason: "settled" | "deadline" | "cancelled";
+  targets: readonly {
+    relayUrl: string;
+    state: RelayCompletionState;
+  }[];
+  receivedEvents: number;
+};
+
+export interface FiniteRelaySession {
+  ensureRelays(
+    relayUrls: readonly string[],
+    connectDeadlineMs: number,
+  ): Promise<readonly RelayConnectionOutcome[]>;
+  query(input: FiniteRelayQuery): Promise<QueryCompletion>;
+}
+
+function normalizeRelayUrls(relayUrls: readonly string[]): string[] {
+  const normalized = new Set<string>();
+  relayUrls.forEach((relayUrl) => {
+    try {
+      normalized.add(normalizeURL(relayUrl));
+    } catch {
+      const preserved = relayUrl.trim();
+      if (preserved) normalized.add(preserved);
+    }
+  });
+  return [...normalized];
+}
+
+type ConnectionAttempt = {
+  outcome: Promise<RelayConnectionOutcome>;
+  settle(state: RelayConnectionOutcome["state"], relay?: Relay): void;
+  settled: boolean;
+  state?: RelayConnectionOutcome["state"];
+};
+
+type QueryTarget = {
+  relayUrl: string;
+  state?: RelayCompletionState;
+  subscription?: Subscription;
+};
+
+class WiredServerFiniteRelaySession implements FiniteRelaySession {
+  private readonly relays = new Map<string, Relay>();
+  private readonly connectionAttempts = new Map<string, ConnectionAttempt>();
+  private readonly timers = new Set<ReturnType<typeof setTimeout>>();
+  private readonly activeQueryCancels = new Set<() => void>();
+  private closed = false;
+
+  async ensureRelays(
+    relayUrls: readonly string[],
+    connectDeadlineMs: number,
+  ): Promise<readonly RelayConnectionOutcome[]> {
+    return Promise.all(
+      normalizeRelayUrls(relayUrls).map((relayUrl) => {
+        if (this.closed) {
+          return Promise.resolve({
+            relayUrl,
+            state: "cancelled" as const,
+          });
+        }
+        if (this.relays.has(relayUrl)) {
+          return Promise.resolve({ relayUrl, state: "connected" as const });
+        }
+
+        const existing = this.connectionAttempts.get(relayUrl);
+        const attempt = existing ?? this.startConnection(relayUrl);
+        if (attempt.settled) return attempt.outcome;
+
+        const timer = setTimeout(
+          () => attempt.settle("timed-out"),
+          Math.max(0, connectDeadlineMs),
+        );
+        this.timers.add(timer);
+        return attempt.outcome.finally(() => {
+          clearTimeout(timer);
+          this.timers.delete(timer);
+        });
+      }),
+    );
+  }
+
+  private startConnection(relayUrl: string): ConnectionAttempt {
+    let resolveOutcome!: (outcome: RelayConnectionOutcome) => void;
+    const attempt: ConnectionAttempt = {
+      outcome: new Promise((resolve) => {
+        resolveOutcome = resolve;
+      }),
+      settled: false,
+      settle: (state, relay) => {
+        if (attempt.settled) {
+          if (relay) relay.close();
+          return;
+        }
+        attempt.settled = true;
+        attempt.state = state;
+        if (state === "connected" && relay && !this.closed) {
+          this.relays.set(relayUrl, relay);
+        } else if (relay) {
+          relay.close();
+        }
+        resolveOutcome({ relayUrl, state });
+      },
+    };
+    this.connectionAttempts.set(relayUrl, attempt);
+    void Promise.resolve()
+      .then(() => Relay.connect(relayUrl))
+      .then((relay) => {
+        attempt.settle(this.closed ? "cancelled" : "connected", relay);
+      })
+      .catch(() => attempt.settle(this.closed ? "cancelled" : "connect-failed"));
+    return attempt;
+  }
+
+  query(input: FiniteRelayQuery): Promise<QueryCompletion> {
+    const relayUrls = input.relayUrls
+      ? normalizeRelayUrls(input.relayUrls)
+      : [...this.connectionAttempts.keys()];
+    const targets: QueryTarget[] = relayUrls.map((relayUrl) => ({ relayUrl }));
+    let receivedEvents = 0;
+    let finished = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let resolveCompletion!: (completion: QueryCompletion) => void;
+    const completion = new Promise<QueryCompletion>((resolve) => {
+      resolveCompletion = resolve;
+    });
+
+    const cleanupTarget = (target: QueryTarget) => {
+      const subscription = target.subscription;
+      target.subscription = undefined;
+      if (!subscription) return;
+      try {
+        subscription.close();
+      } catch {
+        // A terminal relay may already have closed its subscription.
+      }
+    };
+
+    const finish = (reason: QueryCompletion["reason"]) => {
+      if (finished) return;
+      finished = true;
+      if (timer) {
+        clearTimeout(timer);
+        this.timers.delete(timer);
+        timer = undefined;
+      }
+      input.signal?.removeEventListener("abort", cancel);
+      this.activeQueryCancels.delete(cancel);
+      const unfinishedState: RelayCompletionState = reason === "cancelled"
+        ? "cancelled"
+        : "timed-out";
+      targets.forEach((target) => {
+        target.state ??= unfinishedState;
+        cleanupTarget(target);
+      });
+      resolveCompletion({
+        reason,
+        targets: targets.map(({ relayUrl, state }) => ({
+          relayUrl,
+          state: state as RelayCompletionState,
+        })),
+        receivedEvents,
+      });
+    };
+
+    const maybeFinish = () => {
+      if (targets.every((target) => target.state !== undefined)) {
+        finish("settled");
+      }
+    };
+
+    const settleTarget = (target: QueryTarget, state: RelayCompletionState) => {
+      if (finished || target.state) return;
+      target.state = state;
+      cleanupTarget(target);
+      maybeFinish();
+    };
+
+    const subscribeTarget = (target: QueryTarget, relay: Relay) => {
+      if (finished || target.state) return;
+      if (!relay.connected) {
+        settleTarget(target, "closed");
+        return;
+      }
+      try {
+        const subscription = relay.subscribe(input.filters, {
+          onevent: (event) => {
+            if (finished || target.state) return;
+            receivedEvents += 1;
+            input.onEvent(event, target.relayUrl);
+          },
+          oneose: () => settleTarget(target, "eose"),
+          onclose: () => settleTarget(target, "closed"),
+        });
+        if (finished || target.state) {
+          subscription.close();
+          return;
+        }
+        target.subscription = subscription;
+      } catch {
+        settleTarget(target, "closed");
+      }
+    };
+
+    const startTarget = (target: QueryTarget) => {
+      const relay = this.relays.get(target.relayUrl);
+      if (relay) {
+        subscribeTarget(target, relay);
+        return;
+      }
+      const attempt = this.connectionAttempts.get(target.relayUrl);
+      if (!attempt) {
+        settleTarget(target, "connect-failed");
+        return;
+      }
+      if (attempt.settled) {
+        settleTarget(
+          target,
+          attempt.state === "connect-failed"
+            ? "connect-failed"
+            : attempt.state === "cancelled"
+              ? "cancelled"
+              : "timed-out",
+        );
+        return;
+      }
+      void attempt.outcome.then((outcome) => {
+        if (finished || target.state) return;
+        const connectedRelay = this.relays.get(target.relayUrl);
+        if (outcome.state === "connected" && connectedRelay) {
+          subscribeTarget(target, connectedRelay);
+        } else {
+          settleTarget(
+            target,
+            outcome.state === "connected" ? "closed" : outcome.state,
+          );
+        }
+      });
+    };
+
+    function cancel() {
+      finish("cancelled");
+    }
+
+    if (targets.length === 0) {
+      finish("settled");
+    } else if (this.closed || input.signal?.aborted) {
+      finish("cancelled");
+    } else {
+      this.activeQueryCancels.add(cancel);
+      input.signal?.addEventListener("abort", cancel, { once: true });
+      timer = setTimeout(() => finish("deadline"), Math.max(0, input.deadlineMs));
+      this.timers.add(timer);
+      targets.forEach(startTarget);
+    }
+
+    return completion;
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    [...this.activeQueryCancels].forEach((cancel) => cancel());
+    this.connectionAttempts.forEach((attempt) => attempt.settle("cancelled"));
+    this.timers.forEach((timer) => clearTimeout(timer));
+    this.timers.clear();
+    this.relays.forEach((relay) => {
+      try {
+        relay.close();
+      } catch {
+        // A terminal relay may already have closed its socket.
+      }
+    });
+    this.relays.clear();
+  }
+}
+
+export async function withFiniteRelaySession<T>(
+  options: RelaySessionOptions,
+  run: (session: FiniteRelaySession) => Promise<T> | T,
+): Promise<T> {
+  const session = new WiredServerFiniteRelaySession();
+  try {
+    await session.ensureRelays(options.relayUrls, options.connectDeadlineMs);
+    return await run(session);
+  } finally {
+    session.close();
+  }
+}


### PR DESCRIPTION
Closes smolgrrr/wired-admin#94

## Summary
- add a repo-local `withFiniteRelaySession` boundary for Wired server reads against nostr-tools 2.5.1
- own normalized fresh connections, connection deadlines, late arrivals, dynamic hints, sequential reuse, finite query settlement, cancellation, and final cleanup inside the session
- report explicit per-target connection/query outcomes without exposing Relay, Subscription, or timer handles
- leave preview and snapshot production callers unchanged for their separately ticketed migrations (#95–#97)
- keep event publishing on its independent ownership path

## Interface evidence
- 12 interface tests cover connected, partial failure, all-fail, timeout, cancelled and late connection outcomes; EOSE, terminal close, no-EOSE, synchronous EOSE, abort, dynamic hints, sequential reuse, callback failure, sockets, subscriptions, and timer cleanup
- focused preview/snapshot compatibility: 4 files / 24 tests passed
- final full suite: 82 files / 433 tests passed
- typecheck passed
- lint: 0 errors (4 pre-existing Fast Refresh warnings)
- standards review: clean
- spec review: initial all-fail coverage finding fixed; final review clean

## Controlled measurements
- snapshot transcript p95: 38 ms (guardrail <=52 ms)
- isolated preview guard: 14 ms disabled / 15 ms enabled (guardrail <=31 ms)
- publishing evidence guard: 9 ms; publishing behavior is unchanged

These loopback measurements do not estimate or imply public relay load. No production caller, filter, target union, output, cache behavior, or publishing behavior changes in this interface-only slice.

## Rollout / rollback
The new session is additive and has no production caller until #95–#97 migrate one workflow phase at a time. Normal deployment is sufficient. Roll back by reverting this commit if build/runtime compatibility with nostr-tools 2.5.1 is discovered; because no production workflow imports the seam yet, rollback does not alter user-visible relay behavior.