### PR TITLE
Migrate snapshot references and profiles to finite sessions

### DIFF
--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -440,68 +440,110 @@ async function fetchReferencedEvents(
     return { events: [], relayHintsByEventId: new Map() };
   }
 
-  const relayUrls = uniqueRelays([
-    ...snapshotRelayUrls,
-    ...missingRefs.flatMap((ref) => ref.relays),
-  ]);
-  const relays = await connectRelays(relayUrls);
+  const configuredRelayUrls = uniqueRelays(snapshotRelayUrls);
+  const hintedRelayUrls = uniqueRelays(
+    missingRefs.flatMap((ref) => ref.relays),
+  ).filter((relayUrl) => !configuredRelayUrls.includes(relayUrl));
+  const relayUrls = uniqueRelays([...configuredRelayUrls, ...hintedRelayUrls]);
 
-  try {
-    const referencedBatch = await subscribeOnce(
-      relays,
-      {
-        ids: missingRefs.map((ref) => ref.id),
-        kinds: [1, 1068],
-        limit: missingRefs.length,
-      },
-      timeoutMs,
-      relayUrls,
-    );
-
-    const replyEvents: Event[] = [];
-    const seenReplyIds = new Set<string>();
-    const replyRelayHintsByEventId = new Map<string, string[]>();
-    const since = sinceFromAgeHours(ageHours);
-    let parentIds = referencedBatch.events.map((event) => event.id);
-
-    const replyDepth = clampReplyDepth(REPLY_FETCH_DEPTH);
-    for (let depth = 0; depth < replyDepth && parentIds.length > 0; depth += 1) {
-      const replyFilter = buildReplyFilter(parentIds, since);
-      if (!replyFilter) break;
-
-      const replyBatch = await subscribeOnce(
-        relays,
-        replyFilter,
+  return withFiniteRelaySession(
+    { relayUrls: configuredRelayUrls, connectDeadlineMs: timeoutMs },
+    async (session) => {
+      const hintedConnections = session.ensureRelays(hintedRelayUrls, timeoutMs);
+      const configuredBatch = await querySessionOnce(
+        session,
+        {
+          ids: missingRefs.map((ref) => ref.id),
+          kinds: [1, 1068],
+          limit: missingRefs.length,
+        },
         timeoutMs,
-        relayUrls,
+        configuredRelayUrls,
       );
-      const nextParentIds: string[] = [];
+      const foundIds = new Set(configuredBatch.events.map((event) => event.id));
+      const stillMissingRefs = missingRefs.filter((ref) => !foundIds.has(ref.id));
+      const hintedBatches: EventBatch[] = [];
 
-      replyBatch.relayHintsByEventId.forEach((relays, eventId) => {
-        relays.forEach((relay) => addRelayHint(replyRelayHintsByEventId, eventId, relay));
-      });
+      if (stillMissingRefs.length > 0 && hintedRelayUrls.length > 0) {
+        await hintedConnections;
+        const missingIdsByRelay = new Map<string, string[]>();
+        stillMissingRefs.forEach((ref) => {
+          uniqueRelays(ref.relays).forEach((relayUrl) => {
+            if (!hintedRelayUrls.includes(relayUrl)) return;
+            const ids = missingIdsByRelay.get(relayUrl) ?? [];
+            if (!ids.includes(ref.id)) ids.push(ref.id);
+            missingIdsByRelay.set(relayUrl, ids);
+          });
+        });
+        hintedBatches.push(...await Promise.all(
+          [...missingIdsByRelay].map(([relayUrl, ids]) => querySessionOnce(
+            session,
+            {
+              ids,
+              kinds: [1, 1068],
+              limit: ids.length,
+            },
+            timeoutMs,
+            [relayUrl],
+          )),
+        ));
+      }
 
-      replyBatch.events.forEach((event) => {
-        if (knownEventIds.has(event.id) || seenReplyIds.has(event.id)) return;
+      const referencedBatch: EventBatch = {
+        events: mergeEvents(
+          configuredBatch.events,
+          ...hintedBatches.map((batch) => batch.events),
+        ),
+        relayHintsByEventId: mergeRelayHints(
+          configuredBatch.relayHintsByEventId,
+          ...hintedBatches.map((batch) => batch.relayHintsByEventId),
+        ),
+      };
+      const replyEvents: Event[] = [];
+      const seenReplyIds = new Set<string>();
+      const replyRelayHintsByEventId = new Map<string, string[]>();
+      const since = sinceFromAgeHours(ageHours);
+      let parentIds = referencedBatch.events.map((event) => event.id);
 
-        seenReplyIds.add(event.id);
-        replyEvents.push(event);
-        nextParentIds.push(event.id);
-      });
+      const replyDepth = clampReplyDepth(REPLY_FETCH_DEPTH);
+      for (let depth = 0; depth < replyDepth && parentIds.length > 0; depth += 1) {
+        const replyFilter = buildReplyFilter(parentIds, since);
+        if (!replyFilter) break;
 
-      parentIds = nextParentIds;
-    }
+        const replyBatch = await querySessionOnce(
+          session,
+          replyFilter,
+          timeoutMs,
+          relayUrls,
+        );
+        const nextParentIds: string[] = [];
 
-    return {
-      events: mergeEvents(referencedBatch.events, replyEvents),
-      relayHintsByEventId: mergeRelayHints(
-        referencedBatch.relayHintsByEventId,
-        replyRelayHintsByEventId,
-      ),
-    };
-  } finally {
-    closeRelays(relays);
-  }
+        replyBatch.relayHintsByEventId.forEach((relays, eventId) => {
+          relays.forEach((relay) =>
+            addRelayHint(replyRelayHintsByEventId, eventId, relay),
+          );
+        });
+
+        replyBatch.events.forEach((event) => {
+          if (knownEventIds.has(event.id) || seenReplyIds.has(event.id)) return;
+
+          seenReplyIds.add(event.id);
+          replyEvents.push(event);
+          nextParentIds.push(event.id);
+        });
+
+        parentIds = nextParentIds;
+      }
+
+      return {
+        events: mergeEvents(referencedBatch.events, replyEvents),
+        relayHintsByEventId: mergeRelayHints(
+          referencedBatch.relayHintsByEventId,
+          replyRelayHintsByEventId,
+        ),
+      };
+    },
+  );
 }
 
 async function fetchProfileMetadata(
@@ -513,42 +555,40 @@ async function fetchProfileMetadata(
     return {};
   }
 
-  const relays = await connectRelays(profileRelayUrls);
+  return withFiniteRelaySession(
+    { relayUrls: profileRelayUrls, connectDeadlineMs: timeoutMs },
+    async (session) => {
+      const { events } = await querySessionOnce(
+        session,
+        {
+          authors: pubkeys,
+          kinds: [0],
+          limit: profileQueryLimit(pubkeys.length),
+        },
+        timeoutMs,
+        profileRelayUrls,
+      );
+      const profiles: Record<string, { profile: ProfileMetadata; createdAt: number }> =
+        {};
 
-  try {
-    const { events } = await subscribeOnce(
-      relays,
-      {
-        authors: pubkeys,
-        kinds: [0],
-        limit: profileQueryLimit(pubkeys.length),
-      },
-      timeoutMs,
-      [...profileRelayUrls],
-    );
+      events.forEach((event) => {
+        const profile = parseProfileEvent(event);
+        if (!profile) return;
 
-    const profiles: Record<string, { profile: ProfileMetadata; createdAt: number }> =
-      {};
+        const existing = profiles[event.pubkey];
+        if (existing && existing.createdAt >= event.created_at) return;
 
-    events.forEach((event) => {
-      const profile = parseProfileEvent(event);
-      if (!profile) return;
+        profiles[event.pubkey] = {
+          profile,
+          createdAt: event.created_at,
+        };
+      });
 
-      const existing = profiles[event.pubkey];
-      if (existing && existing.createdAt >= event.created_at) return;
-
-      profiles[event.pubkey] = {
-        profile,
-        createdAt: event.created_at,
-      };
-    });
-
-    return Object.fromEntries(
-      Object.entries(profiles).map(([pubkey, entry]) => [pubkey, entry.profile]),
-    );
-  } finally {
-    closeRelays(relays);
-  }
+      return Object.fromEntries(
+        Object.entries(profiles).map(([pubkey, entry]) => [pubkey, entry.profile]),
+      );
+    },
+  );
 }
 
 function pubkeysFromProcessedEvents(processedEvents: ProcessedEvent[]): string[] {

--- a/src/nostr/testing/feed-snapshot-transcript.test.ts
+++ b/src/nostr/testing/feed-snapshot-transcript.test.ts
@@ -465,4 +465,98 @@ describe("server feed snapshot relay transcript", () => {
       relayFanout: 2,
     });
   });
