### PR TITLE
Migrate preview relay reads to finite sessions

### DIFF
--- a/lib/serverRelaySession.ts
+++ b/lib/serverRelaySession.ts
@@ -18,6 +18,7 @@ export type RelayConnectionOutcome = {
 export type RelaySessionOptions = {
   relayUrls: readonly string[];
   connectDeadlineMs: number;
+  signal?: AbortSignal;
 };
 
 export type FiniteRelayQuery = {
@@ -318,10 +319,14 @@ export async function withFiniteRelaySession<T>(
   run: (session: FiniteRelaySession) => Promise<T> | T,
 ): Promise<T> {
   const session = new WiredServerFiniteRelaySession();
+  const cancel = () => session.close();
+  if (options.signal?.aborted) cancel();
+  else options.signal?.addEventListener("abort", cancel, { once: true });
   try {
     await session.ensureRelays(options.relayUrls, options.connectDeadlineMs);
     return await run(session);
   } finally {
+    options.signal?.removeEventListener("abort", cancel);
     session.close();
   }
 }

--- a/lib/threadPreview.ts
+++ b/lib/threadPreview.ts
@@ -1,10 +1,4 @@
-import {
-  Relay,
-  type Event,
-  type Subscription,
-  useWebSocketImplementation,
-} from "nostr-tools";
-import { WebSocket } from "ws";
+import type { Event } from "nostr-tools";
 import { THREAD_RELAYS } from "../src/config.js";
 import {
   isFeedBootstrapSnapshot,
@@ -12,8 +6,7 @@ import {
 } from "../src/shared/lib/feedBootstrapTypes.js";
 import { decodeThreadRef, uniqueRelays } from "../src/shared/lib/threadRefs.js";
 import { cleanThreadExcerpt } from "../src/shared/lib/threadExcerpt.js";
-
-useWebSocketImplementation(WebSocket);
+import { withFiniteRelaySession } from "./serverRelaySession.js";
 
 const SNAPSHOT_TIMEOUT_MS = 1_500;
 const RELAY_TIMEOUT_MS = 2_500;
@@ -37,8 +30,8 @@ export type ResolveThreadPreviewOptions = {
 
 export type FetchThreadEventsOptions = {
   configuredRelayUrls?: readonly string[];
-  connectRelay?: typeof Relay.connect;
   timeoutMs?: number;
+  signal?: AbortSignal;
 };
 
 function replyCountFromEvents(events: readonly Event[], eventId: string): number {
@@ -100,75 +93,23 @@ export async function fetchThreadEventsFromRelays(
     ...(options.configuredRelayUrls ?? THREAD_RELAYS),
   ]);
   const timeoutMs = options.timeoutMs ?? RELAY_TIMEOUT_MS;
-  const connectRelay = options.connectRelay ?? Relay.connect;
-  const relays: Relay[] = [];
-  const events = new Map<string, Event>();
-  let acceptingConnections = true;
-  let connectionTimer: ReturnType<typeof setTimeout> | undefined;
-
-  const connectionAttempts = Promise.all(
-    relayUrls.map(async (url) => {
-      try {
-        const relay = await connectRelay(url);
-        if (!acceptingConnections) {
-          relay.close();
-          return;
-        }
-        relays.push(relay);
-      } catch {
-        // A preview can succeed from any available relay.
-      }
-    }),
-  );
-  await Promise.race([
-    connectionAttempts,
-    new Promise<void>((resolve) => {
-      connectionTimer = setTimeout(resolve, timeoutMs);
-    }),
-  ]);
-  acceptingConnections = false;
-  if (connectionTimer) clearTimeout(connectionTimer);
-
-  if (relays.length === 0) return [];
-
-  await new Promise<void>((resolve) => {
-    const settledRelays = new Set<number>();
-    let settled = false;
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      subscriptions.forEach((subscription) => subscription.close());
-      resolve();
-    };
-    const timer = setTimeout(finish, timeoutMs);
-    const settleRelay = (index: number) => {
-      settledRelays.add(index);
-      if (settledRelays.size >= relays.length) finish();
-    };
-    const subscriptions: Subscription[] = [];
-    relays.forEach((relay, index) => {
-      let subscription: Subscription;
-      subscription = relay.subscribe(
-        [
+  return withFiniteRelaySession(
+    { relayUrls, connectDeadlineMs: timeoutMs, signal: options.signal },
+    async (session) => {
+      const events = new Map<string, Event>();
+      await session.query({
+        filters: [
           { ids: [eventId], kinds: [1], limit: 1 },
           { "#e": [eventId], kinds: [1], limit: 500 },
         ],
-        {
-          onevent: (event) => events.set(event.id, event),
-          oneose: () => settleRelay(index),
-          onclose: () => {
-            subscription.receivedEose();
-            settleRelay(index);
-          },
-        },
-      );
-      subscriptions.push(subscription);
-    });
-  });
-
-  relays.forEach((relay) => relay.close());
-  return [...events.values()];
+        relayUrls,
+        deadlineMs: timeoutMs,
+        signal: options.signal,
+        onEvent: (event) => events.set(event.id, event),
+      });
+      return [...events.values()];
+    },
+  );
 }
 
 export async function resolveThreadPreview(

--- a/lib/threadPreviewRelay.test.ts
+++ b/lib/threadPreviewRelay.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Event, Filter } from "nostr-tools";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+}));
+
+vi.mock("nostr-tools", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("nostr-tools")>();
+  return {
+    ...actual,
+    Relay: { connect: mocks.connect },
+    useWebSocketImplementation: vi.fn(),
+  };
+});
+
+import { fetchThreadEventsFromRelays } from "./threadPreview";
+
+type SubscriptionCallbacks = {
+  onevent?: (event: Event) => void;
+  oneose?: () => void;
+  onclose?: (reason: string) => void;
+};
+
+function controlledRelay(url: string) {
+  const callbacks: SubscriptionCallbacks[] = [];
+  const subscriptions: Array<{
+    close: ReturnType<typeof vi.fn>;
+    receivedEose: ReturnType<typeof vi.fn>;
+  }> = [];
+  const relay = {
+    url,
+    connected: true,
+    close: vi.fn(),
+    subscribe: vi.fn((_filters: Filter[], params: SubscriptionCallbacks) => {
+      callbacks.push(params);
+      const subscription = {
+        close: vi.fn(),
+        receivedEose: vi.fn(() => params.oneose?.()),
+      };
+      subscriptions.push(subscription);
+      return subscription;
+    }),
+  };
+  return { callbacks, relay, subscriptions };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("thread preview relay compatibility", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    mocks.connect.mockReset();
+  });
+
+  it("does not open relay connections for a pre-aborted preview", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(fetchThreadEventsFromRelays("1".repeat(64), [], {
+      configuredRelayUrls: ["wss://preview.example"],
+      timeoutMs: 1_000,
+      signal: controller.signal,
+    })).resolves.toEqual([]);
+
+    expect(mocks.connect).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("settles an abort during connection and closes the relay if it arrives late", async () => {
+    vi.useFakeTimers();
+    const target = controlledRelay("wss://pending.example/");
+    const connection = deferred<typeof target.relay>();
+    mocks.connect.mockReturnValue(connection.promise);
+    const controller = new AbortController();
+    const result = fetchThreadEventsFromRelays("1".repeat(64), [], {
+      configuredRelayUrls: [target.relay.url],
+      timeoutMs: 1_000,
+      signal: controller.signal,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(result).resolves.toEqual([]);
+    expect(target.relay.subscribe).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+
+    connection.resolve(target.relay);
+    await flushPromises();
+    expect(target.relay.close).toHaveBeenCalledOnce();
+  });
+
+  it("cancels an active preview query after closing its owned handles", async () => {
+    vi.useFakeTimers();
+    const target = controlledRelay("wss://preview.example/");
+    mocks.connect.mockResolvedValue(target.relay);
+    const controller = new AbortController();
+    const result = fetchThreadEventsFromRelays("1".repeat(64), [], {
+      configuredRelayUrls: [target.relay.url],
+      timeoutMs: 1_000,
+      signal: controller.signal,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(target.relay.subscribe).toHaveBeenCalledOnce();
+
+    try {
+      controller.abort();
+      await flushPromises();
+      expect(target.subscriptions[0]?.close).toHaveBeenCalledOnce();
+      expect(target.relay.close).toHaveBeenCalledOnce();
+      await expect(result).resolves.toEqual([]);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await vi.advanceTimersByTimeAsync(1_000);
+      await result;
+    }
+  });
+
+  it("settles terminal close before EOSE and closes every session socket", async () => {
+    vi.useFakeTimers();
+    const completed = controlledRelay("wss://completed.example/");
+    const closed = controlledRelay("wss://closed.example/");
+    mocks.connect.mockImplementation((url: string) =>
+      Promise.resolve(url === completed.relay.url ? completed.relay : closed.relay),
+    );
+    const result = fetchThreadEventsFromRelays("1".repeat(64), [], {
+      configuredRelayUrls: [completed.relay.url, closed.relay.url],
+      timeoutMs: 1_000,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    completed.callbacks[0]?.oneose?.();
+    closed.callbacks[0]?.onclose?.("relay closed");
+
+    await expect(result).resolves.toEqual([]);
+    expect(completed.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(closed.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(completed.relay.close).toHaveBeenCalledOnce();
+    expect(closed.relay.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("returns partial events at the no-EOSE deadline and cleans every handle", async () => {
+    vi.useFakeTimers();
+    const silent = controlledRelay("wss://silent.example/");
+    mocks.connect.mockResolvedValue(silent.relay);
+    const result = fetchThreadEventsFromRelays("1".repeat(64), [], {
+      configuredRelayUrls: [silent.relay.url],
+      timeoutMs: 25,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    const event = { id: "1".repeat(64) } as Event;
+    silent.callbacks[0]?.onevent?.(event);
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(result).resolves.toEqual([event]);
+    expect(silent.subscriptions[0]?.close).toHaveBeenCalledOnce();
+    expect(silent.relay.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("returns immediately when every relay connection fails", async () => {
+    vi.useFakeTimers();
+    mocks.connect.mockRejectedValue(new Error("offline"));
+
+    await expect(fetchThreadEventsFromRelays("1".repeat(64), [], {
+      configuredRelayUrls: ["wss://one.example", "wss://two.example"],
+      timeoutMs: 1_000,
+    })).resolves.toEqual([]);
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("closes a connection that arrives after the connection deadline", async () => {
+    vi.useFakeTimers();
+    const late = controlledRelay("wss://late.example/");
+    const connection = deferred<typeof late.relay>();
+    mocks.connect.mockReturnValue(connection.promise);
+    const result = fetchThreadEventsFromRelays("1".repeat(64), [], {
+      configuredRelayUrls: [late.relay.url],
+      timeoutMs: 5,
+    });
+    await vi.advanceTimersByTimeAsync(5);
+
+    await expect(result).resolves.toEqual([]);
+    expect(late.relay.close).not.toHaveBeenCalled();
+    connection.resolve(late.relay);
+    await flushPromises();
+    expect(late.relay.close).toHaveBeenCalledOnce();
+    expect(late.relay.subscribe).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/nostr/testing/thread-preview-transcript.test.ts
+++ b/src/nostr/testing/thread-preview-transcript.test.ts
@@ -1,10 +1,8 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   finalizeEvent,
   matchFilters,
   nip19,
-  Relay,
-  type Subscription,
   useWebSocketImplementation as configureWebSocketImplementation,
 } from "nostr-tools";
 import { WebSocket } from "ws";
@@ -320,59 +318,4 @@ describe("thread preview relay transcript", () => {
     });
   });
 
-  it("settles a terminal subscription close and clears its EOSE timer", async () => {
-    vi.useFakeTimers();
-    try {
-      const completedRelay = new Relay("ws://completed-relay.invalid");
-      const closedRelay = new Relay("ws://closed-relay.invalid");
-      const closedSubscription = {
-        close: vi.fn(),
-        receivedEose: vi.fn(),
-      } as unknown as Subscription;
-      vi.spyOn(completedRelay, "subscribe").mockImplementation((_filters, params) => {
-        queueMicrotask(() => params.oneose?.());
-        return { close: vi.fn() } as unknown as Subscription;
-      });
-      vi.spyOn(closedRelay, "subscribe").mockImplementation((_filters, params) => {
-        queueMicrotask(() => params.onclose?.("relay connection closed"));
-        return closedSubscription;
-      });
-
-      expect(await fetchThreadEventsFromRelays(root.id, [], {
-        configuredRelayUrls: [completedRelay.url, closedRelay.url],
-        connectRelay: async (url) =>
-          url.includes("completed-relay") ? completedRelay : closedRelay,
-        timeoutMs: 2_500,
-      })).toEqual([]);
-
-      expect(closedSubscription.receivedEose).toHaveBeenCalledOnce();
-      expect(vi.getTimerCount()).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("closes a connection that arrives after the connection deadline", async () => {
-    vi.useFakeTimers();
-    try {
-      const lateRelay = new Relay("ws://late-relay.invalid");
-      const close = vi.spyOn(lateRelay, "close");
-      const result = fetchThreadEventsFromRelays(root.id, [], {
-        configuredRelayUrls: [lateRelay.url],
-        connectRelay: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 20));
-          return lateRelay;
-        },
-        timeoutMs: 5,
-      });
-
-      await vi.advanceTimersByTimeAsync(5);
-      expect(await result).toEqual([]);
-      expect(close).not.toHaveBeenCalled();
-      await vi.advanceTimersByTimeAsync(15);
-      expect(close).toHaveBeenCalledOnce();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
 });


### PR DESCRIPTION
Closes smolgrrr/wired-admin#95

## Summary
- route snapshot-miss preview relay reads through `withFiniteRelaySession`
- preserve the exact root/reply filters, configured-plus-hinted target union, event deduplication, partial success, and snapshot-first behavior
- forward cancellation through both connection establishment and the finite query
- remove preview-owned Relay/Subscription/timer lifecycle and the old test-only connector injection
- keep publishing entirely unchanged and independently owned

## Lifecycle evidence
- compatibility tests cover pre-abort, pending-connect abort with late socket closure, active-query abort, close-before-EOSE, no-EOSE partial results, all-fail, and connect-after-deadline; all assert relevant subscriptions/sockets/timers reach zero
- real transcript retains exact two-relay fan-out, two REQs, filters, three unique IDs after duplicate delivery, EOSE/CLOSE cleanup, and degraded partial-relay output
- focused preview/session/transcript verification: 3 files / 23 tests passed
- full suite: 83 files / 438 tests passed
- typecheck passed
- lint: 0 errors (4 pre-existing Fast Refresh warnings)
- spec review: initial pre-connect cancellation finding fixed; final pass with 0 findings
- standards review: pass with 0 hard findings; non-blocking test-overlap advisory accepted because the cases prove adapter forwarding

## Controlled measurements
- guarded warmed preview p95: 14 ms disabled / 14 ms enabled (required <=31 ms)
- broader cold-start two-relay transcript p95: 34 ms; the immediately preceding base observation was 36 ms
- unchanged publishing evidence guard: 9 ms

These are controlled loopback observations, not estimates of public relay traffic or load.

## Rollout / rollback
Deploy the isolated preview migration normally and watch bounded preview completion/terminal summaries. Stop or revert this commit if exact IDs/reply count, target union, filter transcript, availability, socket cleanup, or the guarded <=31 ms preview measurement regresses. Reverting restores the prior preview helper without affecting the additive session module, snapshot workflows, or publishing.