### PR TITLE
Migrate snapshot activity and replies to finite sessions

### DIFF
--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -35,6 +35,10 @@ import type {
   FeedBootstrapProcessedEvent,
   FeedBootstrapSnapshot,
 } from "../src/shared/lib/feedBootstrapTypes.js";
+import {
+  withFiniteRelaySession,
+  type FiniteRelaySession,
+} from "./serverRelaySession.js";
 
 useWebSocketImplementation(WebSocket);
 
@@ -123,7 +127,7 @@ function serializeRelayHints(
   );
 }
 
-async function connectRelays(urls: readonly string[], timeoutMs: number): Promise<Relay[]> {
+async function connectRelays(urls: readonly string[]): Promise<Relay[]> {
   const relays = await Promise.all(
     urls.map(async (url) => {
       try {
@@ -210,7 +214,33 @@ async function subscribeOnce(
   return { events, relayHintsByEventId };
 }
 
+async function querySessionOnce(
+  session: FiniteRelaySession,
+  filter: Filter,
+  timeoutMs: number,
+  relayUrls?: readonly string[],
+): Promise<EventBatch> {
+  const events: Event[] = [];
+  const seenIds = new Set<string>();
+  const relayHintsByEventId = new Map<string, string[]>();
+
+  await session.query({
+    filters: [filter],
+    relayUrls,
+    deadlineMs: timeoutMs,
+    onEvent(event, relayUrl) {
+      addRelayHint(relayHintsByEventId, event.id, relayUrl);
+      if (seenIds.has(event.id)) return;
+      seenIds.add(event.id);
+      events.push(event);
+    },
+  });
+
+  return { events, relayHintsByEventId };
+}
+
 async function fetchRootEvents(
+  session: FiniteRelaySession,
   rootRefs: FeedRootRef[],
   knownEvents: Event[],
   timeoutMs: number,
@@ -244,40 +274,35 @@ async function fetchRootEvents(
       ...snapshotRelayUrls,
       ...pendingRefs.flatMap((ref) => ref.relays),
     ]);
-    const relays = await connectRelays(relayUrls, timeoutMs);
+    await session.ensureRelays(relayUrls, timeoutMs);
+    const nextRefs: FeedRootRef[] = [];
+    const ids = pendingRefs.map((ref) => ref.id);
+    const batch = await querySessionOnce(
+      session,
+      {
+        ids,
+        kinds: [1],
+        limit: ids.length,
+      },
+      timeoutMs,
+      relayUrls,
+    );
 
-    try {
-      const nextRefs: FeedRootRef[] = [];
-      const ids = pendingRefs.map((ref) => ref.id);
-      const batch = await subscribeOnce(
-        relays,
-        {
-          ids,
-          kinds: [1],
-          limit: ids.length,
-        },
-        timeoutMs,
-        relayUrls,
+    events.push(...batch.events);
+    batch.events.forEach((event) => {
+      eventsById.set(event.id.toLowerCase(), event);
+      const nextRef = resolveFeedRootRef(event, eventsById);
+      if (nextRef && nextRef.id !== event.id.toLowerCase()) {
+        nextRefs.push(nextRef);
+      }
+    });
+    batch.relayHintsByEventId.forEach((relaysForEvent, eventId) => {
+      relaysForEvent.forEach((relay) =>
+        addRelayHint(relayHintsByEventId, eventId, relay),
       );
+    });
 
-      events.push(...batch.events);
-      batch.events.forEach((event) => {
-        eventsById.set(event.id.toLowerCase(), event);
-        const nextRef = resolveFeedRootRef(event, eventsById);
-        if (nextRef && nextRef.id !== event.id.toLowerCase()) {
-          nextRefs.push(nextRef);
-        }
-      });
-      batch.relayHintsByEventId.forEach((relaysForEvent, eventId) => {
-        relaysForEvent.forEach((relay) =>
-          addRelayHint(relayHintsByEventId, eventId, relay),
-        );
-      });
-
-      refsToResolve = mergeFeedRootRefs(nextRefs);
-    } finally {
-      closeRelays(relays);
-    }
+    refsToResolve = mergeFeedRootRefs(nextRefs);
   }
 
   return { events, relayHintsByEventId };
@@ -293,90 +318,97 @@ async function fetchGlobalFeedEvents(
     snapshot: readonly string[];
   },
 ): Promise<FeedEventBatch> {
-  const relays = await connectRelays(relayUrls.snapshot, timeoutMs);
+  const sessionRelayUrls = uniqueRelays([
+    ...relayUrls.snapshot,
+    ...relayUrls.pow,
+    ...relayUrls.replies,
+  ]);
+  return withFiniteRelaySession(
+    { relayUrls: sessionRelayUrls, connectDeadlineMs: timeoutMs },
+    async (session) => {
+      const since = sinceFromAgeHours(ageHours);
 
-  try {
-    const since = sinceFromAgeHours(ageHours);
-
-    const activityBatch = await subscribeOnce(
-      relays,
-      { kinds: [1], since, limit: 500 },
-      timeoutMs,
-      [...relayUrls.pow],
-    );
-    const activityEvents = activityBatch.events;
-    const activityRootRefs = feedRootRefsFromQualifyingActivity(
-      activityEvents,
-      filterDifficulty,
-    );
-
-    if (activityRootRefs.length === 0) {
-      return { ...activityBatch, activityRootIds: [] };
-    }
-
-    const resolvedRootBatch = await fetchRootEvents(
-      activityRootRefs,
-      activityEvents,
-      timeoutMs,
-      relayUrls.snapshot,
-    );
-    const seedEvents = mergeEvents(activityEvents, resolvedRootBatch.events);
-    const seedEventsById = buildFeedEventMap(seedEvents);
-    const rootRefs = feedRootRefsFromQualifyingActivity(
-      activityEvents,
-      filterDifficulty,
-      seedEventsById,
-    );
-    const rootIds = rootRefs
-      .map((ref) => seedEventsById.get(ref.id))
-      .filter((event): event is Event => !!event && isFeedThreadRootEvent(event))
-      .map((event) => event.id.toLowerCase());
-    const replyEvents: Event[] = [];
-    const seenReplyIds = new Set<string>();
-    const replyRelayHintsByEventId = new Map<string, string[]>();
-    let parentIds = [...new Set(rootIds)];
-
-    const replyDepth = clampReplyDepth(REPLY_FETCH_DEPTH);
-    for (let depth = 0; depth < replyDepth && parentIds.length > 0; depth += 1) {
-      const replyFilter = buildReplyFilter(parentIds, since);
-      if (!replyFilter) break;
-
-      const replyBatch = await subscribeOnce(
-        relays,
-        replyFilter,
+      const activityBatch = await querySessionOnce(
+        session,
+        { kinds: [1], since, limit: 500 },
         timeoutMs,
-        [...relayUrls.replies],
+        [...relayUrls.pow],
       );
-      const nextReplies = replyBatch.events;
-      const nextParentIds: string[] = [];
+      const activityEvents = activityBatch.events;
+      const activityRootRefs = feedRootRefsFromQualifyingActivity(
+        activityEvents,
+        filterDifficulty,
+      );
 
-      replyBatch.relayHintsByEventId.forEach((relays, eventId) => {
-        relays.forEach((relay) => addRelayHint(replyRelayHintsByEventId, eventId, relay));
-      });
+      if (activityRootRefs.length === 0) {
+        return { ...activityBatch, activityRootIds: [] };
+      }
 
-      nextReplies.forEach((event) => {
-        if (seenReplyIds.has(event.id)) return;
+      const resolvedRootBatch = await fetchRootEvents(
+        session,
+        activityRootRefs,
+        activityEvents,
+        timeoutMs,
+        relayUrls.snapshot,
+      );
+      const seedEvents = mergeEvents(activityEvents, resolvedRootBatch.events);
+      const seedEventsById = buildFeedEventMap(seedEvents);
+      const rootRefs = feedRootRefsFromQualifyingActivity(
+        activityEvents,
+        filterDifficulty,
+        seedEventsById,
+      );
+      const rootIds = rootRefs
+        .map((ref) => seedEventsById.get(ref.id))
+        .filter((event): event is Event => !!event && isFeedThreadRootEvent(event))
+        .map((event) => event.id.toLowerCase());
+      const replyEvents: Event[] = [];
+      const seenReplyIds = new Set<string>();
+      const replyRelayHintsByEventId = new Map<string, string[]>();
+      let parentIds = [...new Set(rootIds)];
 
-        seenReplyIds.add(event.id);
-        replyEvents.push(event);
-        nextParentIds.push(event.id);
-      });
+      const replyDepth = clampReplyDepth(REPLY_FETCH_DEPTH);
+      for (let depth = 0; depth < replyDepth && parentIds.length > 0; depth += 1) {
+        const replyFilter = buildReplyFilter(parentIds, since);
+        if (!replyFilter) break;
 
-      parentIds = nextParentIds;
-    }
+        const replyBatch = await querySessionOnce(
+          session,
+          replyFilter,
+          timeoutMs,
+          [...relayUrls.replies],
+        );
+        const nextReplies = replyBatch.events;
+        const nextParentIds: string[] = [];
 
-    return {
-      events: mergeEvents(activityEvents, resolvedRootBatch.events, replyEvents),
-      relayHintsByEventId: mergeRelayHints(
-        activityBatch.relayHintsByEventId,
-        resolvedRootBatch.relayHintsByEventId,
-        replyRelayHintsByEventId,
-      ),
-      activityRootIds: rootRefs.map((ref) => ref.id),
-    };
-  } finally {
-    closeRelays(relays);
-  }
+        replyBatch.relayHintsByEventId.forEach((relays, eventId) => {
+          relays.forEach((relay) =>
+            addRelayHint(replyRelayHintsByEventId, eventId, relay),
+          );
+        });
+
+        nextReplies.forEach((event) => {
+          if (seenReplyIds.has(event.id)) return;
+
+          seenReplyIds.add(event.id);
+          replyEvents.push(event);
+          nextParentIds.push(event.id);
+        });
+
+        parentIds = nextParentIds;
+      }
+
+      return {
+        events: mergeEvents(activityEvents, resolvedRootBatch.events, replyEvents),
+        relayHintsByEventId: mergeRelayHints(
+          activityBatch.relayHintsByEventId,
+          resolvedRootBatch.relayHintsByEventId,
+          replyRelayHintsByEventId,
+        ),
+        activityRootIds: rootRefs.map((ref) => ref.id),
+      };
+    },
+  );
 }
 
 function snapshotReferenceRefs(processedEvents: ProcessedEvent[]) {
@@ -412,7 +444,7 @@ async function fetchReferencedEvents(
     ...snapshotRelayUrls,
     ...missingRefs.flatMap((ref) => ref.relays),
   ]);
-  const relays = await connectRelays(relayUrls, timeoutMs);
+  const relays = await connectRelays(relayUrls);
 
   try {
     const referencedBatch = await subscribeOnce(
@@ -481,7 +513,7 @@ async function fetchProfileMetadata(
     return {};
   }
 
-  const relays = await connectRelays(profileRelayUrls, timeoutMs);
+  const relays = await connectRelays(profileRelayUrls);
 
   try {
     const { events } = await subscribeOnce(

--- a/src/nostr/testing/feed-snapshot-transcript.test.ts
+++ b/src/nostr/testing/feed-snapshot-transcript.test.ts
@@ -45,6 +45,15 @@ const nestedReply = finalizeEvent({
   tags: [["e", reply.id, "", "reply"]],
   content: "server nested reply",
 }, secretKey);
+const rootSeekingReply = finalizeEvent({
+  created_at: root.created_at + 2,
+  kind: 1,
+  tags: [
+    ["e", root.id, "", "root"],
+    ["e", root.id, "", "reply"],
+  ],
+  content: "activity before root resolution",
+}, secretKey);
 
 function driveSnapshot(request: RelayRequestController): void {
   const [filter] = request.filters;
@@ -206,6 +215,113 @@ describe("server feed snapshot relay transcript", () => {
           .map((entry) => entry.lifetimeMs),
       },
     });
+  });
+
+  it("reuses one session across activity, missing-root, and reply phases", async () => {
+    const session = new RelayTranscriptSession();
+    harnesses.push(
+      await RelayTranscriptHarness.listen({
+        session,
+        onRequest(request) {
+          const [filter] = request.filters;
+          if (filter?.ids?.includes(root.id)) {
+            request.sendEvent(root);
+          } else if (filter?.["#e"]?.includes(root.id)) {
+            request.sendEvent(rootSeekingReply);
+          } else if (filter?.kinds?.includes(1)) {
+            request.sendEvent(rootSeekingReply);
+          }
+          request.sendEose();
+        },
+      }),
+      await RelayTranscriptHarness.listen({
+        session,
+        onRequest(request) {
+          request.sendEose();
+        },
+      }),
+    );
+    const relayUrls = harnesses.map((harness) => harness.url);
+    const workflow = session.beginWorkflow("wired-server-feed-session-reuse");
+
+    const snapshot = await fetchFeedSnapshot({
+      ageHours: 24,
+      filterDifficulty: 0,
+      relayCoverage: {
+        snapshot: relayUrls,
+        pow: relayUrls,
+        replies: relayUrls,
+        profiles: relayUrls,
+      },
+      timeoutMs: 1_000,
+    });
+    await session.waitFor((entries) =>
+      entries.filter((entry) => entry.type === "close").length === 10 &&
+      entries.filter((entry) => entry.type === "connection-closed").length >= 4
+    );
+    workflow.complete();
+
+    expect(Object.keys(snapshot.eventsById).sort()).toEqual(
+      [root.id, rootSeekingReply.id].sort(),
+    );
+    expect(snapshot.processedEvents[0]?.replyIds).toEqual([rootSeekingReply.id]);
+    expect(session.summary(workflow)).toMatchObject({
+      openedConnections: 4,
+      requests: 10,
+      closes: 10,
+      eose: 10,
+      relayFanout: 2,
+    });
+  });
+
+  it("preserves distinct activity and reply relay coverage", async () => {
+    const session = new RelayTranscriptSession();
+    const activityHarness = await RelayTranscriptHarness.listen({
+      session,
+      onRequest(request) {
+        request.sendEvent(root);
+        request.sendEose();
+      },
+    });
+    const replyHarness = await RelayTranscriptHarness.listen({
+      session,
+      onRequest(request) {
+        const [filter] = request.filters;
+        if (filter?.["#e"]?.includes(root.id)) request.sendEvent(reply);
+        if (filter?.["#e"]?.includes(reply.id)) request.sendEvent(nestedReply);
+        request.sendEose();
+      },
+    });
+    harnesses.push(activityHarness, replyHarness);
+    const workflow = session.beginWorkflow("wired-server-feed-distinct-coverage");
+
+    const snapshot = await fetchFeedSnapshot({
+      ageHours: 24,
+      filterDifficulty: 0,
+      relayCoverage: {
+        snapshot: [activityHarness.url],
+        pow: [activityHarness.url],
+        replies: [replyHarness.url],
+        profiles: [],
+      },
+      timeoutMs: 1_000,
+    });
+    workflow.complete();
+
+    expect(Object.keys(snapshot.eventsById).sort()).toEqual(
+      [root.id, reply.id, nestedReply.id].sort(),
+    );
+    expect(snapshot.processedEvents[0]?.replyIds.sort()).toEqual(
+      [reply.id, nestedReply.id].sort(),
+    );
+    const requests = session.entries
+      .slice(workflow.startIndex, workflow.completedIndex)
+      .filter((entry) => entry.type === "request");
+    expect(requests).toHaveLength(3);
+    expect(requests[0]?.relayUrl).toBe(activityHarness.url);
+    expect(requests.slice(1).every((request) =>
+      request.relayUrl === replyHarness.url
+    )).toBe(true);
   });
 
   it("retains complete results when one relay never sends EOSE", async () => {


### PR DESCRIPTION
Closes smolgrrr/wired-admin#96

## Summary
- run snapshot activity discovery, missing-root resolution, and recursive reply phases through one `withFiniteRelaySession`
- keep filters, two-level traversal, result deduplication, processing/cache behavior, and output identity workflow-local and unchanged
- preserve distinct activity, snapshot/root-hint, and reply relay coverage
- reuse session-owned configured connections when root resolution discovers work and add dynamic hints through `ensureRelays`
- leave referenced-event and profile phases on their existing helpers for #97; publishing remains separate and unchanged

## Evidence
- normal real snapshot transcript remains exactly 8 REQs with identical filters, 3 IDs, 2 replies, 4 opened/closed connections, and 8 EOSE/CLOSE completions
- missing-root fixture retains 10 REQs and exact IDs while controlled opened connections change 6 -> 4 through scoped reuse
- distinct activity/reply fixture proves separate configured coverage resolves root plus both reply depths
- no-EOSE fixture retains complete results and bounded cleanup
- controlled normal snapshot p95: 38 ms (required <=52 ms)
- full suite: 83 files / 440 tests passed
- typecheck passed
- lint: 0 errors (4 pre-existing Fast Refresh warnings)
- standards review: pass, 0 findings
- spec review: pass, 0 findings

The connection counts and timing are controlled loopback observations only; they do not estimate or imply public relay load. Query breadth and event publishing are unchanged.

## Rollout / rollback
Deploy the isolated activity/reply migration normally and monitor bounded snapshot completion/terminal summaries. Stop or revert this commit if the exact 8-REQ normal transcript, complete IDs/replies, configured relay coverage, socket cleanup, cache behavior, or <=52 ms guardrail regresses. Reverting restores only the prior activity/root/reply lifecycle; the session foundation, preview migration, reference/profile paths, and publishing remain independent.