+
+  it("queries dynamic hints only for references still missing after configured coverage", async () => {
+    const session = new RelayTranscriptSession();
+    const configuredReference = finalizeEvent({
+      created_at: 2_000_000_050,
+      kind: 1,
+      tags: [],
+      content: "configured reference",
+    }, new Uint8Array(32).fill(72));
+    const hintedReference = finalizeEvent({
+      created_at: 2_000_000_051,
+      kind: 1,
+      tags: [],
+      content: "hinted reference",
+    }, new Uint8Array(32).fill(73));
+    let referenceRoot = root;
+    const configuredHarness = await RelayTranscriptHarness.listen({
+      session,
+      onRequest(request) {
+        const [filter] = request.filters;
+        if (filter?.ids) {
+          if (filter.ids.includes(configuredReference.id)) {
+            request.sendEvent(configuredReference);
+          }
+        } else if (filter?.kinds?.includes(1) && !filter["#e"]) {
+          request.sendEvent(referenceRoot);
+        }
+        request.sendEose();
+      },
+    });
+    const hintedHarness = await RelayTranscriptHarness.listen({
+      session,
+      onRequest(request) {
+        const [filter] = request.filters;
+        if (filter?.ids?.includes(hintedReference.id)) {
+          request.sendEvent(hintedReference);
+        }
+        request.sendEose();
+      },
+    });
+    harnesses.push(configuredHarness, hintedHarness);
+    referenceRoot = finalizeEvent({
+      created_at: 2_000_000_052,
+      kind: 1,
+      tags: [],
+      content: [configuredReference, hintedReference]
+        .map((event) => `nostr:${nip19.neventEncode({
+          id: event.id,
+          relays: [hintedHarness.url],
+        })}`)
+        .join(" "),
+    }, new Uint8Array(32).fill(74));
+    const workflow = session.beginWorkflow("wired-server-feed-targeted-hints");
+
+    const snapshot = await fetchFeedSnapshot({
+      ageHours: 24,
+      filterDifficulty: 0,
+      relayCoverage: {
+        snapshot: [configuredHarness.url],
+        pow: [configuredHarness.url],
+        replies: [configuredHarness.url],
+        profiles: [],
+      },
+      timeoutMs: 1_000,
+    });
+    await session.waitFor((entries) =>
+      entries.filter((entry) => entry.type === "connection-closed").length === 3
+    );
+    workflow.complete();
+
+    expect(Object.keys(snapshot.eventsById).sort()).toEqual(
+      [referenceRoot.id, configuredReference.id, hintedReference.id].sort(),
+    );
+    const referenceRequests = session.entries
+      .slice(workflow.startIndex, workflow.completedIndex)
+      .filter((entry) => entry.type === "request" && entry.filters[0]?.ids);
+    expect(referenceRequests).toHaveLength(2);
+    expect(referenceRequests[0]).toMatchObject({
+      relayUrl: configuredHarness.url,
+      filters: [{
+        ids: [configuredReference.id, hintedReference.id],
+        kinds: [1, 1068],
+        limit: 2,
+      }],
+    });
+    expect(referenceRequests[1]).toMatchObject({
+      relayUrl: hintedHarness.url,
+      filters: [{
+        ids: [hintedReference.id],
+        kinds: [1, 1068],
+        limit: 1,
+      }],
+    });
+  });
 });


