### PR TITLE
Remove obsolete Wired server relay helpers

### DIFF
--- a/lib/feedSnapshot.ts
+++ b/lib/feedSnapshot.ts
@@ -1,4 +1,4 @@
-import { Relay, type Event, type Filter, useWebSocketImplementation } from "nostr-tools";
+import { type Event, type Filter, useWebSocketImplementation } from "nostr-tools";
 import { WebSocket } from "ws";
 import {
   POW_RELAYS,
@@ -125,93 +125,6 @@ function serializeRelayHints(
       uniqueRelays(relays),
     ]),
   );
-}
-
-async function connectRelays(urls: readonly string[]): Promise<Relay[]> {
-  const relays = await Promise.all(
-    urls.map(async (url) => {
-      try {
-        return await Relay.connect(url);
-      } catch {
-        return null;
-      }
-    }),
-  );
-
-  return relays.filter((relay): relay is Relay => relay !== null);
-}
-
-function closeRelays(relays: Relay[]): void {
-  relays.forEach((relay) => {
-    try {
-      relay.close();
-    } catch {
-      // Relay already closed.
-    }
-  });
-}
-
-async function subscribeOnce(
-  relays: Relay[],
-  filter: Filter,
-  timeoutMs: number,
-  relayUrls?: string[],
-): Promise<EventBatch> {
-  if (relays.length === 0) {
-    return { events: [], relayHintsByEventId: new Map() };
-  }
-
-  const targetRelays = relayUrls
-    ? relays.filter((relay) =>
-        relayUrls.some(
-          (url) => normalizeRelayUrl(url) === normalizeRelayUrl(relay.url),
-        ),
-      )
-    : relays;
-
-  if (targetRelays.length === 0) {
-    return { events: [], relayHintsByEventId: new Map() };
-  }
-
-  const events: Event[] = [];
-  const seenIds = new Set<string>();
-  const relayHintsByEventId = new Map<string, string[]>();
-
-  await new Promise<void>((resolve) => {
-    const subscriptions: { close: () => void }[] = [];
-    let eoseCount = 0;
-    let settled = false;
-
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      subscriptions.forEach((sub) => sub.close());
-      resolve();
-    };
-
-    const timer = setTimeout(finish, timeoutMs);
-
-    for (const relay of targetRelays) {
-      const sub = relay.subscribe([filter], {
-        onevent(event) {
-          addRelayHint(relayHintsByEventId, event.id, relay.url);
-          if (seenIds.has(event.id)) return;
-          seenIds.add(event.id);
-          events.push(event);
-        },
-        oneose: () => {
-          eoseCount += 1;
-          if (eoseCount >= targetRelays.length) {
-            finish();
-          }
-        },
-      });
-      subscriptions.push(sub);
-    }
-  });
-
-  return { events, relayHintsByEventId };
 }
 
 async function querySessionOnce(

--- a/lib/serverRelayBoundary.test.ts
+++ b/lib/serverRelayBoundary.test.ts
@@ -1,0 +1,41 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { extname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const sessionOwner = "lib/serverRelaySession.ts";
+
+function productionTypescriptFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return productionTypescriptFiles(path);
+    if (extname(path) !== ".ts" || path.endsWith(".test.ts")) return [];
+    return [path];
+  });
+}
+
+describe("Wired server relay access boundary", () => {
+  it("keeps low-level relay connection and subscription ownership in the finite session", () => {
+    const violations = ["lib", "api", "scripts"]
+      .flatMap((directory) =>
+        productionTypescriptFiles(join(repositoryRoot, directory)),
+      )
+      .map((path) => ({
+        path: relative(repositoryRoot, path),
+        source: readFileSync(path, "utf8"),
+      }))
+      .filter(({ path }) => path !== sessionOwner)
+      .filter(
+        ({ source }) =>
+          /\bRelay\.connect\s*\(/.test(source) ||
+          /\.subscribe\s*\(/.test(source) ||
+          /import\s*{[^}]*\bRelay\b[^}]*}\s*from\s*["']nostr-tools["']/.test(
+            source,
+          ),
+      )
+      .map(({ path }) => path);
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes smolgrrr/wired-admin#98

## Summary
- delete the obsolete direct `Relay.connect`, subscription timer, and cleanup helpers from the snapshot module
- remove its low-level `Relay` value import
- add an architecture boundary test requiring production server relay connection/subscription ownership to remain in `serverRelaySession.ts`
- leave browser relay pooling and event publishing unchanged

## Evidence
- TDD boundary: failed before deletion with `lib/feedSnapshot.ts` as the sole violation; passes after deletion
- focused boundary, session lifecycle/failure, preview, and snapshot tests: 23/23
- zero-handle session fixtures: passing, including late connection, all-connect-failed, no-EOSE timeout, cancellation, and synchronous EOSE cleanup
- full suite: 442/442 passing
- typecheck: passing
- lint: 0 errors; 4 pre-existing Fast Refresh warnings
- Standards review: PASS, 0 findings
- Spec review: PASS, 0 findings

No real public-relay load is inferred from these tests.

## Rollout / rollback
Deploy as a no-runtime-behavior contract cleanup. Confirm the existing preview/snapshot transcript and deployment gates stay green. Roll back this commit if server build resolution, transcript identity, socket cleanup, or production deployment regresses; the previous helpers were unreachable, so rollback restores only redundant code.