### PR DESCRIPTION
Closes smolgrrr/wired-admin#97

## Summary
- migrate referenced-event and profile snapshot phases to scoped relay sessions
- query configured snapshot coverage immediately while dynamic relay hints connect
- restrict hinted fallback queries to exact IDs still missing from configured coverage
- keep referenced-descendant traversal on the same configured + discovered-hint session
- preserve newest-profile selection and publishing behavior

## Evidence
- focused transcript suite: 6/6 passing
- normal transcript: exactly 8 REQs with unchanged filters and exact IDs
- dynamic-hint transcript: configured coverage receives both IDs; the hinted relay receives only the still-missing ID; all sockets close
- controlled loopback p95: 40 ms (guardrail: 52 ms; immediately preceding phase: 38 ms)
- no-EOSE controlled completion: 220 ms
- full suite: 83 files / 441 tests passing
- typecheck: passing
- lint: 0 errors; 4 pre-existing Fast Refresh warnings
- Standards review: PASS, 0 findings
- Spec review: PASS, 0 findings

These are lightweight loopback measurements and do not claim or infer real public-relay load.

## Rollout / rollback
Deploy this isolated phase and monitor transcript/status evidence for exact IDs, newest profiles, filters, coverage, cache behavior, socket cleanup, and the 52 ms controlled p95 guardrail. Roll back this commit if any of those regress. Legacy helpers remain temporarily for the immediately following contract/deletion ticket (#98).
